### PR TITLE
Comments disabled (server)

### DIFF
--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -204,4 +204,42 @@ export default class PostsController {
       exceptions.reportError(res)(e)
     }
   }
+
+  static async disableComments(req, res) {
+    if (!req.user)
+      return res.status(401).jsonp({ err: 'Unauthorized' })
+
+    try {
+      const post = await Post.findById(req.params.postId)
+
+      if (post.userId != req.user.id) {
+        throw new ForbiddenException("You can't disable comments for another user's post")
+      }
+
+      await post.setCommentsDisabled('1')
+
+      res.jsonp({})
+    } catch (e) {
+      exceptions.reportError(res)(e)
+    }
+  }
+
+  static async enableComments(req, res) {
+    if (!req.user)
+      return res.status(401).jsonp({ err: 'Unauthorized' })
+
+    try {
+      const post = await Post.findById(req.params.postId)
+
+      if (post.userId != req.user.id) {
+        throw new ForbiddenException("You can't enable comments for another user's post")
+      }
+
+      await post.setCommentsDisabled('0')
+
+      res.jsonp({})
+    } catch (e) {
+      exceptions.reportError(res)(e)
+    }
+  }
 }

--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -11,9 +11,9 @@ export default class PostsController {
       return
     }
 
-    var feeds = []
     req.body.meta = req.body.meta || {}
 
+    let feeds = []
     if (_.isArray(req.body.meta.feeds)) {
       feeds = req.body.meta.feeds
     } else if (req.body.meta.feeds) {
@@ -22,6 +22,8 @@ export default class PostsController {
       res.status(401).jsonp({ err: 'Cannot publish post to /dev/null' })
       return
     }
+
+    const commentsDisabled = (req.body.meta.commentsDisabled ? '1' : '0')
 
     try {
       let promises = feeds.map(async (username) => {
@@ -49,7 +51,8 @@ export default class PostsController {
       let newPost = await req.user.newPost({
         body: req.body.post.body,
         attachments: req.body.post.attachments,
-        timelineIds: timelineIds
+        timelineIds: timelineIds,
+        commentsDisabled: commentsDisabled
       })
 
       await newPost.create()

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -146,6 +146,22 @@ export function addModel(dbAdapter) {
     return this
   }
 
+  Post.prototype.setCommentsDisabled = async function(newValue) {
+    // Reflect post changes
+    this.commentsDisabled = newValue
+
+    // Update post body in DB
+    let payload = {
+      'commentsDisabled': this.commentsDisabled
+    }
+    await dbAdapter.updatePost(this.id, payload)
+
+    // Finally, publish changes
+    await pubSub.updatePost(this.id)
+
+    return this
+  }
+
   Post.prototype.destroy = async function() {
     // remove all comments
     const comments = await this.getComments()

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -21,18 +21,27 @@ export function addModel(dbAdapter) {
     this.userId = params.userId
     this.timelineIds = params.timelineIds
     this.currentUser = params.currentUser
-    if (parseInt(params.createdAt, 10))
+    this.commentsDisabled = params.commentsDisabled
+
+    if (parseInt(params.createdAt, 10)) {
       this.createdAt = params.createdAt
-    if (parseInt(params.updatedAt, 10))
+    }
+
+    if (parseInt(params.updatedAt, 10)) {
       this.updatedAt = params.updatedAt
-    if (params.maxComments != 'all')
+    }
+
+    if (params.maxComments != 'all') {
       this.maxComments = parseInt(params.maxComments, 10) || 2
-    else
+    } else {
       this.maxComments = params.maxComments
-    if (params.maxLikes != 'all')
+    }
+
+    if (params.maxLikes != 'all') {
       this.maxLikes = parseInt(params.maxLikes, 10) || 4
-    else
+    } else {
       this.maxLikes = params.maxLikes
+    }
   }
 
   inherits(Post, AbstractModel)
@@ -77,10 +86,11 @@ export function addModel(dbAdapter) {
     var timer = monitor.timer('posts.create-time')
 
     let payload = {
-      'body':      this.body,
-      'userId':    this.userId,
+      'body': this.body,
+      'userId': this.userId,
       'createdAt': this.createdAt.toString(),
-      'updatedAt': this.updatedAt.toString()
+      'updatedAt': this.updatedAt.toString(),
+      'commentsDisabled': this.commentsDisabled
     }
     // save post to the database
     this.id = await dbAdapter.createPost(payload)

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -963,6 +963,9 @@ exports.addModel = function(dbAdapter) {
 
     if (!valid)
       throw new NotFoundException("Not found")
+
+    if (post.commentsDisabled === '1' && post.userId !== this.id)
+      throw new ForbiddenException("Comments disabled")
   }
 
   User.prototype.validateCanLikeOrUnlikePost = async function(action, post) {

--- a/app/routes/api/v1/PostsRoute.js
+++ b/app/routes/api/v1/PostsRoute.js
@@ -10,4 +10,6 @@ export default function addRoutes(app) {
   app.post(  '/v1/posts/:postId/unlike', PostsController.unlike)
   app.post(  '/v1/posts/:postId/hide',   PostsController.hide)
   app.post(  '/v1/posts/:postId/unhide', PostsController.unhide)
+  app.post(  '/v1/posts/:postId/disableComments', PostsController.disableComments)
+  app.post(  '/v1/posts/:postId/enableComments',  PostsController.enableComments)
 }

--- a/app/serializers/v1/PostSerializer.js
+++ b/app/serializers/v1/PostSerializer.js
@@ -3,7 +3,7 @@ import { Serializer, AttachmentSerializer, CommentSerializer, SubscriptionSerial
 
 export function addSerializer() {
   return new Serializer("posts", {
-    select: ['id', 'body', 'attachments', 'createdBy', 'comments', 'createdAt', 'updatedAt', 'updatedAt', 'likes', 'isHidden', 'omittedComments', 'omittedLikes', 'postedTo'],
+    select: ['id', 'body', 'attachments', 'createdBy', 'comments', 'createdAt', 'updatedAt', 'updatedAt', 'likes', 'isHidden', 'omittedComments', 'omittedLikes', 'postedTo', 'commentsDisabled'],
     attachments: { through: AttachmentSerializer, embed: true },
     createdBy: { through: UserSerializer, embed: true },
     comments: { through: CommentSerializer, embed: true },

--- a/test/functional/comments.js
+++ b/test/functional/comments.js
@@ -100,6 +100,30 @@ describe("CommentsController", function() {
         done()
       })
     })
+
+    it('should create a comment to own post even when comments disabled', async () => {
+      let postResponse = await funcTestHelper.createPostWithCommentsDisabled(context, 'Post body', true)
+      let data = await postResponse.json()
+      let post = data.posts
+
+      let response = await funcTestHelper.createCommentAsync(context, post.id, 'Comment')
+      response.status.should.eql(200)
+    })
+
+    it("should not create a comment to another user's post when comments disabled", async () => {
+      let postResponse = await funcTestHelper.createPostWithCommentsDisabled(context, 'Post body', true)
+      let postData = await postResponse.json()
+      let post = postData.posts
+
+      let marsContext = await funcTestHelper.createUserAsync('mars', 'password2')
+
+      let response = await funcTestHelper.createCommentAsync(marsContext, post.id, 'Comment')
+      response.status.should.eql(403)
+
+      let data = await response.json()
+      data.should.have.property('err')
+      data.err.should.eql('Comments disabled')
+    })
   })
 
   describe('#update()', function() {

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -116,6 +116,14 @@ export function createPost(context, body, callback) {
   }
 }
 
+export function createPostWithCommentsDisabled(context, body, commentsDisabled) {
+  return postJson('/v1/posts', {
+    post: { body: body },
+    meta: { feeds: context.username, commentsDisabled: commentsDisabled },
+    authToken: context.authToken
+  })
+}
+
 export function createPostForTest(context, body, callback) {
   apiUrl('/v1/posts').then(url => {
     request
@@ -403,4 +411,12 @@ export async function readPostAsync(postId, userContext) {
   }
 
   return fetch(url)
+}
+
+export function disableComments(postId, authToken) {
+  return postJson(`/v1/posts/${postId}/disableComments`, { authToken })
+}
+
+export function enableComments(postId, authToken) {
+  return postJson(`/v1/posts/${postId}/enableComments`, { authToken })
 }

--- a/test/unit/post.js
+++ b/test/unit/post.js
@@ -69,7 +69,8 @@ describe('Post', function() {
       var post = new Post({
         body: 'Post body',
         userId: user.id,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()
@@ -77,6 +78,8 @@ describe('Post', function() {
           post.should.be.an.instanceOf(Post)
           post.should.not.be.empty
           post.should.have.property('id')
+          post.should.have.property('body')
+          post.should.have.property('commentsDisabled')
 
           return post
         })
@@ -86,6 +89,10 @@ describe('Post', function() {
           newPost.should.not.be.empty
           newPost.should.have.property('id')
           newPost.id.should.eql(post.id)
+          newPost.should.have.property('body')
+          newPost.body.should.eql('Post body')
+          newPost.should.have.property('commentsDisabled')
+          newPost.commentsDisabled.should.eql('0')
         })
         .then(function() { done() })
     })
@@ -95,7 +102,8 @@ describe('Post', function() {
       var post = new Post({
         body: body,
         userId: user.id,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()
@@ -114,7 +122,8 @@ describe('Post', function() {
       var post = new Post({
         body: 'Post',
         userId: user.id,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()
@@ -139,7 +148,8 @@ describe('Post', function() {
       var post = new Post({
         body: 'Post',
         userId: user.id,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()
@@ -161,7 +171,8 @@ describe('Post', function() {
       var post = new Post({
         body: '',
         userId: user.id,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()
@@ -175,13 +186,47 @@ describe('Post', function() {
       var post = new Post({
         body: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor. Praesent et diam eget libero egestas mattis sit amet vitae augue. Nam tincidunt congue enim, ut porta lorem lacinia consectetur. Donec ut libero sed arcu vehicula ultricies a non tortor. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean ut gravida lorem. Ut turpis felis, pulvinar a semper sed, adipiscing id dolor. Pellentesque auctor nisi id magna consequat sagittis. Curabitur dapibus enim sit amet elit pharetra tincidunt feugiat nisl imperdiet. Ut convallis libero in urna ultrices accumsan. Donec sed odio eros. Donec viverra mi quis quam pulvinar at malesuada arcu rhoncus. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In rutrum accumsan ultricies. Mauris vitae nisi at sem facilisis semper ac in est. Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi diam iaculis velit, id fringilla sem nunc vel mi. Nam dictum, odio nec pretium volutpat, arcu ante placerat erat, non tristique elit urna et turpis. Quisque mi metus, ornare sit amet fermentum et, tincidunt et orci. Fusce eget orci a orci congue vestibulum. Ut dolor diam, elementum et vestibulum eu, porttitor vel elit. Curabitur venenatis pulvinar tellus gravida ornare.',
         userId: user.id,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()
         .then(function() { done(new Error("FAIL")) })
         .catch(function(e) {
           e.message.should.eql("Maximum post-length is 1500 graphemes")
+          done()
+        })
+    })
+
+    it("should create with commentsDisabled='1'", function(done) {
+      var post = new Post({
+        body: 'Post body',
+        userId: user.id,
+        timelineIds: [timelineId],
+        commentsDisabled: '1'
+      })
+
+      post.create()
+        .then(function(post) {
+          post.should.be.an.instanceOf(Post)
+          post.should.not.be.empty
+          post.should.have.property('id')
+          post.should.have.property('commentsDisabled')
+          post.commentsDisabled.should.eql('1')
+          return post
+        })
+        .then(function(post) {
+          return Post.findById(post.id)
+        })
+        .then(function(newPost) {
+          newPost.should.be.an.instanceOf(Post)
+          newPost.should.not.be.empty
+          newPost.should.have.property('id')
+          newPost.id.should.eql(post.id)
+          newPost.should.have.property('commentsDisabled')
+          newPost.commentsDisabled.should.eql('1')
+        })
+        .then(function() {
           done()
         })
     })
@@ -211,7 +256,8 @@ describe('Post', function() {
       var post = new Post({
         body: 'Post body',
         userId: user.id,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()
@@ -593,7 +639,8 @@ describe('Post', function() {
       var post = new Post({
         body: 'Post body',
         userId: user.id ,
-        timelineIds: [timelineId]
+        timelineIds: [timelineId],
+        commentsDisabled: '0'
       })
 
       post.create()

--- a/test/unit/post.js
+++ b/test/unit/post.js
@@ -324,6 +324,24 @@ describe('Post', function() {
     })
   })
 
+  describe('#setCommentsDisabled()', function() {
+    var user
+      , post
+
+    beforeEach(async () => {
+      user = new User({ username: 'Luna', password: 'password' })
+      await user.create()
+      post = await user.newPost({ body: 'Post body', commentsDisabled: '0' })
+      await post.create()
+    })
+
+    it('should set commentsDisabled', async () => {
+      post.commentsDisabled.should.eql('0')
+      await post.setCommentsDisabled('1')
+      post.commentsDisabled.should.eql('1')
+    })
+  })
+
   describe('#addLike()', function() {
     var userA
       , userB


### PR DESCRIPTION
Full support:
- Support for disabling comments on create-post
- Support for disabling/enabling comments for existing posts
- Check if comments are disabled on adding a new comment

_There is **compatibility** with the old clients, since without explicit truthy `commentsDisabled` property the default state of created post would be "Comments are **not** disabled", as usual._

See also:
- https://github.com/FreeFeed/freefeed-html/pull/23 — partial support for official Ember client. 
- https://github.com/FreeFeed/freefeed-react-client/pull/162 — full support for official React client (check it out, there are lots of screenshots).
