### PR TITLE
Add support for storing frontend preferences in user profile

### DIFF
--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -350,7 +350,7 @@ export default class UsersController {
     if (!req.user || req.user.id != req.params.userId)
       return res.status(401).jsonp({ err: 'Not found' })
 
-    var attrs = _.reduce(['screenName', 'email', 'isPrivate', 'description'], function(acc, key) {
+    var attrs = _.reduce(['screenName', 'email', 'isPrivate', 'description', 'frontendPreferences'], function(acc, key) {
       if (key in req.body.user)
         acc[key] = req.body.user[key]
       return acc

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -10,7 +10,7 @@ import validator from 'validator'
 import uuid from 'uuid'
 
 import { load as configLoader } from "../../config/config"
-import { BadRequestException, ForbiddenException, NotFoundException } from '../support/exceptions'
+import { BadRequestException, ForbiddenException, NotFoundException, ValidationException } from '../support/exceptions'
 import { Attachment, Comment, Post, Stats, Timeline } from '../models'
 
 
@@ -32,6 +32,7 @@ exports.addModel = function(dbAdapter) {
     this.screenName = params.screenName
     this.email = params.email
     this.description = params.description || ''
+    this.frontendPreferences = params.frontendPreferences || {}
 
     if (!_.isUndefined(params.hashedPassword)) {
       this.hashedPassword = params.hashedPassword
@@ -106,6 +107,17 @@ exports.addModel = function(dbAdapter) {
     set: function(newValue) {
       if (_.isString(newValue))
         this.description_ = newValue.trim()
+    }
+  })
+
+  Object.defineProperty(User.prototype, 'frontendPreferences', {
+    get: function() { return this.frontendPreferences_ },
+    set: function(newValue) {
+      if (_.isString(newValue)) {
+        newValue = JSON.parse(newValue)
+      }
+
+      this.frontendPreferences_ = newValue
     }
   })
 
@@ -294,7 +306,8 @@ exports.addModel = function(dbAdapter) {
       'description':    '',
       'createdAt':      this.createdAt.toString(),
       'updatedAt':      this.updatedAt.toString(),
-      'hashedPassword': this.hashedPassword
+      'hashedPassword': this.hashedPassword,
+      'frontendPreferences': JSON.stringify({})
     }
     this.id = await dbAdapter.createUser(payload)
 
@@ -359,14 +372,29 @@ exports.addModel = function(dbAdapter) {
       hasChanges = true
     }
 
+    if (params.hasOwnProperty('frontendPreferences')) {
+      this.frontendPreferences = params.frontendPreferences
+      hasChanges = true
+    }
+
     if (hasChanges) {
       this.updatedAt = new Date().getTime()
+
+      // Validate maximum preferences store size
+      var prefsString = JSON.stringify(this.frontendPreferences)
+      var prefsLen = GraphemeBreaker.countBreaks(prefsString)
+      if (prefsLen > config.frontendPrefsLimit) {
+        throw new ValidationException('Preferences too large')
+      }
+
+      this.validateFrontendPreferencesStructure()
 
       var payload = {
         'screenName': this.screenName,
         'email': this.email,
         'isPrivate': this.isPrivate,
         'description': this.description,
+        'frontendPreferences': prefsString,
         'updatedAt': this.updatedAt.toString()
       }
 
@@ -387,6 +415,18 @@ exports.addModel = function(dbAdapter) {
     }
 
     return this
+  }
+
+  User.prototype.validateFrontendPreferencesStructure = function() {
+    // for each key in prefs there must be an object value
+    if (!_.isPlainObject(this.frontendPreferences)) {
+      throw ValidationException('invalid prefs structure')
+    }
+    for (let prop in this.frontendPreferences) {
+      if (!_.isObjectLike(this.frontendPreferences[prop])) {
+        throw ValidationException('invalid prefs structure')
+      }
+    }
   }
 
   User.prototype.subscribeNonFriends = async function() {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -354,10 +354,12 @@ exports.addModel = function(dbAdapter) {
         throw new Error("bad input")
       }
 
-      if (params.isPrivate === '1' && this.isPrivate === '0')
+      if (params.isPrivate === '1' && this.isPrivate === '0') {
         await this.unsubscribeNonFriends()
-      else if (params.isPrivate === '0' && this.isPrivate === '1')
+      }
+      else if (params.isPrivate === '0' && this.isPrivate === '1') {
         await this.subscribeNonFriends()
+      }
 
       this.isPrivate = params.isPrivate
       hasChanges = true

--- a/app/serializers/v1/MyProfileSerializer.js
+++ b/app/serializers/v1/MyProfileSerializer.js
@@ -6,7 +6,7 @@ export function addSerializer() {
     select: ['id', 'username', 'type', 'screenName', 'email', 'statistics',
              'subscriptions', 'profilePictureLargeUrl', 'profilePictureMediumUrl',
              'banIds', 'subscribers', 'isPrivate', 'pendingSubscriptionRequests',
-             'subscriptionRequests', 'description',
+             'subscriptionRequests', 'description', 'frontendPreferences',
              'administrators'],
     subscriptions: { through: SubscriptionSerializer, embed: true },
     subscribers: { through: SubscriberSerializer },

--- a/app/support/exceptions.js
+++ b/app/support/exceptions.js
@@ -32,3 +32,11 @@ exports.NotFoundException = function(message) {
   this.message = message || "Not found"
   this.status = 404
 }
+
+/**
+ * @constructor
+ */
+exports.ValidationException = function(message) {
+  this.message = message || "Invalid"
+  this.status = 422
+}

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -29,7 +29,8 @@ export function getConfig() {
     onboardingUsername: 'welcome',
     recaptcha: {
       enabled: false
-    }
+    },
+    frontendPrefsLimit: 65536
   }
 
   config.host = 'http://localhost:' + config.port

--- a/config/environments/test.js
+++ b/config/environments/test.js
@@ -18,7 +18,8 @@ export function getConfig() {
     onboardingUsername: 'welcome',
     recaptcha: {
       enabled: false
-    }
+    },
+    frontendPrefsLimit: 65536
   }
 
   config.host = 'http://localhost:' + config.port

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -283,6 +283,18 @@ export function getSubscriptions(username, authToken, callback) {
   }(callback)
 }
 
+async function getUri(relativeUrl, data) {
+  return fetch(
+    await apiUrl(relativeUrl),
+    {
+      method: 'GET',
+      headers: {
+        'X-Authentication-Token': data.authToken
+      }
+    }
+  )
+}
+
 async function postJson(relativeUrl, data) {
   return fetch(
     await apiUrl(relativeUrl),
@@ -323,6 +335,10 @@ export async function createUserAsync(username, password, attributes) {
     password,
     attributes
   }
+}
+
+export function whoami(authToken) {
+  return getUri(`/v1/users/whoami`, { authToken })
 }
 
 export function like(postId, authToken) {


### PR DESCRIPTION
- Preferences are namespaced, first level keys should be in reverse-DNS format for each non-official frontend, `net.freefeed` is reserved for official frontends.
- Preferences storage has limited size, default config limit is 64K unicode graphemes.
