### PR TITLE
Fix removing attachments on edit-post

### DIFF
--- a/app/models/post.js
+++ b/app/models/post.js
@@ -440,7 +440,7 @@ export function addModel(dbAdapter) {
     const attachmentIds = attachmentList || []
     const attachments = await Attachment.findByIds(attachmentIds)
 
-    const attachmentPromises = attachments.map(function(attachment) {
+    const attachmentPromises = attachments.map((attachment) => {
       // should we modify `this.attachments` here?
 
       // Update connections in DB


### PR DESCRIPTION
Seems like a bug after the recent refactoring, `this.id` on line 448
doesn't work correctly, so this change provides correct `this` there.

Fixes #29.
