### PR TITLE
Remove second "comment:new" realtime notification

### DIFF
--- a/app/models/post.js
+++ b/app/models/post.js
@@ -344,7 +344,6 @@ export function addModel(dbAdapter) {
 
     let promises = timelines.map((timeline) => timeline.updatePost(this.id))
     promises.push(dbAdapter.addCommentToPost(this.id, comment.id))
-    promises.push(pubSub.newComment(comment, timelines))
 
     await Promise.all(promises)
 


### PR DESCRIPTION
Remove pubSub.newComment call from Post's model because it already called in CommentsController.create.
It closes FreeFeed/freefeed-server#32
