### PR TITLE
Add admins of subscribed groups to /users/whoami

### DIFF
--- a/app/serializers/v1/SubscriberSerializer.js
+++ b/app/serializers/v1/SubscriberSerializer.js
@@ -1,9 +1,11 @@
-import { Serializer } from '../../models'
+import { Serializer, AdminSerializer } from '../../models'
 
 
 export function addSerializer() {
   return new Serializer("subscribers", {
     select: ['id', 'username', 'screenName', 'type', 'updatedAt', 'createdAt',
-             'isPrivate', 'isRestricted', 'profilePictureLargeUrl', 'profilePictureMediumUrl']
+             'isPrivate', 'isRestricted', 'profilePictureLargeUrl', 'profilePictureMediumUrl',
+             'administrators'],
+    administrators: { through: AdminSerializer, embed: true }
   })
 }


### PR DESCRIPTION
It's the same info we send out in a /timelines/groupname response
(in the `users` object). We need it in /whoami for the "feed selector"
(list of recipients we can post to).

See also: https://github.com/FreeFeed/freefeed-react-client/pull/359
