### PR TITLE
Fix response format for failed sign-in attempt

### DIFF
--- a/app/controllers/api/v1/SessionController.js
+++ b/app/controllers/api/v1/SessionController.js
@@ -18,10 +18,10 @@ export default class SessionController {
 
       if (user === false) {
         if (!msg) {
-          msg = 'Internal server error'
+          msg = { message: 'Internal server error' }
         }
 
-        res.status(401).jsonp({ err: msg })
+        res.status(401).jsonp({ err: msg.message })
         return
       }
 


### PR DESCRIPTION
The format of response for "Missing credentials" is:

```
{ "err": { message: "Missing credentials" } }
```

The format we have everywhere else is:

```
{ "err": "Error details" }
```

This change makes the former response consistent with the latter format.

_**NB.** It seems like this update does not break anything for existing clients since the only affected place I found so far is "Missing credentials" case and even then the response message is not used. But it's better to share this with frontend devs just in case._
