### PR TITLE
Run clean migrations before each testrun

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ before_install:
 before_script:
   - cp  knexfile.js.dist knexfile.js
   - psql -c 'create database freefeed_test;' -U postgres
-  - knex migrate:latest --env test
   - mkdir -p /tmp/pepyatka-media/attachments
   - mkdir /tmp/pepyatka-media/attachments/thumbnails
   - mkdir /tmp/pepyatka-media/attachments/thumbnails2

--- a/bin/clean_test_db
+++ b/bin/clean_test_db
@@ -1,0 +1,27 @@
+#!/usr/bin/env babel-node
+import knexLib from 'knex';
+import config from '../knexfile';
+
+
+if (!('test' in config)) {
+  process.stderr.write(`Error: no "test" section in knexfile`);
+  process.exit(1);
+}
+
+const knex = knexLib(config.test);
+
+async function run() {
+  await knex.raw('drop schema public cascade');
+  await knex.raw('create schema public');
+}
+
+run()
+  .then(() => {
+    knex.destroy();
+    process.exit(0);
+  })
+  .catch((e) => {
+    process.stderr.write(`Error: ${e}\n`);
+    knex.destroy();
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "start": "babel-node --ignore node_modules index",
-    "test": "eslint app test && NODE_ENV=test mocha",
+    "test": "eslint app test && ./bin/clean_test_db && knex --env test migrate:latest && NODE_ENV=test mocha",
     "lint": "eslint app test",
     "console": "babel-node --ignore node_modules bin/console",
     "coverage": "NODE_ENV=test istanbul cover _mocha -- -R spec",


### PR DESCRIPTION
Currently, migrations are supposed to be run manually for test-db. This is quite tedious, as tests kill knex_migrations table.
This patch makes sure that DB is in an up-to-date, sane state before running tests
