### PR TITLE
Fix attachments hangling when tmp/ is not same fs with public/

### DIFF
--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -6,6 +6,7 @@ import gm from 'gm'
 import meta from 'musicmetadata'
 import mmm from 'mmmagic'
 import _ from 'lodash'
+import mv from 'mv'
 
 import { load as configLoader } from '../../config/config'
 
@@ -289,7 +290,7 @@ export function addModel(dbAdapter) {
       await this.uploadToS3(tmpAttachmentFile, config.attachments.path)
       await fs.unlinkAsync(tmpAttachmentFile)
     } else {
-      await fs.renameAsync(tmpAttachmentFile, this.getPath())
+      await promisify(mv)(tmpAttachmentFile, this.getPath(),{})
     }
   }
 
@@ -322,7 +323,7 @@ export function addModel(dbAdapter) {
         await this.uploadToS3(tmpImageFile, sizeConfig.path)
         await fs.unlinkAsync(tmpImageFile)
       } else {
-        await fs.renameAsync(tmpImageFile, this.getResizedImagePath(sizeId))
+        await promisify(mv)(tmpImageFile, this.getResizedImagePath(sizeId),{})
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "monitor-dog": "1.5.0",
     "morgan": "1.7.0",
     "musicmetadata": "2.0.4",
+    "mv": "^2.1.1",
     "newrelic": "1.31.0",
     "node-cache": "4.1.0",
     "node-fetch": "1.6.3",


### PR DESCRIPTION
Currently if attachments are stored locally and `tmp` is not on the same fs with `public/` moving the uploaded file to `public/` will fail. The reason is that `fs.rename()` call is used which cannot move files across file systems. I suggest fixing the bug with `mv` package.