### PR TITLE
Add '/v2/users/whoami' API endpoint

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1015,6 +1015,28 @@ export function addModel(dbAdapter) {
          + this.getProfilePictureFilename(this.profilePictureUuid, User.PROFILE_PICTURE_SIZE_MEDIUM)
   }
 
+  Reflect.defineProperty(User.prototype, 'profilePictureLargeUrl', {
+    get: function () {
+      if (_.isEmpty(this.profilePictureUuid)) {
+        return '';
+      }
+      return config.profilePictures.url
+          + config.profilePictures.path
+          + this.getProfilePictureFilename(this.profilePictureUuid, User.PROFILE_PICTURE_SIZE_LARGE);
+    }
+  });
+
+  Reflect.defineProperty(User.prototype, 'profilePictureMediumUrl', {
+    get: function () {
+      if (_.isEmpty(this.profilePictureUuid)) {
+        return '';
+      }
+      return config.profilePictures.url
+          + config.profilePictures.path
+          + this.getProfilePictureFilename(this.profilePictureUuid, User.PROFILE_PICTURE_SIZE_MEDIUM);
+    }
+  });
+
   /**
    * Checks if the specified user can post to the timeline of this user.
    */

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1127,7 +1127,7 @@ export function addModel(dbAdapter) {
   }
 
   User.prototype.getPendingGroupRequests = function () {
-    return this.pendingPrivateGroupSubscriptionRequests()
+    return dbAdapter.userHavePendingGroupRequests(this.id);
   }
 
   return User

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -732,10 +732,7 @@ export function addModel(dbAdapter) {
   }
 
   User.prototype.getFriendIds = async function () {
-    const timelines = await this.getSubscriptions()
-    const postTimelines = _.filter(timelines, _.method('isPosts'))
-
-    return postTimelines.map((timeline) => timeline.userId)
+    return await dbAdapter.getUserFriendIds(this.id);
   }
 
   User.prototype.getFriends = async function () {

--- a/app/routes/api/v2/UsersRoute.js
+++ b/app/routes/api/v2/UsersRoute.js
@@ -5,4 +5,5 @@ export default function addRoutes(app) {
   app.get('/v2/users/blockedByMe', UsersControllerV2.blockedByMe)
   app.get('/v2/users/getUnreadDirectsNumber', UsersControllerV2.getUnreadDirectsNumber)
   app.get('/v2/users/markAllDirectsAsRead', UsersControllerV2.markAllDirectsAsRead)
+  app.get('/v2/users/whoami', UsersControllerV2.whoAmI)
 }

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -1,5 +1,4 @@
 import { pick } from 'lodash';
-import { dbAdapter } from '../../models';
 
 const commonUserFields = [
   'id',
@@ -31,18 +30,11 @@ export async function serializeSelfUser(user) {
     result.pendingGroupRequests,
     result.unreadDirectsNumber,
     result.statistics,
-    result.subscribers,
-    result.subscriptions,
   ] = await Promise.all([
     user.getBanIds(),
     user.getPendingGroupRequests(),
     user.getUnreadDirectsNumber(),
     user.getStatistics(),
-    (async () => {
-      const subscribers = await user.getSubscribers();
-      return subscribers.map((s) => serializeUser(s));
-    })(),
-    dbAdapter.getUserSubscriptionsIdsByType(user.id, 'Posts'),
   ]);
 
   return result;

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -1,0 +1,53 @@
+import { pick } from 'lodash';
+import { dbAdapter } from '../../models';
+
+const commonUserFields = [
+  'id',
+  'username',
+  'screenName',
+  'isPrivate',
+  'isProtected',
+  'isVisibleToAnonymous',
+  'createdAt',
+  'updatedAt',
+  'type',
+  'profilePictureLargeUrl',
+  'profilePictureMediumUrl',
+];
+
+const selfUserFields = [
+  ...commonUserFields,
+  'description',
+  'email',
+  'frontendPreferences',
+  'privateMeta',
+];
+
+export async function serializeSelfUser(user) {
+  const result = pick(user, selfUserFields);
+
+  [
+    result.banIds,
+    result.pendingGroupRequests,
+    result.unreadDirectsNumber,
+    result.statistics,
+    result.subscribers,
+    result.subscriptions,
+  ] = await Promise.all([
+    user.getBanIds(),
+    user.getPendingGroupRequests(),
+    user.getUnreadDirectsNumber(),
+    user.getStatistics(),
+    (async () => {
+      const subscribers = await user.getSubscribers();
+      return subscribers.map((s) => serializeUser(s));
+    })(),
+    dbAdapter.getUserSubscriptionsIdsByType(user.id, 'Posts'),
+  ]);
+
+  return result;
+}
+
+export function serializeUser(user) {
+  return pick(user, commonUserFields);
+}

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -1,14 +1,18 @@
 import _ from 'lodash'
 import validator from 'validator'
 import NodeCache from 'node-cache'
+import redis from 'redis'
 import cacheManager from 'cache-manager'
 import redisStore from 'cache-manager-redis'
-import { promisifyAll } from 'bluebird'
 import pgFormat, { literal as pgQuote } from 'pg-format';
+import { promisifyAll, promisify } from 'bluebird'
 
 import { load as configLoader } from '../../config/config'
 
 import { Attachment, Comment, Group, Post, Timeline, User } from '../models'
+
+promisifyAll(redis.RedisClient.prototype);
+promisifyAll(redis.Multi.prototype);
 
 const USER_COLUMNS = {
   username:               'username',
@@ -293,7 +297,6 @@ const POST_FIELDS_MAPPING = {
   user_id:           (user_id) => {return user_id ? user_id : ''}
 }
 
-
 export class DbAdapter {
   constructor(database) {
     this.database = database
@@ -541,8 +544,7 @@ export class DbAdapter {
     return null;
   };
 
-  getCachedUserAttrs = async (id) => {
-    const attrs = await this.cache.getAsync(`user_${id}`);
+  fixCachedUserAttrs = (attrs) => {
     if (!attrs) {
       return null;
     }
@@ -552,7 +554,11 @@ export class DbAdapter {
     attrs['reset_password_sent_at'] = this.fixDateType(attrs['reset_password_sent_at']);
     attrs['reset_password_expires_at'] = this.fixDateType(attrs['reset_password_expires_at']);
     return attrs;
-  }
+  };
+
+  getCachedUserAttrs = async (id) => {
+    return this.fixCachedUserAttrs(await this.cache.getAsync(`user_${id}`))
+  };
 
   async fetchUser(id) {
     let attrs = await this.getCachedUserAttrs(id);
@@ -567,11 +573,23 @@ export class DbAdapter {
   }
 
   async fetchUsers(ids) {
+    if (_.isEmpty(ids)) {
+      return [];
+    }
     const uniqIds = _.uniq(ids);
-    const cachedUsers = await Promise.all(uniqIds.map(this.getCachedUserAttrs));
+    let cachedUsers;
+    if (this.cache.store.name === 'redis') {
+      const { client, done } = await promisify(this.cache.store.getClient)();
+      const cacheKeys = ids.map((id) => `user_${id}`);
+      const result = await client.mgetAsync(cacheKeys);
+      done();
+      cachedUsers = result.map((x) => x ? JSON.parse(x) : null).map(this.fixCachedUserAttrs);
+    } else {
+      cachedUsers = await Promise.all(uniqIds.map(this.getCachedUserAttrs));
+    }
 
     const notFoundIds = _.compact(cachedUsers.map((attrs, i) => attrs ? null : uniqIds[i]));
-    const dbUsers = await this.database('users').whereIn('uid', notFoundIds);
+    const dbUsers = notFoundIds.length === 0 ? [] : await this.database('users').whereIn('uid', notFoundIds);
 
     await Promise.all(dbUsers.map((attrs) => this.cache.setAsync(`user_${attrs.uid}`, attrs)));
 

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -1265,6 +1265,20 @@ export class DbAdapter {
     return uuids
   }
 
+  async getTimelinesUserSubscribed(userId, feedType = null) {
+    const where = { 's.user_id': userId };
+    if (feedType !== null) {
+      where['f.name'] = feedType;
+    }
+    const records = await this.database
+      .select('f.*')
+      .from('subscriptions as s')
+      .innerJoin('feeds as f', 's.feed_id', 'f.uid')
+      .where(where)
+      .orderBy('s.created_at', 'desc');
+    return records.map(this.initTimelineObject);
+  }
+
   async getUserNamedFeedId(userId, name) {
     const response = await this.database('feeds').select('uid').where({
       user_id: userId,

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -894,6 +894,15 @@ export class DbAdapter {
     return this.database('group_admins').pluck('group_id').orderBy('created_at', 'desc').where('user_id', userId);
   }
 
+  async userHavePendingGroupRequests(userId) {
+    const res = await this.database.first('r.id')
+      .from('subscription_requests as r')
+      .innerJoin('group_admins as a', 'a.group_id', 'r.to_user_id')
+      .where({ 'a.user_id': userId })
+      .limit(1);
+    return !!res;
+  }
+
   ///////////////////////////////////////////////////
   // Attachments
   ///////////////////////////////////////////////////

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -1558,12 +1558,26 @@ export class DbAdapter {
   // Subscriptions
   ///////////////////////////////////////////////////
 
-  async getUserSubscriptionsIds(userId) {
-    const res = await this.database('subscriptions').select('feed_id').orderBy('created_at', 'desc').where('user_id', userId)
-    const attrs = res.map((record) => {
-      return record.feed_id
-    })
-    return attrs
+  getUserSubscriptionsIds(userId) {
+    return this.database('subscriptions').pluck('feed_id').orderBy('created_at', 'desc').where('user_id', userId)
+  }
+
+  getUserSubscriptionsIdsByType(userId, feedType) {
+    return this.database
+      .pluck('s.feed_id')
+      .from('subscriptions as s').innerJoin('feeds as f', 's.feed_id', 'f.uid')
+      .where({ 's.user_id': userId, 'f.name': feedType })
+      .orderBy('s.created_at', 'desc')
+  }
+
+  getUserFriendIds(userId) {
+    const feedType = 'Posts';
+    return this.database
+      .pluck('f.user_id')
+      .from('subscriptions as s')
+      .innerJoin('feeds as f', 's.feed_id', 'f.uid')
+      .where({ 's.user_id': userId, 'f.name': feedType })
+      .orderBy('s.created_at', 'desc');
   }
 
   async isUserSubscribedToTimeline(currentUserId, timelineId) {

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -1148,6 +1148,14 @@ export class DbAdapter {
   // Feeds
   ///////////////////////////////////////////////////
 
+  initTimelineObject = (attrs, params) => {
+    if (!attrs) {
+      return null;
+    }
+    attrs = this._prepareModelPayload(attrs, FEED_FIELDS, FEED_FIELDS_MAPPING)
+    return DbAdapter.initObject(Timeline, attrs, attrs.id, params)
+  }
+
   async createTimeline(payload) {
     const preparedPayload = this._prepareModelPayload(payload, FEED_COLUMNS, FEED_COLUMNS_MAPPING)
     if (preparedPayload.name == 'MyDiscussions') {
@@ -1224,51 +1232,23 @@ export class DbAdapter {
     if (!validator.isUUID(id, 4)) {
       return null
     }
-    const res = await this.database('feeds').where('uid', id)
-    let attrs = res[0]
-
-    if (!attrs) {
-      return null
-    }
-
-    attrs = this._prepareModelPayload(attrs, FEED_FIELDS, FEED_FIELDS_MAPPING)
-    return DbAdapter.initObject(Timeline, attrs, id, params)
+    const attrs = await this.database('feeds').first().where('uid', id);
+    return this.initTimelineObject(attrs, params);
   }
 
   async getTimelineByIntId(id, params) {
-    const res = await this.database('feeds').where('id', id)
-    let feed = res[0]
-
-    if (!feed) {
-      return null
-    }
-
-    feed = this._prepareModelPayload(feed, FEED_FIELDS, FEED_FIELDS_MAPPING)
-    return DbAdapter.initObject(Timeline, feed, feed.id, params)
+    const attrs = await this.database('feeds').first().where('id', id);
+    return this.initTimelineObject(attrs, params);
   }
 
   async getTimelinesByIds(ids, params) {
-    const responses = await this.database('feeds').whereIn('uid', ids).orderByRaw(`position(uid::text in '${ids.toString()}')`)
-
-    const objects = responses.map((attrs) => {
-      if (attrs) {
-        attrs = this._prepareModelPayload(attrs, FEED_FIELDS, FEED_FIELDS_MAPPING)
-      }
-      return DbAdapter.initObject(Timeline, attrs, attrs.id, params)
-    })
-    return objects
+    const responses = await this.database('feeds').whereIn('uid', ids).orderByRaw(`position(uid::text in '${ids.toString()}')`);
+    return responses.map((r) => this.initTimelineObject(r, params));
   }
 
   async getTimelinesByIntIds(ids, params) {
-    const responses = await this.database('feeds').whereIn('id', ids).orderByRaw(`position(id::text in '${ids.toString()}')`)
-
-    const objects = responses.map((attrs) => {
-      if (attrs) {
-        attrs = this._prepareModelPayload(attrs, FEED_FIELDS, FEED_FIELDS_MAPPING)
-      }
-      return DbAdapter.initObject(Timeline, attrs, attrs.id, params)
-    })
-    return objects
+    const responses = await this.database('feeds').whereIn('id', ids).orderByRaw(`position(id::text in '${ids.toString()}')`);
+    return responses.map((r) => this.initTimelineObject(r, params));
   }
 
   async getTimelinesIntIdsByUUIDs(uuids) {
@@ -1299,19 +1279,11 @@ export class DbAdapter {
   }
 
   async getUserNamedFeed(userId, name, params) {
-    const response = await this.database('feeds').returning('uid').where({
+    const response = await this.database('feeds').first().returning('uid').where({
       user_id: userId,
       name
-    })
-
-    let namedFeed = response[0]
-
-    if (!namedFeed) {
-      return null
-    }
-
-    namedFeed = this._prepareModelPayload(namedFeed, FEED_FIELDS, FEED_FIELDS_MAPPING)
-    return DbAdapter.initObject(Timeline, namedFeed, namedFeed.id, params)
+    });
+    return this.initTimelineObject(response, params);
   }
 
   async getUserNamedFeedsIntIds(userId, names) {

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -4,7 +4,7 @@ import NodeCache from 'node-cache'
 import cacheManager from 'cache-manager'
 import redisStore from 'cache-manager-redis'
 import { promisifyAll } from 'bluebird'
-import pgFormat from 'pg-format';
+import pgFormat, { literal as pgQuote } from 'pg-format';
 
 import { load as configLoader } from '../../config/config'
 
@@ -2075,34 +2075,36 @@ export class DbAdapter {
   }
 
   async getUnreadDirectsNumber(userId) {
+    const [
+      [directsFeedId],
+      [directsReadAt],
+    ] = await Promise.all([
+      this.database.pluck('id').from('feeds').where({ 'user_id': userId, 'name': 'Directs' }),
+      this.database.pluck('directs_read_at').from('users').where({ 'uid': userId }),
+    ]);
+
     /*
      Select posts from my Directs feed, created after the directs_read_at authored by
      users other than me and then add posts from my Directs feed, having comments created after the directs_read_at
      authored by users other than me
      */
-    const uid = pgFormat('%L', userId)
-
     const sql = `
       select count(distinct unread.id) as cnt from (
-        select posts.id, posts.uid from posts
-          inner join feeds on posts.destination_feed_ids # feeds.id > 0 and feeds.name='Directs'
-          inner join users on feeds.user_id = users.uid
-          where 
-            users.uid=${uid}
-            and posts.user_id != ${uid}
-            and posts.created_at > users.directs_read_at
+        select id from 
+          posts 
+        where
+          destination_feed_ids && ARRAY[${directsFeedId}]
+          and user_id != ${pgQuote(userId)}
+          and created_at > ${pgQuote(directsReadAt)}
         union
-        select posts.id, posts.uid from posts
-          inner join feeds on posts.destination_feed_ids # feeds.id > 0 and feeds.name='Directs'
-          inner join users on feeds.user_id = users.uid
-          inner join comments on comments.post_id = posts.uid
-          where 
-            users.uid=${uid}
-            and comments.user_id != ${uid}
-          group by 
-            posts.id, posts.uid, users.directs_read_at
-          having 
-            max(comments.created_at) > users.directs_read_at) as unread`
+        select p.id from
+          comments c
+          join posts p on p.uid = c.post_id
+        where
+          p.destination_feed_ids && ARRAY[${directsFeedId}]
+          and c.user_id != ${pgQuote(userId)}
+          and c.created_at > ${pgQuote(directsReadAt)} 
+      ) as unread`;
 
     const res = await this.database.raw(sql);
     return res.rows[0].cnt;

--- a/migrations/20161126232124_indexes.js
+++ b/migrations/20161126232124_indexes.js
@@ -1,0 +1,13 @@
+export async function up(knex) {
+  await knex.schema.table('subscriptions', (table) => table.index('user_id', 'subscriptions_user_id_idx', 'btree'));
+  await knex.schema.table('bans', (table) => table.index('user_id', 'bans_user_id_idx', 'btree'));
+  await knex.schema.table('subscription_requests', (table) => table.index('to_user_id', 'subscription_requests_to_user_id_idx', 'btree'));
+  await knex.schema.table('group_admins', (table) => table.index('user_id', 'group_admins_user_id_idx', 'btree'));
+}
+
+export async function down(knex) {
+  await knex.schema.table('subscriptions', (table) => table.dropIndex('', 'subscriptions_user_id_idx'));
+  await knex.schema.table('bans', (table) => table.dropIndex('', 'bans_user_id_idx'));
+  await knex.schema.table('subscription_requests', (table) => table.dropIndex('', 'subscription_requests_to_user_id_idx'));
+  await knex.schema.table('group_admins', (table) => table.dropIndex('', 'group_admins_user_id_idx'));
+}

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "npm-run-all": "3.1.1",
     "scarlet": "2.0.20",
     "socket.io-client": "1.3.7",
-    "superagent": "1.8.3"
+    "superagent": "1.8.3",
+    "unexpected": "^10.19.0"
   }
 }

--- a/test/functional/usersV2.js
+++ b/test/functional/usersV2.js
@@ -3,11 +3,12 @@
 import fetch from 'node-fetch'
 import request from 'superagent'
 import knexCleaner from 'knex-cleaner'
+import expect from 'unexpected'
 
 import { getSingleton } from '../../app/app'
 import { DummyPublisher } from '../../app/pubsub'
 import { PubSub } from '../../app/models'
-import { createUserAsync } from '../functional/functional_test_helper'
+import { createUserAsync, mutualSubscriptions, subscribeToAsync } from '../functional/functional_test_helper'
 
 
 describe('UsersControllerV2', () => {
@@ -68,6 +69,78 @@ describe('UsersControllerV2', () => {
       blockedByMe[0].should.have.property('profilePictureLargeUrl')
       blockedByMe[0].should.have.property('profilePictureMediumUrl')
     })
+  })
+
+  describe('#whoami()', () => {
+    it('should reject unauthenticated users', (done) => {
+      request
+        .get(`${app.config.host}/v2/users/whoami`)
+        .end((err) => {
+          err.should.not.be.empty
+          err.status.should.eql(401)
+          done()
+        })
+    })
+
+    it('should return proper structure for authenticated user', async () => {
+      const [
+        luna,
+        mars,
+        venus,
+        zeus,
+      ] = await Promise.all([
+        createUserAsync('luna', 'pw'),
+        createUserAsync('mars', 'pw'),
+        createUserAsync('venus', 'pw'),
+        createUserAsync('zeus', 'pw'),
+      ]);
+
+      await Promise.all([
+        mutualSubscriptions([luna, mars]),
+        subscribeToAsync(luna, venus),
+        subscribeToAsync(zeus, luna),
+      ]);
+
+      const whoAmI = await fetch(`${app.config.host}/v2/users/whoami`, { headers: { 'X-Authentication-Token': luna.authToken } }).then((r) => r.json());
+
+      const userSchema = {
+        id:                      expect.it('to be a string'),
+        username:                expect.it('to be a string'),
+        screenName:              expect.it('to be a string'),
+        isPrivate:               expect.it('to be a string').and('to be one of', ['0', '1']),
+        isProtected:             expect.it('to be a string').and('to be one of', ['0', '1']),
+        isVisibleToAnonymous:    expect.it('to be a string').and('to be one of', ['0', '1']),
+        createdAt:               expect.it('to be a string').and('to match', /^\d+$/),
+        updatedAt:               expect.it('to be a string').and('to match', /^\d+$/),
+        type:                    expect.it('to be a string').and('to be one of', ['user', 'group']),
+        profilePictureLargeUrl:  expect.it('to be a string'),
+        profilePictureMediumUrl: expect.it('to be a string'),
+      };
+
+      const thisUserSchema = {
+        ...userSchema,
+        email:                expect.it('to be a string'),
+        description:          expect.it('to be a string'),
+        privateMeta:          expect.it('to be an object'),
+        frontendPreferences:  expect.it('to be an object'),
+        statistics:           expect.it('to be an object'),
+        banIds:               expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
+        pendingGroupRequests: expect.it('to be a boolean'),
+        unreadDirectsNumber:  expect.it('to be a string').and('to match', /^\d+$/),
+        subscribers:          expect.it('to be an array').and('to be empty').or('to have items exhaustively satisfying', userSchema),
+        subscriptions:        expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
+      };
+
+      expect(whoAmI, 'to exhaustively satisfy', {
+        users:         thisUserSchema,
+        subscribers:   expect.it('to be an array').and('to be empty').or('to have items exhaustively satisfying', userSchema),
+        subscriptions: expect.it('to be an array').and('to be empty').or('to have items exhaustively satisfying', {
+          id:   expect.it('to be a string'),
+          name: expect.it('to be a string'),
+          user: expect.it('to be a string'),
+        }),
+      });
+    });
   })
 })
 


### PR DESCRIPTION
'/v2/users/whoami' is an optimized replacement of '/v1/users/whoami'.

'/v2/users/whoami' don't returns 'admins' collection and returns only 'Posts'-type timelines in subscribers/subscriptions.