### PR TITLE
404-response for timelines of deleted users

### DIFF
--- a/app/controllers/api/v1/TimelinesController.js
+++ b/app/controllers/api/v1/TimelinesController.js
@@ -70,6 +70,10 @@ export default class TimelineController {
         throw new NotFoundException(`Feed "${username}" is not found`)
       }
 
+      if (user.hashedPassword === '') {
+        throw new NotFoundException(`Feed "${username}" is not found`);
+      }
+
       const currentUser = req.user ? req.user.id : null
       const timeline = await user.getPostsTimeline({
         offset: req.query.offset,
@@ -101,6 +105,10 @@ export default class TimelineController {
         throw new NotFoundException(`User "${req.params.username}" is not found`)
       }
 
+      if (user.hashedPassword === '') {
+        throw new NotFoundException(`Feed "${username}" is not found`);
+      }
+
       const currentUser = req.user ? req.user.id : null
       const timeline = await user.getLikesTimeline({
         offset: req.query.offset,
@@ -130,6 +138,10 @@ export default class TimelineController {
 
       if (null === user) {
         throw new NotFoundException(`User "${req.params.username}" is not found`)
+      }
+
+      if (user.hashedPassword === '') {
+        throw new NotFoundException(`Feed "${username}" is not found`);
       }
 
       const currentUser = req.user ? req.user.id : null

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -514,7 +514,12 @@ const getTimelineAsync = async (relativeUrl, userContext) => {
     url = `${url}?authToken=${encodedToken}`
   }
 
-  const response = await fetch(url)
+  const response = await fetch(url);
+
+  if (response.status != 200) {
+    throw new Error(`HTTP/1.1 ${response.status}`);
+  }
+
   const data = await response.json()
 
   return data

--- a/test/functional/timeline.js
+++ b/test/functional/timeline.js
@@ -2,10 +2,11 @@
 /* global $pg_database */
 import request from 'superagent'
 import knexCleaner from 'knex-cleaner'
+import expect from 'unexpected';
 
 import { getSingleton } from '../../app/app'
 import { DummyPublisher } from '../../app/pubsub'
-import { PubSub } from '../../app/models'
+import { dbAdapter, PubSub } from '../../app/models'
 import * as funcTestHelper from './functional_test_helper'
 
 
@@ -99,6 +100,11 @@ describe('TimelinesController', () => {
         done()
       })
     })
+
+    it('should respond with 404 for "deleted" user', async () => {
+      await dbAdapter.updateUser(context.user.id, { hashedPassword: '' });
+      return expect(funcTestHelper.getUserFeed(context), 'to be rejected with', new Error('HTTP/1.1 404'));
+    });
   })
 
   describe('#pagination', () => {
@@ -194,6 +200,12 @@ describe('TimelinesController', () => {
           })
         })
     })
+
+
+    it('should respond with 404 for "deleted" user', async () => {
+      await dbAdapter.updateUser(context.user.id, { hashedPassword: '' });
+      return expect(funcTestHelper.getUserLikesFeed(context), 'to be rejected with', new Error('HTTP/1.1 404'));
+    });
   })
 
   describe('#comments()', () => {
@@ -229,7 +241,6 @@ describe('TimelinesController', () => {
         done()
       })
     })
-
 
     it('should clear comments timeline only after all comments are deleted', (done) => {
       funcTestHelper.removeComment(comment.id, context.authToken, (err, res) => {
@@ -268,5 +279,10 @@ describe('TimelinesController', () => {
         })
       })
     })
+
+    it('should respond with 404 for "deleted" user', async () => {
+      await dbAdapter.updateUser(context.user.id, { hashedPassword: '' });
+      return expect(funcTestHelper.getUserCommentsFeed(context), 'to be rejected with', new Error('HTTP/1.1 404'));
+    });
   })
 })


### PR DESCRIPTION
Whenever we delete the user, we set her password-hash to empty string. This pull-requests adds special handling of this to timeline-requests (otherwise, there was a chance of getting error-500)

Closes T110