### PR TITLE
Fix realtime comment removal

### DIFF
--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -100,6 +100,8 @@ export function addModel(dbAdapter) {
 
   Comment.prototype.destroy = async function () {
     await dbAdapter.deleteComment(this.id, this.postId)
+    await dbAdapter.statsCommentDeleted(this.userId)
+    await pubSub.destroyComment(this.id, this.postId)
 
     // look for comment from this user in this post
     // if this is was the last one remove this post from user's comments timeline
@@ -114,9 +116,6 @@ export function addModel(dbAdapter) {
     const timelineId = await user.getCommentsTimelineIntId()
 
     await dbAdapter.withdrawPostFromFeeds([timelineId], this.postId)
-
-    await dbAdapter.statsCommentDeleted(this.userId)
-    await pubSub.destroyComment(this.id, this.postId)
   }
 
   Comment.prototype.getCreatedBy = function () {

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -99,22 +99,22 @@ export function addModel(dbAdapter) {
   }
 
   Comment.prototype.destroy = async function () {
-    await dbAdapter.deleteComment(this.id, this.postId)
-    await dbAdapter.statsCommentDeleted(this.userId)
-    await pubSub.destroyComment(this.id, this.postId)
+    await dbAdapter.deleteComment(this.id, this.postId);
+    await dbAdapter.statsCommentDeleted(this.userId);
+    await pubSub.destroyComment(this.id, this.postId);
 
     // Look for other comments from this user in the post:
     // if this was the last one then remove the post from "user's comments" timeline
-    const post = await dbAdapter.getPostById(this.postId)
-    const comments = await post.getComments()
+    const post = await dbAdapter.getPostById(this.postId);
+    const comments = await post.getComments();
 
     if (!_.some(comments, ['userId', this.userId])) {
-      const user = await dbAdapter.getUserById(this.userId)
-      const timelineId = await user.getCommentsTimelineIntId()
+      const user = await dbAdapter.getUserById(this.userId);
+      const timelineId = await user.getCommentsTimelineIntId();
 
-      await dbAdapter.withdrawPostFromFeeds([timelineId], this.postId)
+      await dbAdapter.withdrawPostFromFeeds([timelineId], this.postId);
     }
-  }
+  };
 
   Comment.prototype.getCreatedBy = function () {
     return dbAdapter.getUserById(this.userId)


### PR DESCRIPTION
Server didn't dispatch realtime event on comment removal if the post still had other comments from the same author. It was likely introduced on 2016-07-09 in cc9a55a.

I guess that code change was not necessary (at least, it seems to be unrelated to the commit message), but please correct me if I'm missing something here.