### PR TITLE
Add a isLastPage field to the output of v2 timelines

### DIFF
--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -147,7 +147,15 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
     }
   }
 
-  const postsIds = canViewUser ? await dbAdapter.getTimelinePostsIds(timelineIds, viewerId, params) : [];
+  const postsIds = canViewUser ?
+    await dbAdapter.getTimelinePostsIds(timelineIds, viewerId, { ...params, limit: params.limit + 1 }) :
+    [];
+
+  const isLastPage = postsIds.length <= params.limit;
+  if (!isLastPage) {
+    postsIds.length = params.limit;
+  }
+
   const postsWithStuff = await dbAdapter.getPostsWithStuffByIds(postsIds, viewerId);
 
   for (const { post, destinations, attachments, comments, likes, omittedComments, omittedLikes } of postsWithStuff) {
@@ -213,6 +221,7 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
     subscriptions,
     subscribers,
     admins,
+    isLastPage,
     posts:       allPosts,
     comments:    _.compact(allComments),
     attachments: _.compact(allAttachments),

--- a/test/functional/timelinesV2.js
+++ b/test/functional/timelinesV2.js
@@ -501,6 +501,32 @@ describe('TimelinesControllerV2', () => {
       it('should return Mars timelines without posts to Luna', emptyExpected(false));
     });
   });
+
+  describe('#pagination', () => {
+    let luna;
+    beforeEach(async () => {
+      luna = await createUserAsync('luna', 'pw');
+      // Luna creates 10 posts
+      for (let i = 0; i < 10; i++) {
+        await createAndReturnPost(luna, 'Post');  // eslint-disable-line babel/no-await-in-loop
+      }
+    });
+
+    it('should return first page with isLastPage = false', async () => {
+      const timeline = await fetchTimeline('luna?limit=5&offset=0')(app);
+      expect(timeline.isLastPage, 'to equal', false);
+    });
+
+    it('should return last page with isLastPage = true', async () => {
+      const timeline = await fetchTimeline('luna?limit=5&offset=5')(app);
+      expect(timeline.isLastPage, 'to equal', true);
+    });
+
+    it('should return the only page with isLastPage = true', async () => {
+      const timeline = await fetchTimeline('luna?limit=15&offset=0')(app);
+      expect(timeline.isLastPage, 'to equal', true);
+    });
+  });
 });
 
 
@@ -523,6 +549,7 @@ const timelineSchema = {
     name: expect.it('to be one of', ['Posts', 'Directs']),
     user: expect.it('to satisfy', schema.UUID),
   }),
+  isLastPage: expect.it('to be a boolean'),
 };
 
 const fetchTimeline = (path) => async (app, viewerContext = null) => {


### PR DESCRIPTION
Timeline (v2) response now always contains a boolean field `isLastPage`. If page requested by user is a last page of timeline then `isLastPage` is true.