### PR TITLE
Use explicit "bumped_at" field for post-sorting

### DIFF
--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -3,7 +3,7 @@ import { dbAdapter } from '../../../models';
 import { serializePostsCollection, serializePost, serializeComment, serializeAttachment } from '../../../serializers/v2/post';
 import { monitored, authRequired, userSerializerFunction } from './helpers';
 
-const ORD_UPDATED = 'updated'; // eslint-disable-line no-unused-vars
+const ORD_UPDATED = 'bumped'; // eslint-disable-line no-unused-vars
 const ORD_CREATED = 'created'; // eslint-disable-line no-unused-vars
 
 export default class TimelinesController {
@@ -77,7 +77,7 @@ export default class TimelinesController {
  * @param {object} query                 - Query object
  * @param {string} [query.limit]         - Number of posts returned (default: 30)
  * @param {string} [query.offset]        - Number of posts to skip (default: 0)
- * @param {string} [query.sort]          - Sort mode ('created' or 'updated')
+ * @param {string} [query.sort]          - Sort mode ('created' or 'bumped')
  * @param {string} [query.with-my-posts] - For filter/discussions only: return viewer's own
  *                                         posts even without his likes or comments (default: no)
  * @param {string} defaultSort           - Default sort mode

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -32,6 +32,10 @@ export function addModel(dbAdapter) {
       this.updatedAt = params.updatedAt
     }
 
+    if (parseInt(params.bumpedAt, 10)) {
+      this.bumpedAt = params.bumpedAt;
+    }
+
     if (params.maxComments != 'all') {
       this.maxComments = parseInt(params.maxComments, 10) || 2
     } else {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -77,8 +77,9 @@ export function addModel(dbAdapter) {
   }
 
   Post.prototype.create = async function () {
-    this.createdAt = new Date().getTime()
-    this.updatedAt = new Date().getTime()
+    this.createdAt = new Date().getTime();
+    this.updatedAt = new Date().getTime();
+    this.bumpedAt = new Date().getTime();
 
     await this.validate()
 
@@ -87,6 +88,7 @@ export function addModel(dbAdapter) {
       'userId':           this.userId,
       'createdAt':        this.createdAt.toString(),
       'updatedAt':        this.updatedAt.toString(),
+      'bumpedAt':         this.updatedAt.toString(),
       'commentsDisabled': this.commentsDisabled
     }
     this.feedIntIds = await dbAdapter.getTimelinesIntIdsByUUIDs(this.timelineIds)
@@ -340,7 +342,7 @@ export function addModel(dbAdapter) {
     const now = new Date();
 
     const promises = [
-      dbAdapter.setPostUpdatedAt(this.id, now.getTime()),
+      dbAdapter.setPostBumpedAt(this.id, now.getTime()),
       dbAdapter.setUpdatedAtInGroupsByIds(timelineOwnersIds, now.getTime())
     ];
 

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -254,6 +254,7 @@ const FEED_FIELDS_MAPPING = {
 const POST_COLUMNS = {
   createdAt:        'created_at',
   updatedAt:        'updated_at',
+  bumpedAt:         'bumped_at',
   userId:           'user_id',
   body:             'body',
   commentsDisabled: 'comments_disabled',
@@ -287,6 +288,7 @@ const POST_FIELDS = {
   uid:                  'id',
   created_at:           'createdAt',
   updated_at:           'updatedAt',
+  bumped_at:            'bumpedAt',
   user_id:              'userId',
   body:                 'body',
   comments_disabled:    'commentsDisabled',
@@ -301,6 +303,7 @@ const POST_FIELDS = {
 const POST_FIELDS_MAPPING = {
   created_at:        (time) => { return time.getTime().toString() },
   updated_at:        (time) => { return time.getTime().toString() },
+  bumped_at:         (time) => { return time.getTime().toString() },
   comments_disabled: (comments_disabled) => {return comments_disabled ? '1' : '0' },
   user_id:           (user_id) => {return user_id ? user_id : ''},
   is_private:        (is_private) => {return is_private ? '1' : '0' },

--- a/app/support/DbAdapter.js
+++ b/app/support/DbAdapter.js
@@ -1577,13 +1577,13 @@ export class DbAdapter {
     params = {
       limit:          30,
       offset:         0,
-      sort:           'updated',
+      sort:           'bumped',
       withLocalBumps: false,
       withMyPosts:    false,
       ...params,
     };
 
-    params.withLocalBumps = params.withLocalBumps && !!viewerId && params.sort === 'updated';
+    params.withLocalBumps = params.withLocalBumps && !!viewerId && params.sort === 'bumped';
 
     // Private feeds viewer can read
     let visiblePrivateFeedIntIds = [];

--- a/migrations/20170228223110_bumped.js
+++ b/migrations/20170228223110_bumped.js
@@ -1,0 +1,13 @@
+export async function up(knex) {
+  await knex.schema.table('posts', (posts) => {
+    posts.timestamp('bumped_at').defaultTo(knex.fn.now()).notNullable();
+  });
+
+  await knex.raw('UPDATE "posts" SET "bumped_at" = "updated_at"');
+}
+
+export async function down(knex) {
+  await knex.schema.table('posts', (posts) => {
+    posts.dropColumn('bumped_at');
+  });
+}

--- a/test/unit/post_bubbling.js
+++ b/test/unit/post_bubbling.js
@@ -260,6 +260,14 @@ describe('PostBubbling', () => {
           await homeFeedEqualTo(luna, expectedContent, luna.id)
         })
 
+        it('should not change order of posts after edits', async () => {
+          const expectedContent = [...marsPostsContent].reverse().concat([...lunaPostsContent].reverse());
+          await homeFeedEqualTo(luna, expectedContent, luna.id);  // sanity check
+
+          await marsPosts[0].update({ body: marsPosts[0].body });  // empty change, we're interested in metadata
+          await homeFeedEqualTo(luna, expectedContent, luna.id);
+        });
+
         it('each comment moves the post to the top', async () => {
           let expectedContent
 


### PR DESCRIPTION
This pull-request introduces new `bumped_at` field which is used to control global order of posts (can be further tweaked via local bumps).

Previously used "updated_at" field is reserved strictly for changes of post itself.

Fixes T100