### PR TITLE
Search: private users should see their own posts

### DIFF
--- a/app/controllers/api/v2/SearchController.js
+++ b/app/controllers/api/v2/SearchController.js
@@ -35,7 +35,7 @@ export default class SearchController {
     const bannedUserIds = ctx.state.user ? await ctx.state.user.getBanIds() : [];
     const currentUserId = ctx.state.user ? ctx.state.user.id : null;
     const isAnonymous = !ctx.state.user;
-    const visibleFeedIds = ctx.state.user ? ctx.state.user.subscribedFeedIds : [];
+    const visibleFeedIds = ctx.state.user ? [await ctx.state.user.getPostsTimelineIntId(), ...ctx.state.user.subscribedFeedIds] : [];
 
     switch (preparedQuery.scope) {
       case SEARCH_SCOPES.ALL_VISIBLE_POSTS:

--- a/test/functional/search.js
+++ b/test/functional/search.js
@@ -17,7 +17,7 @@ describe('SearchController', () => {
     await knexCleaner.clean($pg_database)
   })
 
-  describe('#create()', () => {
+  describe('#search()', () => {
     let lunaContext = {}
     let marsContext = {}
     const anonContext = {}

--- a/test/functional/search.js
+++ b/test/functional/search.js
@@ -91,5 +91,27 @@ describe('SearchController', () => {
       response.should.have.property('isLastPage')
       response.isLastPage.should.be.eql(true)
     })
+
+    describe('Luna is private', () => {
+      beforeEach(async () => {
+        await funcTestHelper.goPrivate(lunaContext);
+      });
+
+      it(`should search user's posts`, async () => {
+        const response = await funcTestHelper.performSearch(lunaContext, 'from:luna hello');
+        response.should.not.be.empty;
+        response.should.have.property('posts');
+        response.posts.length.should.be.eql(1);
+        response.posts[0].body.should.be.eql('hello from luna');
+      });
+
+      it('should search own posts with from:me', async () => {
+        const response = await funcTestHelper.performSearch(lunaContext, 'from:me hello');
+        response.should.not.be.empty;
+        response.should.have.property('posts');
+        response.posts.length.should.be.eql(1);
+        response.posts[0].body.should.be.eql('hello from luna');
+      });
+    });
   })
 });


### PR DESCRIPTION
Private users were not able to see their own posts while searching. Their subscribers could.

I fixed this by adding user's own feed of posts to the list of "visible feeds" which previously contained only subscriptions.

Close T114