### PR TITLE
Trim leading or trailing spaces from screenName before validation

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -234,11 +234,11 @@ export function addModel(dbAdapter) {
   }
 
   User.prototype.screenNameIsValid = function (screenName) {
-    if (!screenName) {
+    if (typeof screenName !== 'string') {
       return false
     }
 
-    const len = GraphemeBreaker.countBreaks(screenName)
+    const len = GraphemeBreaker.countBreaks(screenName.trim())
 
     if (len < 3 || len > 25) {
       return false

--- a/test/functional/users.js
+++ b/test/functional/users.js
@@ -761,7 +761,9 @@ describe('UsersController', () => {
       const invalid = [
         '', 'a', 'aa', 'aaaaaaaaaaaaaaaaaaaaaaaaaa',
         '\u4E9C\u4E9C',  // 2 han ideographs
-        '\u0928\u093F\u0928\u093F'  // Devanagari syllable "ni" (repeated 2 times)
+        '\u0928\u093F\u0928\u093F',  // Devanagari syllable "ni" (repeated 2 times)
+        '   ', // 3 spaces
+        '\t\t\t', // 3 tabs
       ]
 
       _.forEach(invalid, (screenName) => {


### PR DESCRIPTION
Before that, it was possible to specify a name consisting of only spaces (3 or more).