### PR TITLE
Add an authorization command in the realtime session

### DIFF
--- a/test/functional/realtime.js
+++ b/test/functional/realtime.js
@@ -1289,4 +1289,48 @@ describe('Realtime (Socket.io)', () => {
       });
     });
   });
+
+  describe('Authorization inside the realtime session', () => {
+    describe('Mars is a private user', () => {
+      beforeEach(async () => {
+        await funcTestHelper.goPrivate(marsContext);
+      });
+
+      it(
+        'Anonymous does not get notifications about his posts',
+        () => expect(anonContext, 'when subscribed to timeline', marsTimeline,
+          'not to get post:* events from', marsContext)
+      );
+
+      it(
+        'Mars gets notifications about his posts',
+        () => expect(anonContext, 'when subscribed to timeline', marsTimeline,
+          'when authorized as', marsContext,
+          'to get post:* events from', marsContext)
+      );
+
+      it(
+        'Luna does not gets notifications about his posts',
+        () => expect(anonContext, 'when subscribed to timeline', marsTimeline,
+          'when authorized as', lunaContext,
+          'not to get post:* events from', marsContext)
+      );
+
+      it(
+        'Luna re-auth as Mars and gets notifications about his posts',
+        () => expect(anonContext, 'when subscribed to timeline', marsTimeline,
+          'when authorized as', lunaContext,
+          'when authorized as', marsContext,
+          'to get post:* events from', marsContext)
+      );
+
+      it(
+        'Mars signed out and does not get notifications about his posts',
+        () => expect(anonContext, 'when subscribed to timeline', marsTimeline,
+          'when authorized as', marsContext,
+          'when authorized as', anonContext,
+          'not to get post:* events from', marsContext)
+      );
+    });
+  });
 });

--- a/test/functional/realtime_assertions.js
+++ b/test/functional/realtime_assertions.js
@@ -115,6 +115,15 @@ export function installInto(expect) {
     }
   });
 
+  expect.addAssertion('<realtimeSession> when authorized as <userContext> <assertion>', async (expect, session, user) => {
+    session.send('auth', { authToken: user.authToken });
+    try {
+      return await expect.shift(session);
+    } finally {
+      session.disconnect();
+    }
+  });
+
   expect.addAssertion('<realtimeSession> with post having id <string> <assertion>', (expect, session, postId) => {
     session.context.postId = postId;
     return expect.shift(session);


### PR DESCRIPTION
This PR adds an 'auth' realtime command with payload like `{ authToken: '…' }`. If 'authToken' is a valid user's JWT-token then realtime session becomes authorized. If 'authToken' is empty or falsy or invalid then realtime session becomes anonymous.

With this command one can sign in, sign out, or change authToken during realtime session without reconnect. This should be the recommended way to authorize the realtime session.