### PR TITLE
Realtime and other improvements

### DIFF
--- a/app/controllers/api/v2/PostsController.js
+++ b/app/controllers/api/v2/PostsController.js
@@ -73,6 +73,11 @@ export default class PostsController {
       omittedLikes:    postWithStuff.omittedLikes,
     };
 
+    const { intId: hidesFeedId } = viewer ? await dbAdapter.getUserNamedFeed(viewer.id, 'Hides') : { intId: 0 };
+    if (postWithStuff.post.feedIntIds.includes(hidesFeedId)) {
+      sPost.isHidden = true; // present only if true
+    }
+
     const comments = postWithStuff.comments.map(serializeComment);
     const attachments = postWithStuff.attachments.map(serializeAttachment);
     const subscribersIds = _.compact(_.map(postWithStuff.destinations, 'user'));

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -550,13 +550,13 @@ export function addModel(dbAdapter) {
 
   Post.prototype.removeLike = async function (userId) {
     const user = await dbAdapter.getUserById(userId)
+    const prevFeedIds = await this.getTimelineIds()
     const timelineId = await user.getLikesTimelineIntId()
-    const promises = [
+    await Promise.all([
       dbAdapter.removeUserPostLike(this.id, userId),
       dbAdapter.withdrawPostFromFeeds([timelineId], this.id)
-    ]
-    await Promise.all(promises)
-    await pubSub.removeLike(this.id, userId)
+    ])
+    await pubSub.removeLike(this.id, userId, prevFeedIds)
 
     return true
   }

--- a/app/models/timeline.js
+++ b/app/models/timeline.js
@@ -398,6 +398,17 @@ export function addModel(dbAdapter) {
     return this.name === 'Hides'
   }
 
+  /**
+   * Personal timeline can be viewed only by it owner
+   * @return {boolean}
+   */
+  Timeline.prototype.isPersonal = function () {
+    return this.name === 'RiverOfNews' ||
+      this.name === 'Directs' ||
+      this.name === 'Hides' ||
+      this.name === 'MyDiscussions';
+  }
+
   Timeline.prototype.updatePost = async function (postId, action) {
     if (action === 'like') {
       const postInTimeline = await dbAdapter.isPostPresentInTimeline(this.intId, postId)

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -101,7 +101,17 @@ export default class PubsubListener {
           continue;
         }
 
-        data[channel].filter(Boolean).forEach((id) => {
+        data[channel].filter(Boolean).forEach(async (id) => {
+          if (channel === 'timeline') {
+            const t = await dbAdapter.getTimelineById(id);
+            if (!t) {
+              logger.warn(`attempt to subscribe to nonexistent timeline (ID=${id})`);
+              return;
+            } else if (t.isPersonal() && t.userId !== socket.user.id) {
+              logger.warn(`attempt to subscribe to someone else's '${t.name}' timeline`);
+              return;
+            }
+          }
           socket.join(`${channel}:${id}`)
           logger.info(`User has subscribed to ${id} ${channel}`)
         })

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -1,6 +1,6 @@
 import { promisifyAll } from 'bluebird'
 import { createClient as createRedisClient } from 'redis'
-import { isArray, isPlainObject, keyBy, uniq } from 'lodash'
+import { isArray, isPlainObject, keyBy, uniq, uniqBy, cloneDeep } from 'lodash'
 import IoServer from 'socket.io'
 import redis_adapter from 'socket.io-redis'
 import jwt from 'jsonwebtoken'
@@ -155,9 +155,8 @@ export default class PubsubListener {
     }
   }
 
-  async broadcastMessage(sockets, rooms, type, json, post, emitter = null) {
+  async broadcastMessage(sockets, rooms, type, json, post, emitter = defaultEmitter) {
     const { logger } = this.app.context;
-    emitter = emitter || ((socket, type, json) => socket.emit(type, json));
 
     let destSockets = rooms
       .filter((r) => r in sockets.adapter.rooms) // active rooms
@@ -220,7 +219,7 @@ export default class PubsubListener {
     const json = await new PostSerializer(post).promiseToJSON()
 
     const type = 'post:new'
-    const rooms = await getRoomsOfFeedsAndPost(post)
+    const rooms = await getRoomsOfPost(post)
     await this.broadcastMessage(sockets, rooms, type, json, post, this._postEventEmitter);
   }
 
@@ -229,7 +228,7 @@ export default class PubsubListener {
     const json = await new PostSerializer(post).promiseToJSON()
 
     const type = 'post:update'
-    const rooms = await getRoomsOfFeedsAndPost(post)
+    const rooms = await getRoomsOfPost(post)
     await this.broadcastMessage(sockets, rooms, type, json, post, this._postEventEmitter);
   }
 
@@ -246,7 +245,7 @@ export default class PubsubListener {
 
     const type = 'comment:new'
     const timelines = await dbAdapter.getTimelinesByIds(data.timelineIds)
-    const rooms = await getRoomsOfFeedsAndPost(post, timelines, true);
+    const rooms = await getRoomsOfPost(post, timelines);
     await this.broadcastMessage(sockets, rooms, type, json, post, this._commentLikeEventEmitter);
   }
 
@@ -256,7 +255,7 @@ export default class PubsubListener {
     const json = await new PubsubCommentSerializer(comment).promiseToJSON()
 
     const type = 'comment:update'
-    const rooms = await getRoomsOfFeedsAndPost(post)
+    const rooms = await getRoomsOfPost(post)
     await this.broadcastMessage(sockets, rooms, type, json, post, this._commentLikeEventEmitter);
   }
 
@@ -265,7 +264,7 @@ export default class PubsubListener {
     const post = await dbAdapter.getPostById(data.postId)
 
     const type = 'comment:destroy'
-    const rooms = await getRoomsOfFeedsAndPost(post)
+    const rooms = await getRoomsOfPost(post)
     await this.broadcastMessage(sockets, rooms, type, json, post);
   }
 
@@ -283,31 +282,47 @@ export default class PubsubListener {
     const timelines = await dbAdapter.getTimelinesByIds(data.timelineIds)
 
     const type = 'like:new'
-    const rooms = await getRoomsOfFeedsAndPost(post, timelines, true);
+    const rooms = await getRoomsOfPost(post, timelines);
     await this.broadcastMessage(sockets, rooms, type, json, post);
   }
 
-  onLikeRemove = async (sockets, data) => {
-    const json = { meta: { userId: data.userId, postId: data.postId } }
-    const post = await dbAdapter.getPostById(data.postId)
+  onLikeRemove = async (sockets, { userId, postId, prevFeedIds }) => {
+    const json = { meta: { userId, postId } }
+    const [
+      post,
+      timelines,
+    ] = await Promise.all([
+      dbAdapter.getPostById(postId),
+      dbAdapter.getTimelinesByIds(prevFeedIds),
+    ]);
 
     const type = 'like:remove'
-    const rooms = await getRoomsOfFeedsAndPost(post);
+    const rooms = await getRoomsOfPost(post, timelines);
     await this.broadcastMessage(sockets, rooms, type, json, post);
   }
 
-  onPostHide = (sockets, data) => {
-    // NOTE: posts are hidden only on RiverOfNews timeline so this
-    // event won't leak any personal information
-    const json = { meta: { postId: data.postId } }
-    sockets.in(`timeline:${data.timelineId}`).emit('post:hide', json)
+  onPostHide = async (sockets, data) => {
+    // NOTE: this event only broadcasts to hider's sockets
+    // so it won't leak any personal information
+    const { postId, userId } = data;
+    const json = { meta: { postId } };
+    const post = await dbAdapter.getPostById(data.postId)
+
+    const type = 'post:hide';
+    const rooms = await getRoomsOfPost(post);
+    await this.broadcastMessage(sockets, rooms, type, json, post, this._singleUserEmitter(userId));
   }
 
-  onPostUnhide = (sockets, data) => {
-    // NOTE: posts are hidden only on RiverOfNews timeline so this
-    // event won't leak any personal information
-    const json = { meta: { postId: data.postId } }
-    sockets.in(`timeline:${data.timelineId}`).emit('post:unhide', json)
+  onPostUnhide = async (sockets, data) => {
+    // NOTE: this event only broadcasts to hider's sockets
+    // so it won't leak any personal information
+    const { postId, userId } = data;
+    const json = { meta: { postId } };
+    const post = await dbAdapter.getPostById(data.postId)
+
+    const type = 'post:unhide';
+    const rooms = await getRoomsOfPost(post);
+    await this.broadcastMessage(sockets, rooms, type, json, post, this._singleUserEmitter(userId));
   }
 
   onCommentLikeNew = async (sockets, data) => {
@@ -333,7 +348,7 @@ export default class PubsubListener {
       json.comments.userId = data.unlikerUUID;
     }
 
-    const rooms = await getRoomsOfFeedsAndPost(post, null, true);
+    const rooms = await getRoomsOfPost(post);
     await this.broadcastMessage(sockets, rooms, msgType, json, post, this._commentLikeEventEmitter);
   };
 
@@ -343,15 +358,30 @@ export default class PubsubListener {
     const [commentLikesData] = await dbAdapter.getLikesInfoForComments([commentUUID], viewer.id);
     json.comments.likes = parseInt(commentLikesData.c_likes);
     json.comments.hasOwnLike = commentLikesData.has_own_like;
-
-    socket.emit(type, json);
+    defaultEmitter(socket, type, json);
   }
 
   _postEventEmitter = async (socket, type, json) => {
+    // We should make a copy of json because
+    // there are parallel emitters running with
+    // the same data
+    json = cloneDeep(json);
     const viewer = socket.user;
     json = await this._insertCommentLikesInfo(json, viewer.id);
-    socket.emit(type, json);
+    if (type !== 'post:new') {
+      const isHidden = !!viewer.id && await dbAdapter.isPostHiddenByUser(json.posts.id, viewer.id);
+      if (isHidden) {
+        json.posts.isHidden = true;
+      }
+    }
+    defaultEmitter(socket, type, json);
   }
+
+  _singleUserEmitter = (userId) => (socket, type, json) => {
+    if (socket.user.id === userId) {
+      defaultEmitter(socket, type, json);
+    }
+  };
 
   async _insertCommentLikesInfo(postPayload, viewerUUID) {
     postPayload.posts = { ...postPayload.posts, commentLikes: 0, ownCommentLikes: 0, omittedCommentLikes: 0, omittedOwnCommentLikes: 0 };
@@ -398,48 +428,31 @@ export default class PubsubListener {
 }
 
 /**
- * Returns feeds without RiverOfNews'es and Hides'es
- * which owners have hidden given post.
+ * Returns array of room names related to post as union of
+ * post room and timelines: `post.getTimelines()`, post author's 
+ * and likers/commenters `MyDiscussions` feeds 
+ * and `addFeeds` if it is not empty.
  * 
- * @param {Timeline[]} feeds 
  * @param {Post} post 
- * @return {Timeline[]}
- */
-async function filterFeedsThatHidePost(feeds, post) {
-  const riverOwnerIds = uniq(feeds.filter((f) => f.isRiverOfNews() || f.isHides()).map((f) => f.userId));
-  const hidesFeeds = await dbAdapter.getUsersNamedTimelines(riverOwnerIds, 'Hides');
-  // Post was hidden by these users
-  const blindUserIds = uniq(hidesFeeds.filter((f) => post.feedIntIds.includes(f.intId)).map((f) => f.userId));
-
-  return feeds.filter((f) => {
-    if (f.isRiverOfNews() || f.isHides()) {
-      return !blindUserIds.includes(f.userId);
-    }
-    return true;
-  });
-}
-
-/**
- * Returns array of room names for the given feeds and post.
- * If `filterHides` is true, filter feeds by `filterFeedsThatHidePost`.
- * If `feeds` is falsy then `post.getTimelines()` used.
- * 
- * @param {Timeline[]} feeds 
- * @param {Post} post 
- * @param {boolean} [filterHides]
+ * @param {Timeline[]} addFeeds
  * @return {string[]}
  */
-async function getRoomsOfFeedsAndPost(post, feeds = null, filterHides = false) {
+async function getRoomsOfPost(post, addFeeds = []) {
   if (!post) {
     return [];
   }
-  if (!feeds) {
-    feeds = await post.getTimelines();
-  }
-  if (filterHides) {
-    feeds = await filterFeedsThatHidePost(feeds, post);
-  }
+
+  const postFeeds = await post.getTimelines();
+
+  const myDiscussionsOwnerIds = [...postFeeds, ...addFeeds].filter((f) => f.isLikes() || f.isComments()).map((f) => f.userId);
+  myDiscussionsOwnerIds.push(post.userId);
+  const myDiscussionsFeeds = await dbAdapter.getUsersNamedTimelines(uniq(myDiscussionsOwnerIds), 'MyDiscussions');
+
+  const feeds = uniqBy([...postFeeds, ...myDiscussionsFeeds, ...addFeeds], 'id');
+
   const rooms = feeds.map((t) => `timeline:${t.id}`);
   rooms.push(`post:${post.id}`);
   return rooms;
 }
+
+const defaultEmitter = (socket, type, json) => socket.emit(type, json);

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -82,25 +82,17 @@ export default class pubSub {
     await this.publisher.likeAdded(payload)
   }
 
-  async removeLike(postId, userId) {
-    const payload = JSON.stringify({ userId, postId })
+  async removeLike(postId, userId, prevFeedIds = []) {
+    const payload = JSON.stringify({ userId, postId, prevFeedIds })
     await this.publisher.likeRemoved(payload)
   }
 
   async hidePost(userId, postId) {
-    const user = await dbAdapter.getUserById(userId)
-    const timelineId = await user.getRiverOfNewsTimelineId()
-
-    const payload = JSON.stringify({ timelineId, postId })
-    await this.publisher.postHidden(payload)
+    await this.publisher.postHidden(JSON.stringify({ userId, postId }));
   }
 
   async unhidePost(userId, postId) {
-    const user = await dbAdapter.getUserById(userId)
-    const timelineId = await user.getRiverOfNewsTimelineId()
-
-    const payload = JSON.stringify({ timelineId, postId })
-    await this.publisher.postUnhidden(payload)
+    await this.publisher.postUnhidden(JSON.stringify({ userId, postId }))
   }
 
   async newCommentLike(commentId, postId, likerUUID) {

--- a/app/support/DbAdapter/feeds.js
+++ b/app/support/DbAdapter/feeds.js
@@ -11,11 +11,8 @@ import { initObject, prepareModelPayload } from './utils';
 const feedsTrait = (superClass) => class extends superClass {
   async createTimeline(payload) {
     const preparedPayload = prepareModelPayload(payload, FEED_COLUMNS, FEED_COLUMNS_MAPPING)
-    if (preparedPayload.name == 'MyDiscussions') {
-      preparedPayload.uid = preparedPayload.user_id
-    }
-    const res = await this.database('feeds').returning(['id', 'uid']).insert(preparedPayload)
-    return { intId: res[0].id, id: res[0].uid }
+    const [res] = await this.database('feeds').returning(['id', 'uid']).insert(preparedPayload)
+    return { intId: res.id, id: res.uid }
   }
 
   createUserTimelines(userId, timelineNames) {

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -658,6 +658,18 @@ const postsTrait = (superClass) => class extends superClass {
   initRawPosts(rawPosts, params) {
     return rawPosts.map((attrs) => initPostObject(attrs, params));
   }
+
+  async isPostHiddenByUser(postUID, userUID) {
+    const { rows } = await this.database.raw(
+      `select 1 from
+        feeds f
+        join posts p on p.feed_ids && array[f.id]
+      where p.uid = :postUID and f.user_id = :userUID and f.name = 'Hides'
+      `,
+      { postUID, userUID }
+    );
+    return rows.length > 0;
+  }
 };
 
 export default postsTrait;

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -772,6 +772,10 @@ export function hidePost(postId, user) {
   return postJson(`/v1/posts/${postId}/hide`, { authToken: user.authToken })
 }
 
+export function unhidePost(postId, user) {
+  return postJson(`/v1/posts/${postId}/unhide`, { authToken: user.authToken })
+}
+
 export async function getUserEvents(userContext, eventTypes = null, limit = null, offset = null, startDate = null, endDate = null) {
   const eventTypesQS = eventTypes ? eventTypes.map((t) => `filter=${t}&`).join('') : '';
   const limitQS = limit ? `limit=${limit}&` : '';

--- a/test/functional/postsV2.js
+++ b/test/functional/postsV2.js
@@ -18,6 +18,7 @@ import {
   fetchPost,
   createMockAttachmentAsync,
   updatePostAsync,
+  hidePost,
 } from './functional_test_helper'
 
 describe('TimelinesControllerV2', () => {
@@ -265,6 +266,19 @@ describe('TimelinesControllerV2', () => {
         await updatePostAsync(luna, postData);
         const { posts } = await fetchPost(luna.post.id);
         expect(posts.attachments, 'to equal', postData.attachments);
+      });
+    });
+    describe('Luna wrote post and hide it', () => {
+      let luna;
+      beforeEach(async () => {
+        luna = await createUserAsync('luna', 'pw');
+        luna.post = await createAndReturnPost(luna, 'Luna post');
+        await hidePost(luna.post.id, luna);
+      });
+
+      it('should return post to Luna with truthy isHidden property', async () => {
+        const { posts } = await fetchPost(luna.post.id, luna);
+        expect(posts, 'to have key', 'isHidden'); // it must be true because of schema
       });
     });
   });

--- a/test/functional/realtime.js
+++ b/test/functional/realtime.js
@@ -540,22 +540,22 @@ describe('Realtime (Socket.io)', () => {
             });
 
             describe("when subscribed to Mars's RiverOfNews", () => {
-              it("Mars doesn't get notifications about own comment likes to Luna's comment", async () => {
+              it("Mars gets notifications about own comment likes to Luna's comment", async () => {
                 const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
                   'when subscribed to timeline', marsRiverOfNews,
                   'with comment having id', lunaComment.id,
-                  'not to get comment_like:new event from', marsContext
+                  'to get comment_like:new event from', marsContext
                 );
-                expect(msg, 'to be', null);
+                expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, true, marsContext.user.id));
               });
 
-              it("Mars doesn't get notifications about Jupiter's comment likes to Luna's comment", async () => {
+              it("Mars gets notifications about Jupiter's comment likes to Luna's comment", async () => {
                 const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
                   'when subscribed to timeline', marsRiverOfNews,
                   'with comment having id', lunaComment.id,
-                  'not to get comment_like:new event from', jupiter
+                  'to get comment_like:new event from', jupiter
                 );
-                expect(msg, 'to be', null);
+                expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, jupiter.user.id));
               });
             });
           });
@@ -1147,13 +1147,13 @@ describe('Realtime (Socket.io)', () => {
             });
 
             describe("when subscribed to Mars's RiverOfNews", () => {
-              it("Mars doesn't get notifications about comment likes", async () => {
+              it('Mars gets notifications about comment likes', async () => {
                 const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
                   'when subscribed to timeline', marsRiverOfNews,
                   'with comment having id', lunaComment.id,
-                  'not to get comment_like:remove event from', marsContext
+                  'to get comment_like:remove event from', marsContext
                 );
-                expect(msg, 'to be', null);
+                expect(msg, 'to satisfy', commentHavingNLikesExpectation(0, false, marsContext.user.id));
               });
             });
           });

--- a/test/functional/realtime.js
+++ b/test/functional/realtime.js
@@ -469,15 +469,6 @@ describe('Realtime (Socket.io)', () => {
         });
 
         describe('via RiverOfNews timeline channel', () => {
-          it('Anonymous user gets notifications about comment likes', async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(anonContext,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', lunaComment.id,
-              'to get comment_like:new event from', marsContext
-            );
-            expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, marsContext.user.id));
-          });
-
           it('Luna gets notifications about comment likes to own comment', async () => {
             const { context: { commentLikeRealtimeMsg: msg } } = await expect(lunaContext,
               'when subscribed to timeline', lunaRiverOfNews,
@@ -485,24 +476,6 @@ describe('Realtime (Socket.io)', () => {
               'to get comment_like:new event from', marsContext
             );
             expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, marsContext.user.id));
-          });
-
-          it("Mars gets notifications about comment likes to Luna's comment", async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', lunaComment.id,
-              'to get comment_like:new event from', marsContext
-            );
-            expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, true, marsContext.user.id));
-          });
-
-          it("Luna gets notifications about comment likes to Mars' comment", async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(lunaContext,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', marsComment.id,
-              'to get comment_like:new event from', jupiter
-            );
-            expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, jupiter.user.id));
           });
 
           it("Luna gets notifications about comment likes to Mars' comment", async () => {
@@ -517,26 +490,6 @@ describe('Realtime (Socket.io)', () => {
           describe('when post is hidden by Mars', () => {
             beforeEach(async () => {
               await funcTestHelper.hidePost(lunaPost.id, marsContext);
-            });
-
-            describe("when subscribed to Luna's RiverOfNews", () => {
-              it("Mars gets notifications about own comment likes to Luna's comment", async () => {
-                const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
-                  'when subscribed to timeline', lunaRiverOfNews,
-                  'with comment having id', lunaComment.id,
-                  'to get comment_like:new event from', marsContext
-                );
-                expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, true, marsContext.user.id));
-              });
-
-              it("Mars gets notifications about Jupiter's comment likes to Luna's comment", async () => {
-                const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
-                  'when subscribed to timeline', lunaRiverOfNews,
-                  'with comment having id', lunaComment.id,
-                  'to get comment_like:new event from', jupiter
-                );
-                expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, jupiter.user.id));
-              });
             });
 
             describe("when subscribed to Mars's RiverOfNews", () => {
@@ -591,15 +544,6 @@ describe('Realtime (Socket.io)', () => {
               );
               expect(msg, 'to be', null);
             });
-
-            it("Jupiter doesn't get notifications about own comment likes to Luna's comment to Luna's post", async () => {
-              const { context: { commentLikeRealtimeMsg: msg } } = await expect(jupiter,
-                'when subscribed to timeline', lunaRiverOfNews,
-                'with comment having id', lunaComment.id,
-                'not to get comment_like:new event from', jupiter
-              );
-              expect(msg, 'to be', null);
-            });
           });
 
           describe('when Jupiter is banned by Mars', () => {
@@ -623,24 +567,6 @@ describe('Realtime (Socket.io)', () => {
                 'not to get comment_like:new event from', lunaContext
               );
               expect(msg, 'to be', null);
-            });
-
-            it('Jupiter gets notifications about comment likes to own comment', async () => {
-              const { context: { commentLikeRealtimeMsg: msg } } = await expect(jupiter,
-                'when subscribed to timeline', lunaRiverOfNews,
-                'with comment having id', jupiterComment.id,
-                'to get comment_like:new event from', lunaContext
-              );
-              expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, lunaContext.user.id));
-            });
-
-            it("Jupiter gets notifications about comment likes to Mars' comment", async () => {
-              const { context: { commentLikeRealtimeMsg: msg } } = await expect(jupiter,
-                'when subscribed to timeline', lunaRiverOfNews,
-                'with comment having id', marsComment.id,
-                'to get comment_like:new event from', lunaContext
-              );
-              expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, lunaContext.user.id));
             });
           });
         });
@@ -864,24 +790,6 @@ describe('Realtime (Socket.io)', () => {
         });
 
         describe('via RiverOfNews timeline channel', () => {
-          it("Anonymous user doesn't get notifications about comment likes", async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(anonContext,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', lunaComment.id,
-              'not to get comment_like:new event from', marsContext
-            );
-            expect(msg, 'to be', null);
-          });
-
-          it("Anonymous user doesn't get notifications about comment likes", async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(anonContext,
-              'when subscribed to timeline', marsRiverOfNews,
-              'with comment having id', marsComment.id,
-              'not to get comment_like:new event from', jupiter
-            );
-            expect(msg, 'to be', null);
-          });
-
           it('Luna gets notifications about comment likes to own comment', async () => {
             const { context: { commentLikeRealtimeMsg: msg } } = await expect(lunaContext,
               'when subscribed to timeline', lunaRiverOfNews,
@@ -889,33 +797,6 @@ describe('Realtime (Socket.io)', () => {
               'to get comment_like:new event from', marsContext
             );
             expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, false, marsContext.user.id));
-          });
-
-          it("Mars gets notifications about comment likes to Luna's comment", async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', lunaComment.id,
-              'to get comment_like:new event from', marsContext
-            );
-            expect(msg, 'to satisfy', commentHavingNLikesExpectation(1, true, marsContext.user.id));
-          });
-
-          it("Jupiter doesn't get notifications about comment likes", async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(jupiter,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', lunaComment.id,
-              'not to get comment_like:new event from', marsContext
-            );
-            expect(msg, 'to be', null);
-          });
-
-          it("Jupiter doesn't get notifications about comment likes", async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(jupiter,
-              'when subscribed to timeline', marsRiverOfNews,
-              'with comment having id', marsComment.id,
-              'not to get comment_like:new event from', jupiter
-            );
-            expect(msg, 'to be', null);
           });
         });
 
@@ -1103,15 +984,6 @@ describe('Realtime (Socket.io)', () => {
         });
 
         describe('via RiverOfNews timeline channel', () => {
-          it('Anonymous user gets notifications about comment likes', async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(anonContext,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', lunaComment.id,
-              'to get comment_like:remove event from', marsContext
-            );
-            expect(msg, 'to satisfy', commentHavingNLikesExpectation(0, false, marsContext.user.id));
-          });
-
           it('Luna gets notifications about comment likes', async () => {
             const { context: { commentLikeRealtimeMsg: msg } } = await expect(lunaContext,
               'when subscribed to timeline', lunaRiverOfNews,
@@ -1120,30 +992,9 @@ describe('Realtime (Socket.io)', () => {
             );
             expect(msg, 'to satisfy', commentHavingNLikesExpectation(0, false, marsContext.user.id));
           });
-
-          it('Mars gets notifications about comment likes', async () => {
-            const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
-              'when subscribed to timeline', lunaRiverOfNews,
-              'with comment having id', lunaComment.id,
-              'to get comment_like:remove event from', marsContext
-            );
-            expect(msg, 'to satisfy', commentHavingNLikesExpectation(0, false, marsContext.user.id));
-          });
-
           describe('when post is hidden by Mars', () => {
             beforeEach(async () => {
               await funcTestHelper.hidePost(lunaPost.id, marsContext);
-            });
-
-            describe("when subscribed to Luna's RiverOfNews", () => {
-              it('Mars gets notifications about comment likes', async () => {
-                const { context: { commentLikeRealtimeMsg: msg } } = await expect(marsContext,
-                  'when subscribed to timeline', lunaRiverOfNews,
-                  'with comment having id', lunaComment.id,
-                  'to get comment_like:remove event from', marsContext
-                );
-                expect(msg, 'to satisfy', commentHavingNLikesExpectation(0, false, marsContext.user.id));
-              });
             });
 
             describe("when subscribed to Mars's RiverOfNews", () => {

--- a/test/functional/realtime2.js
+++ b/test/functional/realtime2.js
@@ -126,5 +126,21 @@ describe('Realtime (post hides)', () => {
         expect(marsEvent, 'to be fulfilled');
       });
     });
+
+    describe('Mars tried to subscribe to Luna\'s RiverOfNews', () => {
+      beforeEach(async () => {
+        const lunaRoNFeed = await dbAdapter.getUserNamedFeed(luna.user.id, 'RiverOfNews');
+        marsSession.send('subscribe', { 'timeline': [lunaRoNFeed.id] });
+      });
+
+      it(`shold not deliver 'like:remove' event when Mars unlikes post`, async () => {
+        const marsEvent = marsSession.notReceive('like:remove');
+        await Promise.all([
+          funcTestHelper.unlike(post.id, mars.authToken),
+          marsEvent,
+        ]);
+        expect(marsEvent, 'to be fulfilled');
+      });
+    });
   });
 });

--- a/test/functional/realtime2.js
+++ b/test/functional/realtime2.js
@@ -1,0 +1,130 @@
+/* eslint-env node, mocha */
+/* global $database, $pg_database */
+import knexCleaner from 'knex-cleaner';
+import expect from 'unexpected'
+
+import { getSingleton } from '../../app/app';
+import { dbAdapter, PubSub } from '../../app/models';
+import { PubSubAdapter } from '../../app/support/PubSubAdapter'
+
+import * as funcTestHelper from './functional_test_helper';
+import Session from './realtime_helper';
+
+describe('Realtime (post hides)', () => {
+  let port;
+
+  before(async () => {
+    const app = await getSingleton();
+    port = process.env.PEPYATKA_SERVER_PORT || app.context.config.port;
+    const pubsubAdapter = new PubSubAdapter($database)
+    PubSub.setPublisher(pubsubAdapter)
+  });
+
+  let luna, mars,
+    lunaSession,
+    marsSession,
+    anonSession;
+
+  beforeEach(async () => {
+    await knexCleaner.clean($pg_database);
+
+    [luna, mars] = await Promise.all([
+      funcTestHelper.createUserAsync('luna', 'pw'),
+      funcTestHelper.createUserAsync('mars', 'pw'),
+    ]);
+
+    [lunaSession, marsSession, anonSession] = await Promise.all([
+      Session.create(port, 'Luna session'),
+      Session.create(port, 'Mars session'),
+      Session.create(port, 'Anon session'),
+    ]);
+    lunaSession.send('auth', { authToken: luna.authToken });
+    marsSession.send('auth', { authToken: mars.authToken });
+  });
+
+  afterEach(() => [lunaSession, marsSession, anonSession].forEach((s) => s.disconnect()));
+
+  describe('Luna wrote post, Mars likes it', () => {
+    let post;
+    beforeEach(async () => {
+      post = await funcTestHelper.createAndReturnPost(luna, 'Luna post');
+      await funcTestHelper.like(post.id, mars.authToken);
+    });
+
+    describe('Luna, Mars and Anon are subscribed to the post channel', () => {
+      beforeEach(() => {
+        lunaSession.send('subscribe', { 'post': [post.id] });
+        marsSession.send('subscribe', { 'post': [post.id] });
+        anonSession.send('subscribe', { 'post': [post.id] });
+      });
+
+      it(`shold deliver 'post:hide' event only to Luna when Luna hides post`, async () => {
+        const lunaEvent = lunaSession.receive('post:hide');
+        const marsEvent = marsSession.notReceive('post:hide');
+        const anonEvent = anonSession.notReceive('post:hide');
+        await Promise.all([
+          funcTestHelper.hidePost(post.id, luna),
+          lunaEvent, marsEvent, anonEvent,
+        ]);
+        expect(lunaEvent, 'to be fulfilled with', { meta: { postId: post.id } });
+        expect(marsEvent, 'to be fulfilled');
+        expect(anonEvent, 'to be fulfilled');
+      });
+
+      describe('Lunа hide post', () => {
+        beforeEach(async () => {
+          await funcTestHelper.hidePost(post.id, luna);
+        });
+
+        it(`shold deliver 'post:unhide' event only to Luna when Luna unhides post`, async () => {
+          const lunaEvent = lunaSession.receive('post:unhide');
+          const marsEvent = marsSession.notReceive('post:unhide');
+          const anonEvent = anonSession.notReceive('post:unhide');
+          await Promise.all([
+            funcTestHelper.unhidePost(post.id, luna),
+            lunaEvent, marsEvent, anonEvent,
+          ]);
+          expect(lunaEvent, 'to be fulfilled with', { meta: { postId: post.id } });
+          expect(marsEvent, 'to be fulfilled');
+          expect(anonEvent, 'to be fulfilled');
+        });
+
+        it(`shold deliver 'post:update' event with isHidden field only to Luna when Luna updates post`, async () => {
+          const lunaEvent = lunaSession.receive('post:update');
+          const marsEvent = marsSession.receive('post:update');
+          const anonEvent = anonSession.receive('post:update');
+          luna.post = post;
+          await Promise.all([
+            funcTestHelper.updatePostAsync(luna, { body: 'Updated post' }),
+            lunaEvent, marsEvent, anonEvent,
+          ]);
+          expect(lunaEvent, 'to be fulfilled with value satisfying', { posts: { isHidden: true } });
+          expect(marsEvent, 'to be fulfilled with value satisfying', { posts: expect.it('to not have key', 'isHidden') });
+          expect(anonEvent, 'to be fulfilled with value satisfying', { posts: expect.it('to not have key', 'isHidden') });
+        });
+      });
+    });
+
+    describe('Luna and Mars are subscribed to their MyDiscussions', () => {
+      beforeEach(async () => {
+        const [lunaMDFeed, marsMDFeed] = await Promise.all([
+          dbAdapter.getUserNamedFeed(luna.user.id, 'MyDiscussions'),
+          dbAdapter.getUserNamedFeed(mars.user.id, 'MyDiscussions'),
+        ]);
+        lunaSession.send('subscribe', { 'timeline': [lunaMDFeed.id] });
+        marsSession.send('subscribe', { 'timeline': [marsMDFeed.id] });
+      });
+
+      it(`shold deliver 'like:remove' event when Mars unlikes post`, async () => {
+        const lunaEvent = lunaSession.receive('like:remove');
+        const marsEvent = marsSession.receive('like:remove');
+        await Promise.all([
+          funcTestHelper.unlike(post.id, mars.authToken),
+          lunaEvent, marsEvent,
+        ]);
+        expect(lunaEvent, 'to be fulfilled');
+        expect(marsEvent, 'to be fulfilled');
+      });
+    });
+  });
+});

--- a/test/functional/realtime_helper.js
+++ b/test/functional/realtime_helper.js
@@ -1,0 +1,59 @@
+import SocketIO from 'socket.io-client';
+
+const eventTimeout = 2000;
+const silenceTimeout = 500;
+
+export default class Session {
+  socket = null;
+  name = '';
+
+  static create(port, name = '') {
+    const options = {
+      transports:             ['websocket'],
+      'force new connection': true,
+    };
+    return new Promise((resolve, reject) => {
+      const socket = SocketIO.connect(`http://localhost:${port}/`, options);
+      socket.on('error', reject);
+      socket.on('connect_error', reject);
+      socket.on('connect', () => resolve(new Session(socket, name)));
+    });
+  }
+
+  constructor(socket, name = '') {
+    this.socket = socket;
+    this.name = name;
+  }
+
+  send(event, data) {
+    this.socket.emit(event, data);
+  }
+
+  disconnect() {
+    this.socket.disconnect();
+  }
+
+  receive(event) {
+    return new Promise((resolve, reject) => {
+      const success = (data) => {
+        this.socket.off(event, success);
+        clearTimeout(timer);
+        resolve(data);
+      };
+      this.socket.on(event, success);
+      const timer = setTimeout(() => reject(new Error(`${this.name ? `${this.name}: ` : ''}Expecting '${event}' event, got timeout`)), eventTimeout);
+    });
+  }
+
+  notReceive(event) {
+    return new Promise((resolve, reject) => {
+      const fail = () => {
+        this.socket.off(event, fail);
+        clearTimeout(timer);
+        reject(new Error(`${this.name ? `${this.name}: ` : ''}Expecting silence, got '${event}' event`));
+      };
+      this.socket.on(event, fail);
+      const timer = setTimeout(() => resolve(null), silenceTimeout);
+    });
+  }
+}

--- a/test/functional/timelinesV2.js
+++ b/test/functional/timelinesV2.js
@@ -418,6 +418,7 @@ describe('TimelinesControllerV2', () => {
       postLikedByMars = await createAndReturnPost(venus, 'Post');
       await createCommentAsync(mars, postCommentedByMars.id, 'Comment');
       await like(postLikedByMars.id, mars.authToken);
+      await hidePost(postCreatedByMars.id, luna);
     });
 
     const nonEmptyExpected = (anonymous = true) => async () => {
@@ -461,6 +462,10 @@ describe('TimelinesControllerV2', () => {
     describe('Mars is a public user', () => {
       it('should return Mars timelines with posts to anonymous', nonEmptyExpected());
       it('should return Mars timelines with posts to Luna', nonEmptyExpected(false));
+      it('should return Mars timeline with post having isHidden property', async () => {
+        const feed = await fetchUserTimeline('Posts', mars, luna);
+        expect(feed.posts[0], 'to have key', 'isHidden');
+      });
     });
 
     describe('Mars is a private user', () => {

--- a/test/unit/user.js
+++ b/test/unit/user.js
@@ -648,8 +648,6 @@ describe('User', () => {
           timeline.should.not.be.empty
           timeline.should.have.property('name')
           timeline.name.should.eql('MyDiscussions')
-          timeline.should.have.property('id')
-          timeline.id.should.eql(user.id)
           done()
         })
         .catch((e) => { done(e) })


### PR DESCRIPTION
A fairly large set of changes:

- MyDiscussions feed now creates with random UID (same as other feeds);
- Post objects in v2 post/timeline responses now have 'isHidden' field if they was hidden by viewer;
- isHidden property now visible in 'post:update' realtime event;
- All realtime events are emitted even for hidden posts;
- 'like:remove' realtime event is emitted to timelines in which the post was before the unlike;
- 'post:hide' and 'post:unhide' now emitted to all timelines belongs to hider/unhider;
- Realtime now supports MyDiscussions timelines (it fixes T123);
- Now you can not subscribe to other people's 'RiverOfNews', 'Directs', 'Hides' and 'MyDiscussions' feeds.