### PR TITLE
Unread notifications (and directs) counters fix

### DIFF
--- a/app/controllers/api/v2/UsersController.js
+++ b/app/controllers/api/v2/UsersController.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 import monitor from 'monitor-dog'
-import { dbAdapter } from '../../../models'
+import { dbAdapter, PubSub as pubSub } from '../../../models'
 import { serializeSelfUser, serializeUser } from '../../../serializers/v2/user'
 
 export default class UsersController {
@@ -69,6 +69,7 @@ export default class UsersController {
     }
 
     await dbAdapter.markAllEventsAsRead(ctx.state.user.id);
+    await pubSub.updateUnreadNotifications(ctx.state.user.intId);
     ctx.body = { message: `Notifications are now marked as read for ${ctx.state.user.id}` };
   }
 

--- a/app/controllers/api/v2/UsersController.js
+++ b/app/controllers/api/v2/UsersController.js
@@ -58,6 +58,7 @@ export default class UsersController {
     }
 
     await dbAdapter.markAllDirectsAsRead(ctx.state.user.id)
+    await pubSub.updateUnreadDirects(ctx.state.user.id);
     ctx.body = { message: `Directs are now marked as read for ${ctx.state.user.id}` };
   }
 

--- a/test/functional/events.js
+++ b/test/functional/events.js
@@ -2250,4 +2250,18 @@ describe('Unread events counter realtime updates for ', () => {
       expect(msg, 'to satisfy', userUpdateEventWithUnreadNotifications(1, luna.user.id));
     });
   });
+
+  describe('markAllNotificationsAsRead() call', () => {
+    it('user should receive counter update', async () => {
+      await subscribeToAsync(mars, luna);
+      const { context: { userUpdateRealtimeMsg: msg } } = await expect(luna,
+        'when subscribed to user', luna.user.id,
+        'to get user:update event when called', () => {
+          return markAllNotificationsAsRead(luna);
+        }
+      );
+
+      expect(msg, 'to satisfy', userUpdateEventWithUnreadNotifications(0, luna.user.id));
+    });
+  });
 });

--- a/test/functional/events.js
+++ b/test/functional/events.js
@@ -22,6 +22,7 @@ import {
   goPrivate,
   kickOutUserFromGroup,
   markAllNotificationsAsRead,
+  markAllDirectsAsRead,
   mutualSubscriptions,
   promoteToAdmin,
   rejectRequestAsync,
@@ -2262,6 +2263,26 @@ describe('Unread events counter realtime updates for ', () => {
       );
 
       expect(msg, 'to satisfy', userUpdateEventWithUnreadNotifications(0, luna.user.id));
+    });
+  });
+
+  describe('markAllDirectsAsRead() call', () => {
+    it('user should receive counter update', async () => {
+      await mutualSubscriptions([luna, mars]);
+      await createAndReturnPostToFeed(luna, mars, 'Direct');
+      const { context: { userUpdateRealtimeMsg: msg } } = await expect(luna,
+        'when subscribed to user', luna.user.id,
+        'to get user:update event when called', () => {
+          return markAllDirectsAsRead(luna);
+        }
+      );
+
+      expect(msg, 'to satisfy', {
+        user: {
+          id:                  luna.user.id,
+          unreadDirectsNumber: '0'
+        }
+      });
     });
   });
 });

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -795,6 +795,14 @@ export async function getUnreadNotificationsNumber(user) {
   return response;
 }
 
+export async function markAllDirectsAsRead(user) {
+  const response = await postJson('/v2/users/markAllDirectsAsRead', {
+    authToken: user.authToken,
+    '_method': 'get'
+  });
+  return response;
+}
+
 export async function markAllNotificationsAsRead(user) {
   const response = await postJson('/v2/users/markAllNotificationsAsRead', {
     authToken: user.authToken,


### PR DESCRIPTION
See https://github.com/FreeFeed/freefeed-react-client/issues/652 and https://trello.com/c/bdmbLNTH/32-652-inconsistent-number-of-unread-notifications