### PR TITLE
Add a 'global:users' realtime room with an event 'global:user:update'

### DIFF
--- a/app/models/group.js
+++ b/app/models/group.js
@@ -2,7 +2,7 @@ import { inherits } from 'util'
 
 import _ from 'lodash'
 
-import { User } from '../models'
+import { User, PubSub as pubSub } from '../models'
 import { ForbiddenException } from '../support/exceptions'
 
 
@@ -177,6 +177,7 @@ export function addModel(dbAdapter) {
       }
 
       await dbAdapter.updateUser(this.id, payload)
+      await pubSub.globalUserUpdate(this.id)
     }
 
     return this

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -13,7 +13,7 @@ import uuid from 'uuid'
 
 import { load as configLoader } from '../../config/config'
 import { BadRequestException, ForbiddenException, NotFoundException, ValidationException } from '../support/exceptions'
-import { Attachment, Comment, Post } from '../models'
+import { Attachment, Comment, Post, PubSub as pubSub } from '../models'
 import { EventService } from '../support/EventService';
 import { valiate as validateUserPrefs } from './user-prefs';
 
@@ -456,6 +456,7 @@ export function addModel(dbAdapter) {
       }
 
       await dbAdapter.updateUser(this.id, preparedPayload)
+      await pubSub.globalUserUpdate(this.id)
 
       for (const k in payload) {
         this[k] = payload[k]
@@ -974,7 +975,8 @@ export function addModel(dbAdapter) {
       'updatedAt':          this.updatedAt.toString()
     }
 
-    return dbAdapter.updateUser(this.id, payload)
+    await dbAdapter.updateUser(this.id, payload)
+    await pubSub.globalUserUpdate(this.id)
   }
 
   User.prototype.saveProfilePictureWithSize = async function (path, uuid, originalSize, size) {

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -46,7 +46,8 @@ export default class PubsubListener {
       'user:update',
       'post:new', 'post:update', 'post:destroy', 'post:hide', 'post:unhide',
       'comment:new', 'comment:update', 'comment:destroy',
-      'like:new', 'like:remove', 'comment_like:new', 'comment_like:remove'
+      'like:new', 'like:remove', 'comment_like:new', 'comment_like:remove',
+      'global:user:update',
     )
 
     redisClient.on('message', this.onRedisMessage)
@@ -160,6 +161,8 @@ export default class PubsubListener {
       'like:remove':         this.onLikeRemove,
       'comment_like:new':    this.onCommentLikeNew,
       'comment_like:remove': this.onCommentLikeRemove,
+
+      'global:user:update': this.onGlobalUserUpdate,
     };
 
     try {
@@ -329,6 +332,12 @@ export default class PubsubListener {
   onCommentLikeRemove = async (sockets, data) => {
     await this._sendCommentLikeMsg(sockets, data, 'comment_like:remove');
   };
+
+  onGlobalUserUpdate = async (sockets, user) => {
+    await this.broadcastMessage(sockets, ['global:users'], 'global:user:update', { user });
+  };
+
+  // Helpers
 
   _sendCommentLikeMsg = async (sockets, data, msgType) => {
     const comment = await dbAdapter.getCommentById(data.commentId);

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -1,4 +1,5 @@
 import { dbAdapter } from './models'
+import { serializeUser } from './serializers/v2/user'
 
 
 export class DummyPublisher {
@@ -15,6 +16,7 @@ export class DummyPublisher {
   postUnhidden() {}
   commentLikeAdded() {}
   commentLikeRemoved() {}
+  globalUserUpdated() {}
 }
 
 export default class pubSub {
@@ -99,5 +101,11 @@ export default class pubSub {
   async removeCommentLike(commentId, postId, unlikerUUID) {
     const payload = JSON.stringify({ commentId, postId, unlikerUUID });
     await this.publisher.commentLikeRemoved(payload);
+  }
+
+  async globalUserUpdate(userId) {
+    const user = await dbAdapter.getUserById(userId);
+    const payload = JSON.stringify(serializeUser(user));
+    await this.publisher.globalUserUpdated(payload);
   }
 }

--- a/app/support/PubSubAdapter.js
+++ b/app/support/PubSubAdapter.js
@@ -12,6 +12,7 @@ const CHANNEL_NAMES = {
   LIKE_REMOVED:         'like:remove',
   COMMENT_LIKE_ADDED:   'comment_like:new',
   COMMENT_LIKE_REMOVED: 'comment_like:remove',
+  GLOBAL_USER_UPDATED:  'global:user:update',
 }
 
 export class PubSubAdapter {
@@ -79,6 +80,12 @@ export class PubSubAdapter {
 
   commentLikeRemoved(payload) {
     return this._publish(CHANNEL_NAMES.COMMENT_LIKE_REMOVED, payload);
+  }
+
+  ///////////////////////////////////////////////////
+
+  globalUserUpdated(payload) {
+    return this._publish(CHANNEL_NAMES.GLOBAL_USER_UPDATED, payload);
   }
 
   ///////////////////////////////////////////////////

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "eslint-plugin-lodash": "2.4.5",
     "eslint-plugin-promise": "3.5.0",
     "eslint-plugin-you-dont-need-lodash-underscore": "6.3.1",
+    "form-data": "^2.3.1",
     "istanbul": "0.4.5",
     "mkdirp": "0.5.1",
     "mocha": "3.5.3",

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -1,6 +1,8 @@
 import http from 'http';
+import { createReadStream } from 'fs';
 
 import fetch from 'node-fetch'
+import FormData from 'form-data';
 import request  from 'superagent'
 import _ from 'lodash'
 import SocketIO from 'socket.io-client';
@@ -486,6 +488,30 @@ export function updateGroupAsync(group, adminContext, groupData) {
       '_method': 'put'
     }
   )
+}
+
+export async function updateProfilePicture(userContext, filePath) {
+  const form = new FormData();
+  form.append('file', createReadStream(filePath));
+  const url = await apiUrl(`/v1/users/updateProfilePicture`);
+  return await fetch(url, {
+    agent,
+    method:  'POST',
+    headers: { ...form.getHeaders(), 'X-Authentication-Token': userContext.authToken },
+    body:    form,
+  });
+}
+
+export async function updateGroupProfilePicture(userContext, groupName, filePath) {
+  const form = new FormData();
+  form.append('file', createReadStream(filePath));
+  const url = await apiUrl(`/v1/groups/${groupName}/updateProfilePicture`);
+  return await fetch(url, {
+    agent,
+    method:  'POST',
+    headers: { ...form.getHeaders(), 'X-Authentication-Token': userContext.authToken },
+    body:    form,
+  });
 }
 
 export function getUserAsync(context, username) {

--- a/test/functional/realtime-session.js
+++ b/test/functional/realtime-session.js
@@ -60,4 +60,13 @@ export default class Session {
      const timer = setTimeout(() => resolve(null), silenceTimeout);
    });
  }
+
+ async receiveWhile(event, ...promises) {
+   const [result] = await Promise.all([this.receive(event), ...promises]);
+   return result;
+ }
+
+ async notReceiveWhile(event, ...promises) {
+   await Promise.all([this.notReceive(event), ...promises]);
+ }
 }

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -8,7 +8,7 @@ export const timeStampString = (v) => expect(v, 'to be a string').and('to match'
 
 export const UUID = (v) => expect(v, 'to match', /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-(8|9|a|b)[a-f0-9]{3}-[a-f0-9]{12}$/);
 
-export const user = {
+export const userBasic = {
   id:                      expect.it('to satisfy', UUID),
   username:                expect.it('to be a string'),
   screenName:              expect.it('to be a string'),
@@ -21,14 +21,28 @@ export const user = {
   description:             expect.it('to be a string'),
   profilePictureLargeUrl:  expect.it('to be a string'),
   profilePictureMediumUrl: expect.it('to be a string'),
-  statistics:              expect.it('to be an object'),
+};
+
+export const groupBasic = {
+  ...userBasic,
+  isRestricted: expect.it('to satisfy', boolString),
+  type:         expect.it('to equal', 'group'),
+};
+
+export const user = {
+  ...userBasic,
+  statistics: expect.it('to be an object'),
 };
 
 export const group = {
-  ...user,
-  isRestricted:   expect.it('to satisfy', boolString),
-  type:           expect.it('to equal', 'group'),
+  ...groupBasic,
+  statistics:     expect.it('to be an object'),
   administrators: expect.it('to be an array').and('to have items satisfying', UUID),
+};
+
+export const userOrGroupBasic = (obj) => {
+  const isGroup = obj && typeof obj === 'object' && obj.type === 'group';
+  return expect(obj, 'to exhaustively satisfy', isGroup ? groupBasic : userBasic);
 };
 
 export const userOrGroup = (obj) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,17 +2031,17 @@ form-data@1.0.0-rc3:
     combined-stream "^1.0.5"
     mime-types "^2.1.3"
 
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+form-data@^2.3.1, form-data@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+form-data@~2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"


### PR DESCRIPTION
'global:user:update' event fires when any user or group changes any of their public properties: screenName, profile picture, description, privacy flags and so on. Event has the following structure:
```
{
  user: {
     id
     username
     screenName
     isPrivate
     isProtected
     isVisibleToAnonymous
     createdAt
     updatedAt
     type
     description
     profilePictureLargeUrl
     profilePictureMediumUrl
  }
  realtimeChannels: […]
}
```