### PR TITLE
Stop sending read notifications

### DIFF
--- a/app/support/NotificationsDigest.js
+++ b/app/support/NotificationsDigest.js
@@ -59,44 +59,22 @@ export function getUnreadEventsIntervalStart(digestSentAt, notificationsLastSeen
   const wrappedNow = moment(now);
 
   const _90DaysAgo = wrappedNow.clone().subtract(90, 'days');
-  const DayAgo = wrappedNow.clone().subtract(1, 'days');
-  const DayAgoAndHalfAnHour = wrappedNow.clone().subtract(1, 'days').subtract(30, 'minutes');
+  const DayAgoAndHalfAnHour = wrappedNow.clone().subtract(1, 'days').add(30, 'minutes');
 
-  if (!wrappedDigestSentAt) {
-    if (!wrappedNotificationsLastSeenAt) {
-      return _90DaysAgo;
-    }
-
-    if (wrappedNotificationsLastSeenAt.isSameOrBefore(DayAgo, 'minute')) {
-      return wrappedNotificationsLastSeenAt;
-    }
-
-    return wrappedNotificationsLastSeenAt;
-  }
-
-  if (wrappedDigestSentAt.isAfter(DayAgo)) {
+  if (wrappedDigestSentAt && wrappedDigestSentAt.isAfter(DayAgoAndHalfAnHour)) {
     return null;
   }
 
-  if (wrappedDigestSentAt.isBefore(DayAgo) && wrappedDigestSentAt.isSameOrAfter(DayAgoAndHalfAnHour, 'minute')) {
-    if (!wrappedNotificationsLastSeenAt) {
-      return DayAgo;
-    }
-
-    if (wrappedNotificationsLastSeenAt.isAfter(DayAgo)) {
-      return wrappedNotificationsLastSeenAt;
-    }
-
-    return DayAgo;
+  if (
+    (!wrappedDigestSentAt || wrappedDigestSentAt.isBefore(_90DaysAgo)) &&
+    (!wrappedNotificationsLastSeenAt || wrappedNotificationsLastSeenAt.isBefore(_90DaysAgo))
+  ) {
+    return _90DaysAgo;
   }
 
-  if (!wrappedNotificationsLastSeenAt) {
+  if (wrappedDigestSentAt && (!wrappedNotificationsLastSeenAt || wrappedDigestSentAt.isAfter(wrappedNotificationsLastSeenAt))) {
     return wrappedDigestSentAt;
   }
 
-  if (wrappedNotificationsLastSeenAt.isAfter(DayAgo)) {
-    return wrappedNotificationsLastSeenAt;
-  }
-
-  return wrappedDigestSentAt;
+  return wrappedNotificationsLastSeenAt;
 }

--- a/app/support/NotificationsDigest.js
+++ b/app/support/NotificationsDigest.js
@@ -54,38 +54,48 @@ export async function sendEmails() {
 }
 
 function getUnreadEventsIntervalStart(digestSentAt, notificationsLastSeenAt) {
-  digestSentAt = digestSentAt ? moment(digestSentAt) : null;
-  notificationsLastSeenAt = notificationsLastSeenAt ? moment(notificationsLastSeenAt) : null;
-  const _90DaysAgo = moment().subtract(90, 'days'),
-    DayAgo = moment().subtract(1, 'days'),
-    DayAgoAndHalfAnHour = moment().subtract(1, 'days').subtract(30, 'minutes');
+  const wrappedDigestSentAt = digestSentAt ? moment(digestSentAt) : null;
+  const wrappedNotificationsLastSeenAt = notificationsLastSeenAt ? moment(notificationsLastSeenAt) : null;
 
-  if (!digestSentAt) {
-    if (!notificationsLastSeenAt) {
+  const _90DaysAgo = moment().subtract(90, 'days');
+  const DayAgo = moment().subtract(1, 'days');
+  const DayAgoAndHalfAnHour = moment().subtract(1, 'days').subtract(30, 'minutes');
+
+  if (!wrappedDigestSentAt) {
+    if (!wrappedNotificationsLastSeenAt) {
       return _90DaysAgo;
     }
-    if (notificationsLastSeenAt.isSameOrBefore(DayAgo, 'minute')) {
-      return notificationsLastSeenAt;
+
+    if (wrappedNotificationsLastSeenAt.isSameOrBefore(DayAgo, 'minute')) {
+      return wrappedNotificationsLastSeenAt;
     }
-    return notificationsLastSeenAt;
+
+    return wrappedNotificationsLastSeenAt;
   }
-  if (digestSentAt.isAfter(DayAgo)) {
+
+  if (wrappedDigestSentAt.isAfter(DayAgo)) {
     return null;
   }
-  if (digestSentAt.isBefore(DayAgo) && digestSentAt.isSameOrAfter(DayAgoAndHalfAnHour, 'minute')) {
-    if (!notificationsLastSeenAt) {
+
+  if (wrappedDigestSentAt.isBefore(DayAgo) && wrappedDigestSentAt.isSameOrAfter(DayAgoAndHalfAnHour, 'minute')) {
+    if (!wrappedNotificationsLastSeenAt) {
       return DayAgo;
     }
-    if (notificationsLastSeenAt.isAfter(DayAgo)) {
-      return notificationsLastSeenAt;
+
+    if (wrappedNotificationsLastSeenAt.isAfter(DayAgo)) {
+      return wrappedNotificationsLastSeenAt;
     }
+
     return DayAgo;
   }
-  if (!notificationsLastSeenAt) {
-    return digestSentAt;
+
+  if (!wrappedNotificationsLastSeenAt) {
+    return wrappedDigestSentAt;
   }
-  if (notificationsLastSeenAt.isAfter(DayAgo)) {
-    return notificationsLastSeenAt;
+
+  if (wrappedNotificationsLastSeenAt.isAfter(DayAgo)) {
+    return wrappedNotificationsLastSeenAt;
   }
-  return digestSentAt;
+
+  return wrappedDigestSentAt;
 }

--- a/app/support/NotificationsDigest.js
+++ b/app/support/NotificationsDigest.js
@@ -53,13 +53,14 @@ export async function sendEmails() {
   debug('all promised actions are finished');
 }
 
-function getUnreadEventsIntervalStart(digestSentAt, notificationsLastSeenAt) {
+export function getUnreadEventsIntervalStart(digestSentAt, notificationsLastSeenAt, now) {
   const wrappedDigestSentAt = digestSentAt ? moment(digestSentAt) : null;
   const wrappedNotificationsLastSeenAt = notificationsLastSeenAt ? moment(notificationsLastSeenAt) : null;
+  const wrappedNow = moment(now);
 
-  const _90DaysAgo = moment().subtract(90, 'days');
-  const DayAgo = moment().subtract(1, 'days');
-  const DayAgoAndHalfAnHour = moment().subtract(1, 'days').subtract(30, 'minutes');
+  const _90DaysAgo = wrappedNow.clone().subtract(90, 'days');
+  const DayAgo = wrappedNow.clone().subtract(1, 'days');
+  const DayAgoAndHalfAnHour = wrappedNow.clone().subtract(1, 'days').subtract(30, 'minutes');
 
   if (!wrappedDigestSentAt) {
     if (!wrappedNotificationsLastSeenAt) {

--- a/bin/count-daily-stats.js
+++ b/bin/count-daily-stats.js
@@ -4,7 +4,9 @@ import bluebird from 'bluebird';
 import pgFormat from 'pg-format';
 
 global.Promise = bluebird;
-global.Promise.onPossiblyUnhandledRejection((e) => { throw e; });
+global.Promise.onPossiblyUnhandledRejection((e) => {
+  throw e;
+});
 
 import { postgres } from '../app/models'
 

--- a/bin/db_maintenance.js
+++ b/bin/db_maintenance.js
@@ -2,7 +2,9 @@
 import bluebird from 'bluebird';
 
 global.Promise = bluebird;
-global.Promise.onPossiblyUnhandledRejection((e) => { throw e; });
+global.Promise.onPossiblyUnhandledRejection((e) => {
+  throw e;
+});
 
 import { postgres } from '../app/models'
 

--- a/bin/import_clikes.js
+++ b/bin/import_clikes.js
@@ -3,7 +3,9 @@ import fs from 'fs';
 import bluebird from 'bluebird';
 
 global.Promise = bluebird;
-global.Promise.onPossiblyUnhandledRejection((e) => { throw e; });
+global.Promise.onPossiblyUnhandledRejection((e) => {
+  throw e;
+});
 
 Promise.promisifyAll(fs);
 
@@ -12,7 +14,7 @@ import { postgres, dbAdapter } from '../app/models'
 async function main() {
   process.stdout.write(`Started\n`);
 
-  const dataFilePath = process.argv[2];
+  const [,, dataFilePath] = process.argv;
   if (!dataFilePath) {
     return;
   }
@@ -24,7 +26,7 @@ async function main() {
   for (const i in clikesData) {
     const clike = clikesData[i];
     process.stdout.write(`Processing clikes: ${parseInt(i) + 1} of ${clikesCount}\r`);
-    const [commentId, userId] = await dbAdapter._getCommentAndUserIntId(clike.comment_id, clike.user_id);
+    const [commentId, userId] = await dbAdapter._getCommentAndUserIntId(clike.comment_id, clike.user_id);  // eslint-disable-line no-await-in-loop
 
     if (!commentId) {
       process.stderr.write(`Can't find comment "${clike.comment_id}": SKIP\n`);
@@ -43,7 +45,7 @@ async function main() {
     };
 
     try {
-      await postgres('comment_likes').insert(payload);
+      await postgres('comment_likes').insert(payload);  // eslint-disable-line no-await-in-loop
     } catch (e) {
       if (e.message.includes('duplicate key value')) {
         continue;

--- a/bin/notification_emails.js
+++ b/bin/notification_emails.js
@@ -1,17 +1,20 @@
 #!/usr/bin/env babel-node
 import bluebird from 'bluebird';
-import _ from 'lodash';
-import { dbAdapter } from '../app/models';
+
 import { sendEmails } from '../app/support/NotificationsDigest';
 
+
 global.Promise = bluebird;
-global.Promise.onPossiblyUnhandledRejection((e) => { throw e; });
-
-async function main(){
-  await sendEmails();
-}
-
-main().then(()=> {
-  console.log("Finished");
-  process.exit(0);
+global.Promise.onPossiblyUnhandledRejection((e) => {
+  throw e;
 });
+
+sendEmails()
+  .then(() => {
+    process.stdout.write('Finished\n');
+    process.exit(0);
+  })
+  .catch((e) => {
+    process.stderr.write(`Error: ${e}\n`);
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "scarlet": "2.0.20",
     "socket.io-client": "1.3.7",
     "superagent": "1.8.3",
-    "unexpected": "~10.36.2"
+    "unexpected": "~10.36.2",
+    "unexpected-moment": "~3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "babel-node profiled.js",
     "travis": "run-s -c test lint",
     "test": "run-s reset-test-db test-rollback mocha",
-    "lint": "eslint app config test",
+    "lint": "eslint app bin config test",
     "reset-test-db": "babel-node bin/clean_test_db && knex --env test migrate:latest",
     "test-rollback": "knex --env test migrate:rollback && knex --env test migrate:latest",
     "mocha": "cross-env NODE_ENV=test mocha --opts test/mocha.opts test/unit test/functional",

--- a/test/unit/support/NotificationsDigest.js
+++ b/test/unit/support/NotificationsDigest.js
@@ -1,0 +1,98 @@
+/* eslint-env node, mocha */
+import unexpected from 'unexpected';
+import unexpectedMoment from 'unexpected-moment';
+import moment from 'moment';
+
+import { getUnreadEventsIntervalStart } from '../../../app/support/NotificationsDigest';
+
+
+const expect = unexpected.clone()
+  .use(unexpectedMoment);
+
+describe('NotificationsDigest', () => {
+  describe('getUnreadEventsIntervalStart()', () => {
+    const longTimeAgo1 = '2017-01-10T01:00:00.000Z';
+    const longTimeAgo2 = '2017-01-11T01:00:00.000Z';
+    const someTimeAgo1 = '2017-12-20T00:00:00.000Z';
+    const someTimeAgo2 = '2017-12-21T00:00:00.000Z';
+    const recently = '2018-01-01T00:00:00.000Z';
+
+    const now = recently;
+    const ninetyAgo = moment(now).subtract(90, 'days');
+
+    describe('if never sent previously', () => {
+      it('should not send items earlier than 90 days ago (if never saw)', async () => {
+        await expect(getUnreadEventsIntervalStart(null, null, now), 'to be same or after', ninetyAgo);
+      });
+
+      it('should not send items earlier than 90 days ago (if saw something)', async () => {
+        const seenAt = longTimeAgo1;
+
+        await expect(getUnreadEventsIntervalStart(null, seenAt, now), 'to be same or after', ninetyAgo);
+      });
+    });
+
+    describe('if sent long time ago', () => {
+      it('should not send items earlier than 90 days ago', async () => {
+        const sentAt = longTimeAgo1;
+
+        await expect(getUnreadEventsIntervalStart(sentAt, null, now), 'to be same or after', ninetyAgo);
+      });
+
+      it('should not send items earlier than 90 days ago', async () => {
+        const seenAt = longTimeAgo1;
+        const sentAt = longTimeAgo2;
+
+        await expect(getUnreadEventsIntervalStart(sentAt, seenAt, now), 'to be same or after', ninetyAgo);
+      });
+    });
+
+    describe('if seen or sent less than 90 days ago', () => {
+      it('should sent all unsent items (if never saw)', async () => {
+        const sentAt = someTimeAgo1;
+
+        await expect(getUnreadEventsIntervalStart(sentAt, null, now), 'to equal', moment(sentAt));
+      });
+
+      it('should send all unseen items (if never sent)', async () => {
+        const seenAt = someTimeAgo1;
+
+        await expect(getUnreadEventsIntervalStart(null, seenAt, now), 'to equal', moment(seenAt));
+      });
+
+      it('should not send items which were already seen', async () => {
+        const seenAt = someTimeAgo2;
+        const sentAt = someTimeAgo1;
+
+        await expect(getUnreadEventsIntervalStart(sentAt, seenAt, now), 'to equal', moment(seenAt));
+      });
+
+      it('should not send items which were sent previously', async () => {
+        const seenAt = someTimeAgo1;
+        const sentAt = someTimeAgo2;
+
+        await expect(getUnreadEventsIntervalStart(sentAt, seenAt, now), 'to equal', moment(sentAt));
+      });
+    });
+
+    describe('if sent 23 hours 30 minutes ago', () => {
+      const sentAt = moment(now).subtract(23, 'hours').subtract(30, 'minutes').toISOString();
+
+      it('should send recent items', async () => {
+        const seenAt = longTimeAgo1;
+
+        await expect(getUnreadEventsIntervalStart(sentAt, seenAt, now), 'to equal', moment(sentAt));
+      });
+    });
+
+    describe('if sent less than 23 hours 30 minutes ago', () => {
+      const sentAt = moment(now).subtract(23, 'hours').subtract(29, 'minutes').toISOString();
+
+      it('should not send anything', async () => {
+        const seenAt = longTimeAgo1;
+
+        await expect(getUnreadEventsIntervalStart(sentAt, seenAt, now), 'to be null');
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3667,7 +3667,7 @@ mocha@~4.1.0:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
-moment@~2.20.1:
+moment@^2.13.0, moment@~2.20.1:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
@@ -5515,6 +5515,12 @@ underscore.string@3.3.4:
 unexpected-bluebird@2.9.34-longstack2:
   version "2.9.34-longstack2"
   resolved "https://registry.yarnpkg.com/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz#49acac753b0556ded6025210ee96182307d2b2c9"
+
+unexpected-moment@~3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/unexpected-moment/-/unexpected-moment-3.2.1.tgz#1e3304404b9ef52c1736818e77294b2e7b3fb0a6"
+  dependencies:
+    moment "^2.13.0"
 
 unexpected@~10.36.2:
   version "10.36.2"


### PR DESCRIPTION
This pull-request:

* adds unit-tests for method which calculates list of items not seen by user
* makes sure that user doesn't get email with notifications she already saw
* makes sure that user wouldn't get ancient notifications (purely theoretical case) if it is a first digest