### PR TITLE
Ability to specify custom endpoint for S3

### DIFF
--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import { execFile } from 'child_process';
 
-import aws from 'aws-sdk'
 import { promisify, promisifyAll } from 'bluebird'
 import gm from 'gm'
 import meta from 'musicmetadata'
@@ -11,7 +10,7 @@ import mv from 'mv';
 import gifsicle from 'gifsicle';
 import probe from 'probe-image-size';
 
-aws.config.setPromisesDependency(Promise);
+import { getS3 } from '../support/s3';
 import { load as configLoader } from '../../config/config'
 
 
@@ -400,10 +399,7 @@ export function addModel(dbAdapter) {
 
   // Upload original attachment or its thumbnail to the S3 bucket
   Attachment.prototype.uploadToS3 = async function (sourceFile, destPath) {
-    const s3 = new aws.S3({
-      'accessKeyId':     config.attachments.storage.accessKeyId || null,
-      'secretAccessKey': config.attachments.storage.secretAccessKey || null
-    });
+    const s3 = getS3(config.attachments.storage);
     await s3.putObject({
       ACL:                'public-read',
       Bucket:             config.attachments.storage.bucket,

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,7 +3,6 @@ import fs from 'fs'
 
 import bcrypt from 'bcrypt'
 import { promisifyAll } from 'bluebird'
-import aws from 'aws-sdk'
 import gm from 'gm'
 import GraphemeBreaker from 'grapheme-breaker'
 import _ from 'lodash'
@@ -12,13 +11,13 @@ import validator from 'validator'
 import uuid from 'uuid'
 
 import { load as configLoader } from '../../config/config'
+import { getS3 } from '../support/s3';
 import { BadRequestException, ForbiddenException, NotFoundException, ValidationException } from '../support/exceptions'
 import { Attachment, Comment, Post, PubSub as pubSub } from '../models'
 import { EventService } from '../support/EventService';
 import { valiate as validateUserPrefs } from './user-prefs';
 
 
-aws.config.setPromisesDependency(Promise);
 promisifyAll(crypto)
 promisifyAll(gm)
 
@@ -1016,10 +1015,7 @@ export function addModel(dbAdapter) {
 
   // Upload profile picture to the S3 bucket
   User.prototype.uploadToS3 = async function (sourceFile, destFile, subConfig) {
-    const s3 = new aws.S3({
-      'accessKeyId':     subConfig.storage.accessKeyId || null,
-      'secretAccessKey': subConfig.storage.secretAccessKey || null
-    });
+    const s3 = getS3(subConfig.storage);
     await s3.putObject({
       ACL:                'public-read',
       Bucket:             subConfig.storage.bucket,

--- a/app/support/s3.js
+++ b/app/support/s3.js
@@ -1,0 +1,13 @@
+import aws from 'aws-sdk';
+
+
+aws.config.setPromisesDependency(Promise);
+
+export function getS3(storageConfig) {
+  const s3Config = {
+    'accessKeyId':     storageConfig.accessKeyId || null,
+    'secretAccessKey': storageConfig.secretAccessKey || null
+  };
+
+  return new aws.S3(s3Config);
+}

--- a/app/support/s3.js
+++ b/app/support/s3.js
@@ -9,5 +9,10 @@ export function getS3(storageConfig) {
     'secretAccessKey': storageConfig.secretAccessKey || null
   };
 
+  if ('endpoint' in storageConfig) {
+    // useful for usage with DigitalOcean Spaces or other S3-compatible services
+    s3Config.endpoint = new aws.Endpoint(storageConfig.endpoint);
+  }
+
   return new aws.S3(s3Config);
 }

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -77,7 +77,8 @@ export function getConfig() {
       // Parameters for 's3'
       accessKeyId:     'ACCESS-KEY-ID',
       secretAccessKey: 'SECRET-ACCESS-KEY',
-      bucket:          'bucket-name'
+      bucket:          'bucket-name',
+      // endpoint:        'nyc3.digitaloceanspaces.com',
     }
   };
   config.attachments = {


### PR DESCRIPTION
After applying this pull-request it would be possible to specify additional configuration option for S3: `endpoint`

This way it is possible to use freefeed server with DigitalOcean's Spaces service (or other API-compatible services)