### PR TITLE
Speed up post creation in small groups

### DIFF
--- a/app/models/group.js
+++ b/app/models/group.js
@@ -248,7 +248,7 @@ export function addModel(dbAdapter) {
    * @returns {Timeline[]}
    */
   Group.prototype.getFeedsToPost = async function (postingUser) {
-    const timeline = await this.getPostsTimeline();
+    const timeline = await dbAdapter.getUserNamedFeed(this.id, 'Posts');
     const isSubscribed = await dbAdapter.isUserSubscribedToTimeline(postingUser.id, timeline.id);
     if (!isSubscribed) {
       return [];

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -987,15 +987,15 @@ export function addModel(dbAdapter) {
   User.prototype.getFeedsToPost = async function (postingUser) {
     if (this.id === postingUser.id) {
       // Users always can post to own timeline
-      return [await this.getPostsTimeline()];
+      return [await dbAdapter.getUserNamedFeed(this.id, 'Posts')];
     }
 
     // Users can send directs only to their mutual friends
     const isMutual = await dbAdapter.areUsersMutuallySubscribed(this.id, postingUser.id);
     if (isMutual) {
       return await Promise.all([
-        this.getDirectsTimeline(),
-        postingUser.getDirectsTimeline(),
+        dbAdapter.getUserNamedFeed(this.id, 'Directs'),
+        dbAdapter.getUserNamedFeed(postingUser.id, 'Directs'),
       ]);
     }
 


### PR DESCRIPTION
Use low-level dbAdapter functions now. High-level getPostsTimeline-s are fetches timelines posts as a side effect which is slow on small groups.