### PR TITLE
Allow group admins to moderate posts and comments in their groups

### DIFF
--- a/app/controllers/api/v1/CommentsController.js
+++ b/app/controllers/api/v1/CommentsController.js
@@ -107,7 +107,7 @@ export const destroy = compose([
       throw new ForbiddenException("You don't have permission to delete this comment");
     }
 
-    await comment.destroy();
+    await comment.destroy(user);
     monitor.increment('comments.destroys');
 
     ctx.body = {};

--- a/app/controllers/api/v1/CommentsController.js
+++ b/app/controllers/api/v1/CommentsController.js
@@ -103,7 +103,7 @@ export const destroy = compose([
       throw new ForbiddenException('You can not destroy a deleted comment');
     }
 
-    if (comment.userId !== user.id && post.userId !== user.id) {
+    if (comment.userId !== user.id && !await post.isAuthorOrGroupAdmin(user)) {
       throw new ForbiddenException("You don't have permission to delete this comment");
     }
 

--- a/app/controllers/api/v1/CommentsController.js
+++ b/app/controllers/api/v1/CommentsController.js
@@ -22,7 +22,7 @@ export const create = compose([
     const { user: author, post } = ctx.state;
     const { comment: { body, postId } } = ctx.request.body;
 
-    if (post.commentsDisabled === '1' && post.userId !== author.id) {
+    if (post.commentsDisabled === '1' && !await post.isAuthorOrGroupAdmin(author)) {
       throw new ForbiddenException('Comments disabled');
     }
 

--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -150,45 +150,33 @@ export default class PostsController {
     ctx.body = {};
   }
 
-  static async disableComments(ctx) {
-    if (!ctx.state.user) {
-      throw new NotAuthorizedException();
-    }
+  static disableComments = compose([
+    authRequired(),
+    postAccessRequired(),
+    async (ctx) => {
+      const { user, post } = ctx.state;
+      if (post.userId !== user.id) {
+        throw new ForbiddenException("You can't disable comments for another user's post");
+      }
 
-    const post = await dbAdapter.getPostById(ctx.params.postId)
+      await post.setCommentsDisabled('1');
+      ctx.body = {};
+    },
+  ]);
 
-    if (null === post) {
-      throw new NotFoundException("Can't find post");
-    }
+  static enableComments = compose([
+    authRequired(),
+    postAccessRequired(),
+    async (ctx) => {
+      const { user, post } = ctx.state;
+      if (post.userId !== user.id) {
+        throw new ForbiddenException("You can't enable comments for another user's post");
+      }
 
-    if (post.userId != ctx.state.user.id) {
-      throw new ForbiddenException("You can't disable comments for another user's post")
-    }
-
-    await post.setCommentsDisabled('1')
-
-    ctx.body = {};
-  }
-
-  static async enableComments(ctx) {
-    if (!ctx.state.user) {
-      throw new NotAuthorizedException();
-    }
-
-    const post = await dbAdapter.getPostById(ctx.params.postId)
-
-    if (null === post) {
-      throw new NotFoundException("Can't find post");
-    }
-
-    if (post.userId != ctx.state.user.id) {
-      throw new ForbiddenException("You can't enable comments for another user's post")
-    }
-
-    await post.setCommentsDisabled('0')
-
-    ctx.body = {};
-  }
+      await post.setCommentsDisabled('0');
+      ctx.body = {};
+    },
+  ]);
 }
 
 /**

--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -155,7 +155,7 @@ export default class PostsController {
     postAccessRequired(),
     async (ctx) => {
       const { user, post } = ctx.state;
-      if (post.userId !== user.id) {
+      if (!await post.isAuthorOrGroupAdmin(user)) {
         throw new ForbiddenException("You can't disable comments for another user's post");
       }
 
@@ -169,7 +169,7 @@ export default class PostsController {
     postAccessRequired(),
     async (ctx) => {
       const { user, post } = ctx.state;
-      if (post.userId !== user.id) {
+      if (!await post.isAuthorOrGroupAdmin(user)) {
         throw new ForbiddenException("You can't enable comments for another user's post");
       }
 

--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -138,8 +138,12 @@ export default class PostsController {
         return;
       }
 
-      // TODO: make partial removal
-      throw new Error('Partial removal is not implemented yet');
+      // Partial removal: remove post only from several feeds
+      await post.update({
+        destinationFeedIds: _.map(feedsToRemain, 'intId'),
+        updatedBy:          user,
+      });
+      ctx.body = {};
     },
   ]);
 

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -160,7 +160,7 @@ export function addModel(dbAdapter) {
       return this.hideType !== Comment.DELETED;
     }
 
-    async destroy() {
+    async destroy(destroyedBy = null) {
       const post = await this.getPost();
       const realtimeRooms = await getRoomsOfPost(post);
       await Promise.all([
@@ -168,6 +168,7 @@ export function addModel(dbAdapter) {
         pubSub.destroyComment(this.id, this.postId, realtimeRooms),
         this.userId ? dbAdapter.withdrawPostFromCommentsFeed(this.postId, this.userId) : null,
         this.userId ? dbAdapter.statsCommentDeleted(this.userId) : null,
+        destroyedBy ? EventService.onCommentDestroyed(this, destroyedBy) : null,
       ]);
     }
 

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -280,6 +280,15 @@ export function addModel(dbAdapter) {
     }
 
     /**
+     * Return all groups post posted to or empty array
+     *
+     * @returns {Array.<User>}
+     */
+    async getGroupsPostedTo() {
+      return await dbAdapter.getPostGroups(this.id);
+    }
+
+    /**
      * Returns all RiverOfNews timelines this post belongs to.
      * Timelines are calculated dynamically.
      *

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -774,6 +774,21 @@ export function addModel(dbAdapter) {
         }
       }
     }
+
+    /**
+     * Returns true if user is the post author or one of group(s)
+     * admins if post was posted to group(s).
+     *
+     * @param {User} user
+     * @returns {boolean}
+     */
+    async isAuthorOrGroupAdmin(user) {
+      if (this.userId === user.id) {
+        return true;
+      }
+      const admins = await dbAdapter.getAdminsOfPostGroups(this.id);
+      return admins.some((a) => a.id === user.id);
+    }
   }
 
   return Post;

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -302,12 +302,12 @@ export default class PubsubListener {
     await this.broadcastMessage(rooms, type, json, post, this._postEventEmitter);
   };
 
-  onPostUpdate = async (data) => {
-    const post = await dbAdapter.getPostById(data.postId);
+  onPostUpdate = async ({ postId, rooms = null }) => {
+    const post = await dbAdapter.getPostById(postId);
     const json = await new PostSerializer(post).promiseToJSON();
 
     const type = 'post:update';
-    const rooms = await getRoomsOfPost(post);
+    rooms = rooms || await getRoomsOfPost(post);
     await this.broadcastMessage(rooms, type, json, post, this._postEventEmitter);
   };
 

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -53,8 +53,8 @@ export default class pubSub {
     await this.publisher.postDestroyed(payload)
   }
 
-  async updatePost(postId) {
-    const payload = JSON.stringify({ postId })
+  async updatePost(postId, rooms = null) {
+    const payload = JSON.stringify({ postId, rooms })
     await this.publisher.postUpdated(payload)
   }
 

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -787,15 +787,17 @@ export function initPostObject(attrs, params) {
 }
 
 const POST_COLUMNS = {
-  createdAt:        'created_at',
-  updatedAt:        'updated_at',
-  bumpedAt:         'bumped_at',
-  userId:           'user_id',
-  body:             'body',
-  commentsDisabled: 'comments_disabled',
-  isPrivate:        'is_private',
-  isProtected:      'is_protected',
-  isPropagable:     'is_propagable',
+  createdAt:          'created_at',
+  updatedAt:          'updated_at',
+  bumpedAt:           'bumped_at',
+  userId:             'user_id',
+  body:               'body',
+  commentsDisabled:   'comments_disabled',
+  isPrivate:          'is_private',
+  isProtected:        'is_protected',
+  isPropagable:       'is_propagable',
+  feedIntIds:         'feed_ids',
+  destinationFeedIds: 'destination_feed_ids',
 }
 
 const POST_COLUMNS_MAPPING = {

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -738,6 +738,21 @@ const postsTrait = (superClass) => class extends superClass {
     );
     return rows.length > 0;
   }
+
+  async getAdminsOfPostGroups(postUID) {
+    const { rows } = await this.database.raw(
+      `select distinct(ga.user_id) from
+        posts p
+        join feeds f on array[f.id] && p.destination_feed_ids
+        join users owners on owners.uid = f.user_id
+        join group_admins ga on owners.uid = ga.group_id
+      where
+        p.uid = :postUID
+      `, { postUID }
+    );
+    const adminIds = _.map(rows, 'user_id');
+    return this.getUsersByIds(adminIds);
+  }
 };
 
 export default postsTrait;

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -753,6 +753,25 @@ const postsTrait = (superClass) => class extends superClass {
     const adminIds = _.map(rows, 'user_id');
     return this.getUsersByIds(adminIds);
   }
+
+  /**
+   * Return all groups post posted to or empty array
+   *
+   * @returns {Array.<User>}
+   */
+  async getPostGroups(postUID) {
+    const { rows } = await this.database.raw(
+      `select distinct(owners.uid) from
+        posts p
+        join feeds f on array[f.id] && p.destination_feed_ids
+        join users owners on owners.uid = f.user_id and owners.type = 'group'
+      where
+        p.uid = :postUID
+      `, { postUID }
+    );
+    const adminIds = _.map(rows, 'uid');
+    return this.getUsersByIds(adminIds);
+  }
 };
 
 export default postsTrait;

--- a/app/support/EventService.js
+++ b/app/support/EventService.js
@@ -246,7 +246,7 @@ export class EventService {
       const groups = _.intersectionBy(managedGroups, postGroups, 'id');
       await dbAdapter.createEvent(
         a.intId,
-        EVENT_TYPES.COMMENT_DELETED_BY_ANOTHER_ADMIN,
+        EVENT_TYPES.COMMENT_MODERATED_BY_ANOTHER_ADMIN,
         destroyedBy.intId,
         commentAuthor.intId,
         groups[0].intId,
@@ -293,7 +293,7 @@ export class EventService {
       const groups = _.intersectionBy(managedGroups, postGroups, 'id');
       await dbAdapter.createEvent(
         a.intId,
-        EVENT_TYPES.POST_DELETED_BY_ANOTHER_ADMIN,
+        EVENT_TYPES.POST_MODERATED_BY_ANOTHER_ADMIN,
         destroyedBy.intId,
         postAuthor.intId,
         groups[0].intId,

--- a/app/support/EventTypes.js
+++ b/app/support/EventTypes.js
@@ -29,10 +29,10 @@ export const EVENT_TYPES = {
   MANAGED_GROUP_SUBSCRIPTION_APPROVED: 'managed_group_subscription_approved',
   MANAGED_GROUP_SUBSCRIPTION_REJECTED: 'managed_group_subscription_rejected',
 
-  COMMENT_MODERATED:                'comment_moderated',
-  COMMENT_DELETED_BY_ANOTHER_ADMIN: 'comment_deleted_by_another_admin',
-  POST_MODERATED:                   'post_moderated',
-  POST_DELETED_BY_ANOTHER_ADMIN:    'post_deleted_by_another_admin',
+  COMMENT_MODERATED:                  'comment_moderated',
+  COMMENT_MODERATED_BY_ANOTHER_ADMIN: 'comment_moderated_by_another_admin',
+  POST_MODERATED:                     'post_moderated',
+  POST_MODERATED_BY_ANOTHER_ADMIN:    'post_moderated_by_another_admin',
 };
 
 export const INVISIBLE_EVENT_TYPES = ['banned_by_user', 'unbanned_by_user', 'user_unsubscribed'];

--- a/app/support/EventTypes.js
+++ b/app/support/EventTypes.js
@@ -28,6 +28,11 @@ export const EVENT_TYPES = {
 
   MANAGED_GROUP_SUBSCRIPTION_APPROVED: 'managed_group_subscription_approved',
   MANAGED_GROUP_SUBSCRIPTION_REJECTED: 'managed_group_subscription_rejected',
+
+  COMMENT_MODERATED:                'comment_moderated',
+  COMMENT_DELETED_BY_ANOTHER_ADMIN: 'comment_deleted_by_another_admin',
+  POST_MODERATED:                   'post_moderated',
+  POST_DELETED_BY_ANOTHER_ADMIN:    'post_deleted_by_another_admin',
 };
 
 export const INVISIBLE_EVENT_TYPES = ['banned_by_user', 'unbanned_by_user', 'user_unsubscribed'];

--- a/migrations/20180520131249_group_moder_event_types.js
+++ b/migrations/20180520131249_group_moder_event_types.js
@@ -1,0 +1,76 @@
+export async function up(knex) {
+  await knex.raw('ALTER TABLE events DROP CONSTRAINT events_event_type_check');
+  await knex.raw(`ALTER TABLE events ADD CONSTRAINT events_event_type_check CHECK (event_type = ANY (ARRAY[
+    'mention_in_post'::text,
+    'mention_in_comment'::text,
+    'mention_comment_to'::text,
+    'banned_user'::text,
+    'unbanned_user'::text,
+    'banned_by_user'::text,
+    'unbanned_by_user'::text,
+    'subscription_requested'::text,
+    'subscription_request_revoked'::text,
+    'user_subscribed'::text,
+    'user_unsubscribed'::text,
+    'subscription_request_approved'::text,
+    'subscription_request_rejected'::text,
+    'group_created'::text,
+    'group_subscription_requested'::text,
+    'group_subscription_request_revoked'::text,
+    'group_subscription_rejected'::text,
+    'group_subscribed'::text,
+    'group_unsubscribed'::text,
+    'group_admin_promoted'::text,
+    'group_admin_demoted'::text,
+    'group_subscription_approved'::text,
+    'group_subscription_rejected'::text,
+    'direct'::text,
+    'direct_comment'::text,
+    'managed_group_subscription_approved'::text,
+    'managed_group_subscription_rejected'::text,
+    
+    'comment_moderated'::text,
+    'comment_deleted_by_another_admin'::text,
+    'post_moderated'::text,
+    'post_deleted_by_another_admin'::text
+    ]))`);
+}
+
+export async function down(knex) {
+  await knex.raw(`delete from events where event_type in (
+    'comment_moderated',
+    'comment_deleted_by_another_admin',
+    'post_moderated',
+    'post_deleted_by_another_admin'
+  )`);
+  await knex.raw('ALTER TABLE events DROP CONSTRAINT events_event_type_check');
+  await knex.raw(`ALTER TABLE events ADD CONSTRAINT events_event_type_check CHECK (event_type = ANY (ARRAY[
+    'mention_in_post'::text,
+    'mention_in_comment'::text,
+    'mention_comment_to'::text,
+    'banned_user'::text,
+    'unbanned_user'::text,
+    'banned_by_user'::text,
+    'unbanned_by_user'::text,
+    'subscription_requested'::text,
+    'subscription_request_revoked'::text,
+    'user_subscribed'::text,
+    'user_unsubscribed'::text,
+    'subscription_request_approved'::text,
+    'subscription_request_rejected'::text,
+    'group_created'::text,
+    'group_subscription_requested'::text,
+    'group_subscription_request_revoked'::text,
+    'group_subscription_rejected'::text,
+    'group_subscribed'::text,
+    'group_unsubscribed'::text,
+    'group_admin_promoted'::text,
+    'group_admin_demoted'::text,
+    'group_subscription_approved'::text,
+    'group_subscription_rejected'::text,
+    'direct'::text,
+    'direct_comment'::text,
+    'managed_group_subscription_approved'::text,
+    'managed_group_subscription_rejected'::text
+    ]))`);
+}

--- a/migrations/20180520131249_group_moder_event_types.js
+++ b/migrations/20180520131249_group_moder_event_types.js
@@ -30,18 +30,18 @@ export async function up(knex) {
     'managed_group_subscription_rejected'::text,
     
     'comment_moderated'::text,
-    'comment_deleted_by_another_admin'::text,
+    'comment_moderated_by_another_admin'::text,
     'post_moderated'::text,
-    'post_deleted_by_another_admin'::text
+    'post_moderated_by_another_admin'::text
     ]))`);
 }
 
 export async function down(knex) {
   await knex.raw(`delete from events where event_type in (
     'comment_moderated',
-    'comment_deleted_by_another_admin',
+    'comment_moderated_by_another_admin',
     'post_moderated',
-    'post_deleted_by_another_admin'
+    'post_moderated_by_another_admin'
   )`);
   await knex.raw('ALTER TABLE events DROP CONSTRAINT events_event_type_check');
   await knex.raw(`ALTER TABLE events ADD CONSTRAINT events_event_type_check CHECK (event_type = ANY (ARRAY[

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -1,0 +1,90 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../dbCleaner'
+import { getSingleton } from '../../app/app';
+import {
+  createTestUsers,
+  createGroupAsync,
+  subscribeToAsync,
+  createAndReturnPostToFeed,
+  disableComments,
+  enableComments,
+  createCommentAsync
+} from './functional_test_helper';
+
+describe('Group Moderation', () => {
+  before(async () => {
+    await getSingleton();
+  });
+
+  beforeEach(() => cleanDB($pg_database));
+
+  describe('Mars creates group Celestials, Luna writes post to group, Venus is stranger', () => {
+    let luna, mars, venus, post;
+    beforeEach(async () => {
+      [luna, mars, venus] = await createTestUsers(3);
+      const { group: celestials } = await createGroupAsync(mars, 'celestials', 'Celestials');
+      await subscribeToAsync(luna, celestials);
+      post = await createAndReturnPostToFeed([celestials], luna, 'My post');
+    });
+
+    describe('Disable comments', () => {
+      it('should allow Luna to disable comments', async () => {
+        const response = await disableComments(post.id, luna.authToken);
+        expect(response.status, 'to be', 200);
+      });
+
+      it('should allow Mars to disable comments', async () => {
+        const response = await disableComments(post.id, mars.authToken);
+        expect(response.status, 'to be', 200);
+      });
+
+      it('should not allow Venus to disable comments', async () => {
+        const response = await disableComments(post.id, venus.authToken);
+        expect(response.status, 'to be', 403);
+      });
+
+      describe('when comments are disabled', () => {
+        beforeEach(async () => {
+          await disableComments(post.id, luna.authToken);
+        });
+
+        describe('enabling', () => {
+          it('should allow Luna to enable comments', async () => {
+            const response = await enableComments(post.id, luna.authToken);
+            expect(response.status, 'to be', 200);
+          });
+
+          it('should allow Mars to enable comments', async () => {
+            const response = await enableComments(post.id, mars.authToken);
+            expect(response.status, 'to be', 200);
+          });
+
+          it('should not allow Venus to enable comments', async () => {
+            const response = await enableComments(post.id, venus.authToken);
+            expect(response.status, 'to be', 403);
+          });
+        });
+
+        describe('commenting', () => {
+          it('should allow Luna to comment post', async () => {
+            const response = await createCommentAsync(luna, post.id, 'My comment');
+            expect(response.status, 'to be', 200);
+          });
+
+          it('should allow Mars to comment post', async () => {
+            const response = await createCommentAsync(mars, post.id, 'My comment');
+            expect(response.status, 'to be', 200);
+          });
+
+          it('should not allow Venus to comment post', async () => {
+            const response = await createCommentAsync(venus, post.id, 'My comment');
+            expect(response.status, 'to be', 403);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -21,6 +21,9 @@ import {
   fetchPost
 } from './functional_test_helper';
 
+const postModerationEvents = [EVENT_TYPES.POST_MODERATED, EVENT_TYPES.POST_MODERATED_BY_ANOTHER_ADMIN];
+const commentModerationEvents = [EVENT_TYPES.COMMENT_MODERATED, EVENT_TYPES.COMMENT_MODERATED_BY_ANOTHER_ADMIN];
+
 describe('Group Moderation', () => {
   before(async () => {
     await getSingleton();
@@ -120,7 +123,6 @@ describe('Group Moderation', () => {
       describe('Mars and Jupiter are admins of Celestials and Gods, Luna wrote post to both groups, Mars and Luna comments post', () => {
         let jupiter, gods;
         let marsCommentId, lunaCommentId;
-        const commentModerationEvents = [EVENT_TYPES.COMMENT_MODERATED, EVENT_TYPES.COMMENT_DELETED_BY_ANOTHER_ADMIN];
 
         beforeEach(async () => {
           jupiter = await createTestUser();
@@ -199,7 +201,7 @@ describe('Group Moderation', () => {
           ]);
           expect(jupiterEvents, 'to satisfy', [
             {
-              event_type:       EVENT_TYPES.COMMENT_DELETED_BY_ANOTHER_ADMIN,
+              event_type:       EVENT_TYPES.COMMENT_MODERATED_BY_ANOTHER_ADMIN,
               created_user_id:  mars.user.id,
               affected_user_id: luna.user.id,
               post_id:          post.id,
@@ -233,8 +235,6 @@ describe('Group Moderation', () => {
       });
 
       describe('Notifications (Jupiter is also admin of Celestials)', () => {
-        const postModerationEvents = [EVENT_TYPES.POST_MODERATED, EVENT_TYPES.POST_DELETED_BY_ANOTHER_ADMIN];
-
         let jupiter;
         beforeEach(async () => {
           jupiter = await createTestUser();
@@ -266,7 +266,7 @@ describe('Group Moderation', () => {
           expect(marsEvents, 'to be empty');
           expect(jupiterEvents, 'to satisfy', [
             {
-              event_type:       EVENT_TYPES.POST_DELETED_BY_ANOTHER_ADMIN,
+              event_type:       EVENT_TYPES.POST_MODERATED_BY_ANOTHER_ADMIN,
               created_user_id:  mars.user.id,
               affected_user_id: luna.user.id,
               group_id:         celestials.group.id,

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -223,6 +223,7 @@ describe('Group Moderation', () => {
       it('should allow Luna to delete their post', async () => {
         const response = await deletePostAsync(luna, post.id);
         expect(response.status, 'to be', 200);
+        expect(await response.json(), 'to satisfy', { postStillAvailable: false });
 
         const postResponse = await fetchPost(post.id, null, { returnError: true });
         expect(postResponse.status, 'to be', 404);
@@ -231,6 +232,7 @@ describe('Group Moderation', () => {
       it('should allow Mars to delete Luna post', async () => {
         const response = await deletePostAsync(mars, post.id);
         expect(response.status, 'to be', 200);
+        expect(await response.json(), 'to satisfy', { postStillAvailable: false });
 
         const postResponse = await fetchPost(post.id, null, { returnError: true });
         expect(postResponse.status, 'to be', 404);
@@ -305,6 +307,12 @@ describe('Group Moderation', () => {
             expect(postResponse.status, 'to be', 404);
           });
 
+          it('should allow Mars to remove Luna post from Mars groups', async () => {
+            const response = await deletePostAsync(mars, post.id);
+            expect(response.status, 'to be', 200);
+            expect(await response.json(), 'to satisfy', { postStillAvailable: true });
+          });
+
           describe('Mars removes Luna post from managed groups', () => {
             beforeEach(async () => {
               await deletePostAsync(mars, post.id);
@@ -355,6 +363,17 @@ describe('Group Moderation', () => {
             });
           });
 
+          describe('Luna becomes private, Mars is not a friend', () => {
+            beforeEach(async () => {
+              await goPrivate(luna);
+            });
+
+            it('should return { postStillAvailable: false } to Mars', async () => {
+              const response = await deletePostAsync(mars, post.id);
+              expect(response.status, 'to be', 200);
+              expect(await response.json(), 'to satisfy', { postStillAvailable: false });
+            });
+          });
 
           describe('Jupiter removes Luna post from managed groups', () => {
             beforeEach(async () => {

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -11,7 +11,8 @@ import {
   createAndReturnPostToFeed,
   disableComments,
   enableComments,
-  createCommentAsync
+  createCommentAsync,
+  removeCommentAsync
 } from './functional_test_helper';
 
 describe('Group Moderation', () => {
@@ -84,6 +85,29 @@ describe('Group Moderation', () => {
             expect(response.status, 'to be', 403);
           });
         });
+      });
+    });
+
+    describe('Delete comments', () => {
+      let commentId;
+      beforeEach(async () => {
+        const response = await createCommentAsync(luna, post.id, 'My comment');
+        ({ comments: { id: commentId } } = await response.json());
+      });
+
+      it('should allow Luna to delete comment', async () => {
+        const response = await removeCommentAsync(luna, commentId);
+        expect(response.status, 'to be', 200);
+      });
+
+      it('should allow Mars to delete comment', async () => {
+        const response = await removeCommentAsync(mars, commentId);
+        expect(response.status, 'to be', 200);
+      });
+
+      it('should not allow Venus to delete comment', async () => {
+        const response = await removeCommentAsync(venus, commentId);
+        expect(response.status, 'to be', 403);
       });
     });
   });

--- a/test/functional/posts.js
+++ b/test/functional/posts.js
@@ -1117,7 +1117,8 @@ describe('PostsController', () => {
           '_method': 'delete'
         })
         .end((err, res) => {
-          res.body.should.be.empty
+          res.body.should.have.property('postStillAvailable')
+          res.body.postStillAvailable.should.eql(false)
           res.status.should.eql(200)
 
           request

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -169,7 +169,7 @@ export const timelineResponse = {
     posts:       expect.it('to be an array').and('to be empty').or('to have items satisfying', UUID),
     subscribers: expect.it('to be an array').and('to be empty').or('to have items satisfying', UUID),
   }),
-  users:         expect.it('to be an array').and('to be empty').or('to have items satisfying', user),
+  users:         expect.it('to be an array').and('to be empty').or('to have items satisfying', userOrGroup),
   admins:        expect.it('to be an array').and('to be empty').or('to have items satisfying', user),
   posts:         expect.it('to be an array').and('to be empty').or('to have items satisfying', post),
   comments:      expect.it('to be an array').and('to be empty').or('to have items satisfying', comment),


### PR DESCRIPTION
This is a server-side part of group moderation described [here](https://docs.google.com/document/d/1KoZ9seBvZPAA4XNPLt8xDEexmTOuWfr05uzgJig5VXY/edit). Admins can:

- Remove post from groups they manages. If post has not other destination feeds, it deletes.
- Turn on and off post comments.
- Delete post comments.