### PR TITLE
Set explicit operations order of Comment.destroy

### DIFF
--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -163,10 +163,12 @@ export function addModel(dbAdapter) {
     async destroy() {
       const post = await this.getPost();
       const realtimeRooms = await getRoomsOfPost(post);
+      await dbAdapter.deleteComment(this.id, this.postId);
+      if (this.userId) {
+        dbAdapter.withdrawPostFromCommentsFeed(this.postId, this.userId);
+      }
       await Promise.all([
-        dbAdapter.deleteComment(this.id, this.postId),
         pubSub.destroyComment(this.id, this.postId, realtimeRooms),
-        this.userId ? dbAdapter.withdrawPostFromCommentsFeed(this.postId, this.userId) : null,
         this.userId ? dbAdapter.statsCommentDeleted(this.userId) : null,
       ]);
     }

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -165,7 +165,7 @@ export function addModel(dbAdapter) {
       const realtimeRooms = await getRoomsOfPost(post);
       await dbAdapter.deleteComment(this.id, this.postId);
       if (this.userId) {
-        dbAdapter.withdrawPostFromCommentsFeed(this.postId, this.userId);
+        dbAdapter.withdrawPostFromCommentsFeedIfNoMoreComments(this.postId, this.userId);
       }
       await Promise.all([
         pubSub.destroyComment(this.id, this.postId, realtimeRooms),

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -96,7 +96,7 @@ const postsTrait = (superClass) => class extends superClass {
    * @param {string} postId
    * @param {string} commentatorId
    */
-  async withdrawPostFromCommentsFeed(postId, commentatorId) {
+  async withdrawPostFromCommentsFeedIfNoMoreComments(postId, commentatorId) {
     await this.database.transaction(async (trx) => {
       // Lock posts table
       await trx.raw('select 1 from posts where uid = :postId for update', { postId });


### PR DESCRIPTION
These operations depend on the results of each other, and may give incorrect result being used in parallel. In particular, the post can remain in the comment feed when deleting the comment.