### PR TITLE
Change the conditions for sending direct messages

### DIFF
--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -161,13 +161,14 @@ export default class UsersController {
     targetUserRequired(),
     monitored('users.show'),
     async (ctx) => {
-      const { targetUser } = ctx.state;
+      const { targetUser, user: viewer } = ctx.state;
 
       const serUsers = await serializeUsersByIds([targetUser.id]);
       const users = serUsers.find((u) => u.id === targetUser.id);
       const admins = serUsers.filter((u) => u.type === 'user');
+      const acceptsDirects = await targetUser.acceptsDirectsFrom(viewer);
 
-      ctx.body = { users, admins };
+      ctx.body = { users, admins, acceptsDirects };
     },
   ]);
 

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -240,6 +240,15 @@ export function addModel(dbAdapter) {
   }
 
   /**
+   * Always returns false for groups (groups cannot receive directs).
+   *
+   * @returns {boolean}
+   */
+  Group.prototype.acceptsDirectsFrom = function () {
+    return false;
+  }
+
+  /**
    * Checks if the specified user can post to the timeline of this group
    * and returns array of destination timelines or empty array if
    * user can not post to this group.

--- a/app/models/user-prefs.js
+++ b/app/models/user-prefs.js
@@ -2,8 +2,10 @@ import Ajv from 'ajv';
 import { cloneDeep } from 'lodash';
 
 import { addModel as commentModelMaker } from './comment';
+import { addModel as userModelMaker } from './user';
 
 const commentModel = commentModelMaker(null);
+const userModel = userModelMaker(null);
 
 const schema = {
   '$schema': 'http://json-schema.org/schema#',
@@ -40,10 +42,14 @@ const schema = {
       default: false,
       type:    'boolean',
     },
-    directsFromAll: {
+    acceptDirectsFrom: {
       title:   'Accept direct messages from all users',
-      default: false,
-      type:    'boolean',
+      default: userModel.ACCEPT_DIRECTS_FROM_FRIENDS,
+      type:    'string',
+      enum:    [
+        userModel.ACCEPT_DIRECTS_FROM_ALL,
+        userModel.ACCEPT_DIRECTS_FROM_FRIENDS,
+      ],
     }
   },
   additionalProperties: false,

--- a/app/models/user-prefs.js
+++ b/app/models/user-prefs.js
@@ -40,6 +40,11 @@ const schema = {
       default: false,
       type:    'boolean',
     },
+    directsFromAll: {
+      title:   'Accept direct messages from all users',
+      default: false,
+      type:    'boolean',
+    }
   },
   additionalProperties: false,
 };

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -84,6 +84,9 @@ export function addModel(dbAdapter) {
   User.PROFILE_PICTURE_SIZE_LARGE = 75
   User.PROFILE_PICTURE_SIZE_MEDIUM = 50
 
+  User.ACCEPT_DIRECTS_FROM_ALL     = 'all';
+  User.ACCEPT_DIRECTS_FROM_FRIENDS = 'friends';
+
   Reflect.defineProperty(User.prototype, 'username', {
     get: function () { return this.username_ },
     set: function (newValue) {
@@ -990,15 +993,17 @@ export function addModel(dbAdapter) {
       return [await dbAdapter.getUserNamedFeed(this.id, 'Posts')];
     }
 
-    if (!this.preferences.directsFromAll) {
+    if (this.preferences.acceptDirectsFrom === User.ACCEPT_DIRECTS_FROM_FRIENDS) {
       const friendIds = await this.getFriendIds();
       if (!friendIds.includes(postingUser.id)) {
         return [];
       }
-    }
-
-    const banIds = await this.getBanIds();
-    if (banIds.includes(postingUser.id)) {
+    } else if (this.preferences.acceptDirectsFrom === User.ACCEPT_DIRECTS_FROM_ALL) {
+      const banIds = await this.getBanIds();
+      if (banIds.includes(postingUser.id)) {
+        return [];
+      }
+    } else {
       return [];
     }
 

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -30,7 +30,10 @@ const selfUserFields = [
 ];
 
 export async function serializeSelfUser(user) {
-  const result = pick(user, selfUserFields);
+  const result = {
+    ...pick(user, selfUserFields),
+    directsFromAll: user.preferences.directsFromAll,
+  };
 
   [
     result.banIds,
@@ -48,7 +51,13 @@ export async function serializeSelfUser(user) {
 }
 
 export function serializeUser(user) {
-  return pick(user, user.type === 'group' ? commonGroupFields : commonUserFields);
+  if (user.type === 'user') {
+    return {
+      ...pick(user, commonUserFields),
+      directsFromAll: user.preferences.directsFromAll,
+    };
+  }
+  return pick(user, commonGroupFields);
 }
 
 const defaultStats = {

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -30,10 +30,7 @@ const selfUserFields = [
 ];
 
 export async function serializeSelfUser(user) {
-  const result = {
-    ...pick(user, selfUserFields),
-    directsFromAll: user.preferences.directsFromAll,
-  };
+  const result = pick(user, selfUserFields);
 
   [
     result.banIds,
@@ -52,10 +49,7 @@ export async function serializeSelfUser(user) {
 
 export function serializeUser(user) {
   if (user.type === 'user') {
-    return {
-      ...pick(user, commonUserFields),
-      directsFromAll: user.preferences.directsFromAll,
-    };
+    return pick(user, commonUserFields);
   }
   return pick(user, commonGroupFields);
 }

--- a/test/functional/posts.js
+++ b/test/functional/posts.js
@@ -134,7 +134,7 @@ describe('PostsController', () => {
 
       describe('Luna accepts private messages from any user', () => {
         beforeEach(async () => {
-          await funcTestHelper.updateUserAsync(ctx, { preferences: { directsFromAll: true } });
+          await funcTestHelper.updateUserAsync(ctx, { preferences: { acceptDirectsFrom: 'all' } });
         });
 
         it('should accept private message from Mars', async () => {

--- a/test/functional/posts.js
+++ b/test/functional/posts.js
@@ -132,6 +132,39 @@ describe('PostsController', () => {
           })
       })
 
+      describe('Luna accepts private messages from any user', () => {
+        beforeEach(async () => {
+          await funcTestHelper.updateUserAsync(ctx, { preferences: { directsFromAll: true } });
+        });
+
+        it('should accept private message from Mars', async () => {
+          const req = funcTestHelper.createAndReturnPostToFeed([ctx.user], marsCtx, 'Hello');
+          await expect(req, 'to be fulfilled with', { body: 'Hello' });
+        });
+
+        describe('Luna bans Mars', () => {
+          beforeEach(async () => {
+            await funcTestHelper.banUser(ctx, marsCtx);
+          });
+
+          it('should not accept private message from Mars', async () => {
+            const req = funcTestHelper.createAndReturnPostToFeed([ctx.user], marsCtx, 'Hello');
+            await expect(req, 'to be rejected');
+          });
+        });
+      });
+
+      describe('Luna is subscribed to Mars', () => {
+        beforeEach(async () => {
+          await funcTestHelper.subscribeToAsync(ctx, marsCtx);
+        });
+
+        it('should accept private message from Mars', async () => {
+          const req = funcTestHelper.createAndReturnPostToFeed([ctx.user], marsCtx, 'Hello');
+          await expect(req, 'to be fulfilled with', { body: 'Hello' });
+        });
+      });
+
       describe('for mutual friends', () => {
         beforeEach(async () => {
           await funcTestHelper.mutualSubscriptions([marsCtx, ctx])

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -30,7 +30,8 @@ export const groupBasic = {
 
 export const user = {
   ...userBasic,
-  statistics: expect.it('to be an object'),
+  statistics:     expect.it('to be an object'),
+  directsFromAll: expect.it('to be a boolean'),
 };
 
 export const group = {

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -30,8 +30,7 @@ export const groupBasic = {
 
 export const user = {
   ...userBasic,
-  statistics:     expect.it('to be an object'),
-  directsFromAll: expect.it('to be a boolean'),
+  statistics: expect.it('to be an object'),
 };
 
 export const group = {

--- a/test/functional/usersV2.js
+++ b/test/functional/usersV2.js
@@ -17,6 +17,8 @@ import {
   sendRequestToJoinGroup,
   updateUserAsync,
   createTestUsers,
+  getUserAsync,
+  banUser,
 } from '../functional/functional_test_helper'
 import { valiate as validateUserPrefs } from '../../app/models/user-prefs';
 import * as schema from './schemaV2-helper';
@@ -233,5 +235,61 @@ describe('UsersControllerV2', () => {
       expect(res, 'to satisfy', { status: 422 });
     });
   })
+
+  describe('"acceptsDirects" flag', () => {
+    let luna, mars;
+
+    beforeEach(async () => {
+      [luna, mars] = await createTestUsers(2);
+    });
+
+    const getLunaInfo = async (anon = false) => {
+      const resp = await getUserAsync(anon ? {} : mars, luna.username);
+      return await resp.json();
+    };
+
+    it('should not accept directs from anonymous', async () => {
+      const info = await getLunaInfo(true);
+      expect(info, 'to satisfy', { acceptsDirects: false });
+    });
+
+    it('should not accept directs from non-friends', async () => {
+      const info = await getLunaInfo();
+      expect(info, 'to satisfy', { acceptsDirects: false });
+    });
+
+    describe('Luna subscribed to Mars', () => {
+      beforeEach(async () => {
+        await subscribeToAsync(luna, mars);
+      });
+
+      it('should accept directs from friends', async () => {
+        const info = await getLunaInfo();
+        expect(info, 'to satisfy', { acceptsDirects: true });
+      });
+    });
+
+    describe('Luna accepts directs from all', () => {
+      beforeEach(async () => {
+        await updateUserAsync(luna, { preferences: { acceptDirectsFrom: 'all' } });
+      });
+
+      it('should accept directs from non-friends', async () => {
+        const info = await getLunaInfo();
+        expect(info, 'to satisfy', { acceptsDirects: true });
+      });
+
+      describe('Luna bans Mars', () => {
+        beforeEach(async () => {
+          await banUser(luna, mars);
+        });
+
+        it('should not accept directs from non-friends', async () => {
+          const info = await getLunaInfo();
+          expect(info, 'to satisfy', { acceptsDirects: false });
+        });
+      });
+    });
+  });
 })
 


### PR DESCRIPTION
User has an 'acceptDirectsFrom' string field in preferences. This field may have value 'all' or 'friends' (those to whom the user has subscribed).

If recipient's 'acceptDirectsFrom' equals 'all' then anybody can send directs to him. If 'acceptDirectsFrom' equals 'friends' then only recipient's friends (users he subscribed to) can send directs.

Users, who are banned by recipient, cannot send direct to him.

The 'GET /v1/users/:id' API method returns a new top-level boolean field 'acceptsDirects'. This field is true if the requested user can receive direct message from the authorized user.