### PR TITLE
Access tokens

### DIFF
--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -405,6 +405,11 @@ export default class UsersController {
         return acc;
       }, {});
 
+      // Email change requires full access token
+      if (attrs.email && (attrs.email !== ctx.state.user.email) && !ctx.state.user.hasFullAccess) {
+        throw new NotAuthorizedException();
+      }
+
       await user.update(attrs);
 
       // should return the same response as 'whoami'

--- a/app/controllers/api/v2/AccessTokensController.js
+++ b/app/controllers/api/v2/AccessTokensController.js
@@ -8,7 +8,7 @@ import { NotFoundException, ForbiddenException } from '../../../support/exceptio
 
 
 export const getTokens = compose([
-  authRequired(),
+  authRequired(true),
   monitored('tokens.get'),
   async (ctx) => {
     const currentUserId = ctx.state.user.id;
@@ -18,7 +18,7 @@ export const getTokens = compose([
 ]);
 
 export const createToken = compose([
-  authRequired(),
+  authRequired(true),
   monitored('tokens.create'),
   async (ctx) => {
     const currentUserId = ctx.state.user.id;
@@ -33,7 +33,7 @@ export const createToken = compose([
 ]);
 
 export const revokeToken = compose([
-  authRequired(),
+  authRequired(true),
   monitored('tokens.revoke'),
   async (ctx) => {
     const currentUserId = ctx.state.user.id;

--- a/app/controllers/api/v2/AccessTokensController.js
+++ b/app/controllers/api/v2/AccessTokensController.js
@@ -37,12 +37,14 @@ export const revokeToken = compose([
   monitored('tokens.revoke'),
   async (ctx) => {
     const currentUserId = ctx.state.user.id;
-    const tokenId = ctx.request.body.tokenId; // eslint-disable-line prefer-destructuring
+    const { tokenId } = ctx.params;
 
     const token = await dbAdapter.getAccessTokenById(currentUserId, tokenId);
+
     if (token === null) {
       throw new NotFoundException("Can't find token");
     }
+
     if (token.status !== 'active') {
       throw new ForbiddenException('Token is already revoked');
     }

--- a/app/controllers/api/v2/AccessTokensController.js
+++ b/app/controllers/api/v2/AccessTokensController.js
@@ -1,0 +1,16 @@
+import compose from 'koa-compose';
+
+import { dbAdapter } from '../../../models'
+import { authRequired, monitored } from '../../middlewares';
+import { serializeAccessToken } from '../../../serializers/v2/accessToken';
+
+
+export const getTokens = compose([
+  authRequired(),
+  monitored('tokens.get'),
+  async (ctx) => {
+    const currentUserId = ctx.state.user.id;
+    const tokens = await dbAdapter.getAccessTokens(currentUserId);
+    ctx.body = tokens.map(serializeAccessToken);
+  }
+]);

--- a/app/controllers/api/v2/AccessTokensController.js
+++ b/app/controllers/api/v2/AccessTokensController.js
@@ -1,8 +1,10 @@
+import crypto from 'crypto';
 import compose from 'koa-compose';
 
 import { dbAdapter } from '../../../models'
 import { authRequired, monitored } from '../../middlewares';
 import { serializeAccessToken } from '../../../serializers/v2/accessToken';
+import { NotFoundException, ForbiddenException } from '../../../support/exceptions';
 
 
 export const getTokens = compose([
@@ -12,5 +14,41 @@ export const getTokens = compose([
     const currentUserId = ctx.state.user.id;
     const tokens = await dbAdapter.getAccessTokens(currentUserId);
     ctx.body = tokens.map(serializeAccessToken);
+  }
+]);
+
+export const createToken = compose([
+  authRequired(),
+  monitored('tokens.create'),
+  async (ctx) => {
+    const currentUserId = ctx.state.user.id;
+    const description = ctx.request.body.description; // eslint-disable-line prefer-destructuring
+    const code = crypto.randomBytes(128).toString('base64');
+
+    const tokenId = await dbAdapter.createAccessToken(currentUserId, description, code);
+
+    const token = await dbAdapter.getAccessTokenById(currentUserId, tokenId);
+    ctx.body = serializeAccessToken(token);
+  }
+]);
+
+export const revokeToken = compose([
+  authRequired(),
+  monitored('tokens.revoke'),
+  async (ctx) => {
+    const currentUserId = ctx.state.user.id;
+    const tokenId = ctx.request.body.tokenId; // eslint-disable-line prefer-destructuring
+
+    const token = await dbAdapter.getAccessTokenById(currentUserId, tokenId);
+    if (token === null) {
+      throw new NotFoundException("Can't find token");
+    }
+    if (token.status !== 'active') {
+      throw new ForbiddenException('Token is already revoked');
+    }
+
+    await dbAdapter.revokeAccessToken(tokenId);
+
+    ctx.body = serializeAccessToken({ ...token, status: 'revoked' });
   }
 ]);

--- a/app/controllers/middlewares/index.js
+++ b/app/controllers/middlewares/index.js
@@ -37,9 +37,13 @@ export function monitored(monitorName, monitor = monitorDog) {
   };
 }
 
-export function authRequired() {
+export function authRequired(fullAccessRequired = false) {
   return async (ctx, next) => {
     if (!ctx.state.user) {
+      throw new NotAuthorizedException();
+    }
+
+    if (fullAccessRequired && !ctx.state.user.hasFullAccess) {
       throw new NotAuthorizedException();
     }
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -34,6 +34,7 @@ import ArchivesRoute from './routes/api/v2/ArchivesRoute';
 import NotificationsRoute from './routes/api/v2/NotificationsRoute';
 import CommentLikesRoute from './routes/api/v2/CommentLikesRoute';
 import InvitationsRoute from './routes/api/v2/InvitationsRoute';
+import AccessTokensRoute from './routes/api/v2/AccessTokensRoute';
 
 
 promisifyAll(jwt);
@@ -95,6 +96,7 @@ export default function (app) {
   NotificationsRoute(router);
   CommentLikesRoute(router);
   InvitationsRoute(router);
+  AccessTokensRoute(router);
 
   router.use('/v[0-9]+/*', (ctx) => {
     ctx.status = 404;

--- a/app/routes.js
+++ b/app/routes.js
@@ -1,6 +1,4 @@
 /* eslint babel/semi: "error" */
-import { promisifyAll } from 'bluebird';
-import jwt from 'jsonwebtoken';
 import conditional from 'koa-conditional-get';
 import etag from 'koa-etag';
 import koaStatic from 'koa-static';
@@ -8,7 +6,7 @@ import Router from 'koa-router';
 import createDebug from 'debug';
 
 import { load as configLoader } from '../config/config';
-import { dbAdapter } from './models';
+import { getUserByToken } from './support/tokens';
 import { reportError } from './support/exceptions';
 
 import AttachmentsRoute from './routes/api/v1/AttachmentsRoute';
@@ -37,8 +35,6 @@ import InvitationsRoute from './routes/api/v2/InvitationsRoute';
 import AccessTokensRoute from './routes/api/v2/AccessTokensRoute';
 
 
-promisifyAll(jwt);
-
 const config = configLoader();
 
 export default function (app) {
@@ -52,8 +48,7 @@ export default function (app) {
       authDebug('got token', authToken);
 
       try {
-        const decoded = await jwt.verifyAsync(authToken, config.secret);
-        const user = await dbAdapter.getUserById(decoded.userId);
+        const user = await getUserByToken(authToken);
 
         if (user && user.isActive) {
           ctx.state.user = user;

--- a/app/routes/api/v2/AccessTokensRoute.js
+++ b/app/routes/api/v2/AccessTokensRoute.js
@@ -1,0 +1,6 @@
+import { getTokens } from '../../../controllers/api/v2/AccessTokensController';
+
+
+export default function addRoutes(app) {
+  app.get('/v2/tokens', getTokens);
+}

--- a/app/routes/api/v2/AccessTokensRoute.js
+++ b/app/routes/api/v2/AccessTokensRoute.js
@@ -3,6 +3,6 @@ import { getTokens, createToken, revokeToken } from '../../../controllers/api/v2
 
 export default function addRoutes(app) {
   app.get('/v2/tokens', getTokens);
-  app.post('/v2/tokens/create', createToken);
-  app.post('/v2/tokens/revoke', revokeToken);
+  app.post('/v2/tokens', createToken);
+  app.delete('/v2/tokens/:tokenId', revokeToken);
 }

--- a/app/routes/api/v2/AccessTokensRoute.js
+++ b/app/routes/api/v2/AccessTokensRoute.js
@@ -1,6 +1,8 @@
-import { getTokens } from '../../../controllers/api/v2/AccessTokensController';
+import { getTokens, createToken, revokeToken } from '../../../controllers/api/v2/AccessTokensController';
 
 
 export default function addRoutes(app) {
   app.get('/v2/tokens', getTokens);
+  app.post('/v2/tokens/create', createToken);
+  app.post('/v2/tokens/revoke', revokeToken);
 }

--- a/app/serializers/v2/accessToken.js
+++ b/app/serializers/v2/accessToken.js
@@ -1,0 +1,10 @@
+export function serializeAccessToken(token) {
+  return {
+    id:          token.uid,
+    description: token.description,
+    code:        token.code,
+    createdAt:   new Date(token.created_at).getTime(),
+    lastUsedAt:  (token.last_used_at === null ? null : new Date(token.last_used_at).getTime()),
+    status:      token.status
+  };
+}

--- a/app/support/DbAdapter/access-tokens.js
+++ b/app/support/DbAdapter/access-tokens.js
@@ -9,6 +9,33 @@ const accessTokensTrait = (superClass) => class extends superClass {
       .where('user_id', currentUserId)
       .orderBy('id', 'asc');
   }
+
+  async getAccessTokenById(currentUserId, tokenId) {
+    return await this.database
+      .first('uid', 'description', 'code', 'created_at', 'last_used_at', 'status')
+      .from('access_tokens')
+      .where({ user_id: currentUserId, uid: tokenId });
+  }
+
+  async createAccessToken(userId, description, code) {
+    const res = await this.database
+      .table('access_tokens')
+      .insert({
+        user_id: userId,
+        description,
+        code
+      })
+      .returning('uid');
+
+    return res[0];
+  }
+
+  async revokeAccessToken(tokenId) {
+    return await this.database
+      .table('access_tokens')
+      .update('status', 'revoked')
+      .where('uid', tokenId);
+  }
 };
 
 export default accessTokensTrait;

--- a/app/support/DbAdapter/access-tokens.js
+++ b/app/support/DbAdapter/access-tokens.js
@@ -1,6 +1,7 @@
-/**
- * Get list of access tokens
- */
+///////////////////////////////////////////////////
+// Access tokens
+///////////////////////////////////////////////////
+
 const accessTokensTrait = (superClass) => class extends superClass {
   async getAccessTokens(currentUserId) {
     return await this.database
@@ -38,17 +39,30 @@ const accessTokensTrait = (superClass) => class extends superClass {
   }
 
   async getUserIdByAccessToken(code) {
-    // Update last_used_at for this token AND select user_id at the same time
-    const res = await this.database
-      .table('access_tokens')
-      .update('last_used_at', 'now')
-      .where({ code, status: 'active' })
-      .returning('user_id');
+    // 1. Select `user_id`
+    // 2. Update `last_used_at` if it's older than 60 seconds
+    return await this.database.transaction(async (trx) => {
+      const { rows } = await trx.raw(
+        'SELECT user_id, last_used_at FROM access_tokens WHERE code = :code AND status = :status FOR UPDATE',
+        { code, status: 'active' }
+      );
 
-    if (res.length === 0) {
-      return null;
-    }
-    return res[0];
+      if (rows.length === 0) {
+        return null;
+      }
+
+      const lastUsedAt = new Date(rows[0].last_used_at).getTime();
+      const now = new Date().getTime();
+
+      if (now - lastUsedAt > 60 * 1000) {
+        await trx
+          .table('access_tokens')
+          .update('last_used_at', 'now')
+          .where({ code, status: 'active' });
+      }
+
+      return rows[0].user_id;
+    });
   }
 };
 

--- a/app/support/DbAdapter/access-tokens.js
+++ b/app/support/DbAdapter/access-tokens.js
@@ -36,6 +36,18 @@ const accessTokensTrait = (superClass) => class extends superClass {
       .update('status', 'revoked')
       .where('uid', tokenId);
   }
+
+  async getUserIdByAccessToken(code) {
+    const res = await this.database
+      .first('user_id')
+      .from('access_tokens')
+      .where({ code, status: 'active' });
+
+    if (res === undefined) {
+      return null;
+    }
+    return res.user_id;
+  }
 };
 
 export default accessTokensTrait;

--- a/app/support/DbAdapter/access-tokens.js
+++ b/app/support/DbAdapter/access-tokens.js
@@ -38,15 +38,17 @@ const accessTokensTrait = (superClass) => class extends superClass {
   }
 
   async getUserIdByAccessToken(code) {
+    // Update last_used_at for this token AND select user_id at the same time
     const res = await this.database
-      .first('user_id')
-      .from('access_tokens')
-      .where({ code, status: 'active' });
+      .table('access_tokens')
+      .update('last_used_at', 'now')
+      .where({ code, status: 'active' })
+      .returning('user_id');
 
-    if (res === undefined) {
+    if (res.length === 0) {
       return null;
     }
-    return res.user_id;
+    return res[0];
   }
 };
 

--- a/app/support/DbAdapter/access-tokens.js
+++ b/app/support/DbAdapter/access-tokens.js
@@ -1,0 +1,14 @@
+/**
+ * Get list of access tokens
+ */
+const accessTokensTrait = (superClass) => class extends superClass {
+  async getAccessTokens(currentUserId) {
+    return await this.database
+      .select('uid', 'description', 'code', 'created_at', 'last_used_at', 'status')
+      .from('access_tokens')
+      .where('user_id', currentUserId)
+      .orderBy('id', 'asc');
+  }
+};
+
+export default accessTokensTrait;

--- a/app/support/DbAdapter/index.js
+++ b/app/support/DbAdapter/index.js
@@ -29,6 +29,7 @@ import commentLikesTrait from './comment-likes';
 import allGroupsTrait from './all-groups';
 import summaryTrait from './summary';
 import invitationsTrait from './invitations';
+import accessTokensTrait from './access-tokens';
 
 
 promisifyAll(redis.RedisClient.prototype);
@@ -80,4 +81,5 @@ export const DbAdapter = _.flow([
   allGroupsTrait,
   summaryTrait,
   invitationsTrait,
+  accessTokensTrait,
 ])(DbAdapterBase);

--- a/app/support/tokens.js
+++ b/app/support/tokens.js
@@ -10,13 +10,15 @@ const config = configLoader();
 
 export async function getUserByToken(token) {
   let userId;
+  let hasFullAccess = false;
 
   try {
     // It can be an old JWT token...
     const decrypted = await jwt.verifyAsync(token, config.secret);
     userId = decrypted.userId; // eslint-disable-line prefer-destructuring
+    hasFullAccess = true;
   } catch (e) {
-    // ...or it can be a new DB-stored access token
+    // ...or it can be a new DB-stored access token with limited permissions
     userId = await dbAdapter.getUserIdByAccessToken(token);
   }
 
@@ -24,5 +26,8 @@ export async function getUserByToken(token) {
     return null;
   }
 
-  return await dbAdapter.getUserById(userId);
+  const user = await dbAdapter.getUserById(userId);
+  user.hasFullAccess = hasFullAccess;
+
+  return user;
 }

--- a/app/support/tokens.js
+++ b/app/support/tokens.js
@@ -1,0 +1,28 @@
+import jwt from 'jsonwebtoken';
+import { promisifyAll } from 'bluebird';
+
+import { dbAdapter } from '../models';
+import { load as configLoader } from '../../config/config';
+
+
+promisifyAll(jwt);
+const config = configLoader();
+
+export async function getUserByToken(token) {
+  let userId;
+
+  try {
+    // It can be an old JWT token...
+    const decrypted = await jwt.verifyAsync(token, config.secret);
+    userId = decrypted.userId; // eslint-disable-line prefer-destructuring
+  } catch (e) {
+    // ...or it can be a new DB-stored access token
+    userId = await dbAdapter.getUserIdByAccessToken(token);
+  }
+
+  if (!userId) {
+    return null;
+  }
+
+  return await dbAdapter.getUserById(userId);
+}

--- a/migrations/20180806112349_access_tokens.js
+++ b/migrations/20180806112349_access_tokens.js
@@ -1,0 +1,24 @@
+export async function up(knex) {
+  await knex.schema.createTable('access_tokens', (table) => {
+    table.increments().notNullable().primary();
+    table.uuid('uid').defaultTo(knex.raw('gen_random_uuid()')).notNullable().unique();
+
+    table.uuid('user_id').notNullable()
+      .references('uid').inTable('users')
+      .onUpdate('cascade').onDelete('cascade');
+
+    table.text('description').notNullable();
+    table.text('code').notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('last_used_at').defaultTo(null).nullable();
+    table.enu('status', ['active', 'revoked']).defaultTo('active').notNullable();
+
+    table.index('user_id', 'access_tokens_user_id_idx', 'btree');
+    table.index(['uid', 'user_id'], 'access_tokens_uid_user_id_idx', 'btree');
+    table.index(['code', 'status'], 'access_tokens_code_status_idx', 'btree');
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.dropTableIfExists('access_tokens');
+}


### PR DESCRIPTION
This is an implementation of access tokens (a.k.a. API tokens, application tokens, security tokens) in FreeFeed API.

### 1. What this PR does (or should) implement

- [x] A database table of access tokens with description, creation date and last usage date
- [x] API endpoints for getting list of tokens, creating a token and revoking a token
- [x] Support for the new access tokens in authentication flow
- [x] Updating token's last_used_at property every time it's used
- [ ] Unit/functional tests

These tokens are stored in DB as plain text and have <s>every permission the old JWT ones have</s> limited permissions (not allowed to change user email and read/create/revoke tokens).

A token itself is 128 random bytes, encoded in a Base64 string of length 172. Example:

> C8oLZGb7DBMKbpX5VJ4kY87WQM8j0rkgTfV3dGAEKlsZ6Q+1I6/fjCOzLt6ZJ3JYyreZV2h8YMI0REgAcYJDCcrqK6VPltdRQqPmU+nZ4PpRoBJSK7jclpVXOuRwSLDldDCgbbeWqWbhypsCE5nkGhnOt/wcHYCtGwd8/QbttcE=

Featurewise, this implementation is considered ready for production use. There's a respective client implementation that successfully utilizes this API (*the link to be added*).

**Your comments on this approach, as well as code reviews, are welcome.**


### 2. What's not going to be covered in this PR...

...and will (or might) be added in the following ones instead. In no particular order:

- Issuing the new type of tokens on login/password signin, instead of the old JWT tokens (and eventual deprecation of the latter).

- Requirement of a password for getting a short-lived (N minutes) access to the tokens API (to view, create and revoke tokens).

- Storing some sort of hash in DB, instead of plain-text token (hence, user gets the token once during its creation and can never see it again).

- Logging of token usage beyond that simple last_used_at property. I.e., the list of last N clients / places / IP addresses for each token, timestamped.

- Per-token permissions (read-only / only write to user feed / no settings changes / no DM access / no access to other tokens / whatnot).
