### PR TITLE
Allow to edit post destinations

### DIFF
--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -229,6 +229,16 @@ export async function checkDestNames(destNames, author) {
     throw new NotFoundException('Some of destination users was not found');
   }
 
+  // Checking if this will be a regular post or a direct message.
+  // Mixed posts ("public directs") are prohibited.
+  const isMixed = destUsers
+    .map((u) => u.isGroup() || u.id === author.id)
+    .some((v, i, arr) => v !== arr[0]);
+
+  if (isMixed) {
+    throw new ForbiddenException(`You can not create "public directs"`);
+  }
+
   const destFeeds = await Promise.all(destUsers.map((u) => u.getFeedsToPost(author)));
   if (destFeeds.some((x) => x.length === 0)) {
     if (destUsers.length === 1) {

--- a/app/controllers/api/v1/data-schemes/index.js
+++ b/app/controllers/api/v1/data-schemes/index.js
@@ -1,3 +1,3 @@
-export { postCreateInputSchema } from './posts';
+export { postCreateInputSchema, postUpdateInputSchema } from './posts';
 export { commentCreateInputSchema, commentUpdateInputSchema } from './comments';
 export { bookmarkletCreateInputSchema } from './bookmarklet';

--- a/app/controllers/api/v1/data-schemes/posts.js
+++ b/app/controllers/api/v1/data-schemes/posts.js
@@ -43,3 +43,29 @@ export const postCreateInputSchema = {
     }
   }
 };
+
+export const postUpdateInputSchema = {
+  '$schema': 'http://json-schema.org/schema#',
+
+  definitions,
+
+  type:       'object',
+  required:   ['post'],
+  properties: {
+    post: {
+      type:       'object',
+      required:   [],
+      properties: {
+        body: {
+          type:      'string',
+          minLength: 1,
+          pattern:   '\\S'
+        },
+        attachments: {
+          type:  'array',
+          items: { '$ref': '#/definitions/uuid' }
+        }
+      }
+    }
+  }
+};

--- a/app/controllers/api/v1/data-schemes/posts.js
+++ b/app/controllers/api/v1/data-schemes/posts.js
@@ -64,6 +64,11 @@ export const postUpdateInputSchema = {
         attachments: {
           type:  'array',
           items: { '$ref': '#/definitions/uuid' }
+        },
+        feeds: {
+          type:     'array',
+          minItems: 1,
+          items:    { '$ref': '#/definitions/accountName' }
         }
       }
     }

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -216,9 +216,17 @@ export function addModel(dbAdapter) {
           payload.destinationFeedIds = this.destinationFeedIds;
           payload.feedIntIds = this.feedIntIds;
 
-          if (params.updatedBy) {
-            const removedFeeds = await dbAdapter.getTimelinesByIntIds(removedFeedIds);
-            afterUpdate.push(() => EventService.onPostFeedsChanged(this, params.updatedBy, { removedFeeds }));
+          {
+            const [
+              postAuthor,
+              removedFeeds,
+              addedFeeds,
+            ] = await Promise.all([
+              this.getCreatedBy(),
+              dbAdapter.getTimelinesByIntIds(removedFeedIds),
+              dbAdapter.getTimelinesByIntIds(addedFeedIds),
+            ]);
+            afterUpdate.push(() => EventService.onPostFeedsChanged(this, params.updatedBy || postAuthor, { addedFeeds, removedFeeds }));
           }
 
           // Publishing changes to the old AND new realtime rooms

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -173,7 +173,9 @@ export function addModel(dbAdapter) {
         'attachments',
         'destinationFeedIds',
       ];
-      if (!editableProperties.some((p) => p in params)) {
+      // It is important to use "!= null" here and below because
+      // params[p] can exists but have a null or undefined value.
+      if (!editableProperties.some((p) => params[p] != null)) {
         // Nothing changed
         return this;
       }
@@ -184,7 +186,7 @@ export function addModel(dbAdapter) {
 
       let realtimeRooms = await getRoomsOfPost(this);
 
-      if ('body' in params) {
+      if (params.body != null) {
         this.body = params.body;
         payload.body = this.body;
 
@@ -192,7 +194,7 @@ export function addModel(dbAdapter) {
         afterUpdate.push(() => this.processHashtagsOnUpdate());
       }
 
-      if ('attachments' in params) {
+      if (params.attachments != null) {
         // Calculate changes in attachments
         const oldAttachments = await this.getAttachmentIds() || [];
         const newAttachments = params.attachments || [];
@@ -203,9 +205,10 @@ export function addModel(dbAdapter) {
         afterUpdate.push(() => this.unlinkAttachments(removedAttachments));
       }
 
-      if ('destinationFeedIds' in params) {
+      if (params.destinationFeedIds != null) {
         const removedFeedIds = _.difference(this.destinationFeedIds, params.destinationFeedIds);
-        if (removedFeedIds.length > 0) {
+        const addedFeedIds = _.difference(params.destinationFeedIds, this.destinationFeedIds);
+        if (removedFeedIds.length > 0 || addedFeedIds.length > 0) {
           this.destinationFeedIds = params.destinationFeedIds;
           this.feedIntIds = _.union(this.feedIntIds, this.destinationFeedIds);
           this.feedIntIds = _.difference(this.feedIntIds, removedFeedIds);

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -186,6 +186,7 @@ export function addModel(dbAdapter) {
       const afterUpdate = [];
 
       let realtimeRooms = await getRoomsOfPost(this);
+      const usersCanSeePostBeforeIds = await this.usersCanSeePostIds();
 
       if (params.body != null) {
         this.body = params.body;
@@ -247,7 +248,7 @@ export function addModel(dbAdapter) {
       await Promise.all(afterUpdate.map((f) => f()));
 
       // Finally, publish changes
-      await pubSub.updatePost(this.id, realtimeRooms);
+      await pubSub.updatePost(this.id, realtimeRooms, usersCanSeePostBeforeIds);
 
       return this;
     }

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -53,8 +53,8 @@ export default class pubSub {
     await this.publisher.postDestroyed(payload)
   }
 
-  async updatePost(postId, rooms = null) {
-    const payload = JSON.stringify({ postId, rooms })
+  async updatePost(postId, rooms = null, usersBeforeIds = null) {
+    const payload = JSON.stringify({ postId, rooms, usersBeforeIds })
     await this.publisher.postUpdated(payload)
   }
 

--- a/app/support/EventService.js
+++ b/app/support/EventService.js
@@ -305,7 +305,12 @@ export class EventService {
   }
 
   static async onPostFeedsChanged(post, changedBy, params = {}) {
-    const { removedFeeds = [] } = params;
+    const { addedFeeds = [], removedFeeds = [] } = params;
+
+    if (addedFeeds.length > 0) {
+      const postAuthor = await post.getCreatedBy();
+      await this._processDirectMessagesForPost(post, addedFeeds, postAuthor);
+    }
 
     if (changedBy.id === post.userId || removedFeeds.length === 0) {
       return;

--- a/app/support/open-lists.js
+++ b/app/support/open-lists.js
@@ -1,0 +1,118 @@
+import _ from 'lodash';
+
+/**
+ * List represents a possible open list of items. It can model two situation:
+ * 1. All these items (when 'inclusive' is true);
+ * 2. All items EXCEPT of these (when 'inclusive' is false).
+ */
+export class List {
+  items = [];
+  inclusive = true;
+
+  /**
+   * @param {array} items
+   * @param {boolean} inclusive
+   */
+  constructor(items = [], inclusive = true) {
+    this.items = items;
+    this.inclusive = inclusive;
+  }
+
+  isEmpty() {
+    return this.inclusive && this.items.length === 0;
+  }
+
+  includes(item) {
+    return this.inclusive === this.items.includes(item);
+  }
+}
+
+/**
+ * @param {List|array} list1
+ * @param {List|array} list2
+ * @return {List}
+ */
+export function difference(list1, list2) {
+  if (Array.isArray(list1)) {
+    list1 = new List(list1);
+  }
+  if (Array.isArray(list2)) {
+    list2 = new List(list2);
+  }
+
+  if (list1.inclusive && list2.inclusive) {
+    // [1,2] - [2,3,4] = [1]
+    return new List(_.difference(list1.items, list2.items));
+  } else if (list1.inclusive && !list2.inclusive) {
+    // [1,2] - ^[2,3,4] = [2]
+    return new List(_.intersection(list1.items, list2.items));
+  } else if (!list1.inclusive && list2.inclusive) {
+    // ^[1,2] - [2,3,4] = ^[1,2,3,4]
+    return new List(_.union(list1.items, list2.items), false);
+  } else if (!list1.inclusive && !list2.inclusive) {
+    // ^[1,2] - ^[2,3,4] = [3,4]
+    return new List(_.difference(list2.items, list1.items));
+  }
+  // unreachable
+  return new List();
+}
+
+/**
+ * @param {List|array} list1
+ * @param {List|array} list2
+ * @return {List}
+ */
+export function union(list1, list2) {
+  if (Array.isArray(list1)) {
+    list1 = new List(list1);
+  }
+  if (Array.isArray(list2)) {
+    list2 = new List(list2);
+  }
+
+  if (list1.inclusive && list2.inclusive) {
+    // [1,2] + [2,3,4] = [1,2,3,4]
+    return new List(_.union(list1.items, list2.items));
+  } else if (list1.inclusive && !list2.inclusive) {
+    // [1,2] + ^[2,3,4] = ^[3,4]
+    return new List(_.difference(list2.items, list1.items), false);
+  } else if (!list1.inclusive && list2.inclusive) {
+    // ^[1,2] + [2,3,4] = ^[1]
+    return new List(_.difference(list1.items, list2.items), false);
+  } else if (!list1.inclusive && !list2.inclusive) {
+    // ^[1,2] + ^[2,3,4] = ^[2]
+    return new List(_.intersection(list2.items, list1.items), true);
+  }
+  // unreachable
+  return new List();
+}
+
+/**
+ * @param {List|array} list1
+ * @param {List|array} list2
+ * @return {List}
+ */
+export function intersection(list1, list2) {
+  if (Array.isArray(list1)) {
+    list1 = new List(list1);
+  }
+  if (Array.isArray(list2)) {
+    list2 = new List(list2);
+  }
+
+  if (list1.inclusive && list2.inclusive) {
+    // [1,2] & [2,3,4] = [2]
+    return new List(_.intersection(list1.items, list2.items));
+  } else if (list1.inclusive && !list2.inclusive) {
+    // [1,2] & ^[2,3,4] = [1]
+    return new List(_.difference(list1.items, list2.items));
+  } else if (!list1.inclusive && list2.inclusive) {
+    // ^[1,2] & [2,3,4] = [3,4]
+    return new List(_.difference(list2.items, list1.items));
+  } else if (!list1.inclusive && !list2.inclusive) {
+    // ^[1,2] & ^[2,3,4] = ^[1,2,3,4]
+    return new List(_.union(list2.items, list1.items), true);
+  }
+  // unreachable
+  return new List();
+}

--- a/test/functional/events.js
+++ b/test/functional/events.js
@@ -961,18 +961,6 @@ describe('EventService', () => {
           post_author_id:     lunaUserModel.intId,
         }]);
       });
-
-      it('should not create direct event on semi-direct post (copy to own post feed) creation for direct sender', async () => {
-        await createAndReturnPostToFeed([luna, mars], luna, 'Direct');
-        await expectPostEvents(marsUserModel, [{
-          user_id:            marsUserModel.intId,
-          event_type:         'direct',
-          created_by_user_id: lunaUserModel.intId,
-          target_user_id:     marsUserModel.intId,
-          post_author_id:     lunaUserModel.intId,
-        }]);
-        await expectPostEvents(lunaUserModel, []);
-      });
     });
 
     describe('comments', () => {
@@ -1034,56 +1022,6 @@ describe('EventService', () => {
           event_type:         'direct_comment',
           created_by_user_id: lunaUserModel.intId,
           target_user_id:     plutoUserModel.intId,
-          post_author_id:     lunaUserModel.intId,
-        }, { event_type: 'direct' }]);
-      });
-
-      it('should not create direct_comment event on comment to semi-direct post (copy to own post feed) creation for comment author', async () => {
-        const post = await createAndReturnPostToFeed([luna, mars], luna, 'Direct');
-        await createCommentAsync(luna, post.id, 'Comment');
-        await expectPostEvents(lunaUserModel, []);
-      });
-
-      it('should create direct_comment event on comment to semi-direct post (copy to own post feed) creation', async () => {
-        const post = await createAndReturnPostToFeed([luna, mars], luna, 'Direct');
-        await createCommentAsync(luna, post.id, 'Comment');
-        await expectPostEvents(marsUserModel, [{
-          user_id:            marsUserModel.intId,
-          event_type:         'direct_comment',
-          created_by_user_id: lunaUserModel.intId,
-          target_user_id:     marsUserModel.intId,
-          post_author_id:     lunaUserModel.intId,
-        }, { event_type: 'direct' }]);
-      });
-
-      it('should create direct_comment event on comment to semi-direct post (copy to own post feed) creation', async () => {
-        const post = await createAndReturnPostToFeed([luna, mars], luna, 'Direct');
-        await createCommentAsync(mars, post.id, 'Comment');
-        await expectPostEvents(lunaUserModel, [{
-          user_id:            lunaUserModel.intId,
-          event_type:         'direct_comment',
-          created_by_user_id: marsUserModel.intId,
-          target_user_id:     lunaUserModel.intId,
-          post_author_id:     lunaUserModel.intId,
-        }]);
-        await expectPostEvents(marsUserModel, [{ event_type: 'direct' }]);
-      });
-
-      it('should create direct_comment event on comment to semi-direct post (copy to own post feed) creation by arbitrary user', async () => {
-        const post = await createAndReturnPostToFeed([luna, mars], luna, 'Direct');
-        await createCommentAsync(jupiter, post.id, 'Comment');
-        await expectPostEvents(lunaUserModel, [{
-          user_id:            lunaUserModel.intId,
-          event_type:         'direct_comment',
-          created_by_user_id: jupiterUserModel.intId,
-          target_user_id:     lunaUserModel.intId,
-          post_author_id:     lunaUserModel.intId,
-        }]);
-        await expectPostEvents(marsUserModel, [{
-          user_id:            marsUserModel.intId,
-          event_type:         'direct_comment',
-          created_by_user_id: jupiterUserModel.intId,
-          target_user_id:     marsUserModel.intId,
           post_author_id:     lunaUserModel.intId,
         }, { event_type: 'direct' }]);
       });

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -863,6 +863,14 @@ export async function getUnreadNotificationsNumber(user) {
   return response;
 }
 
+export async function getUnreadDirectsNumber(user) {
+  const response = await postJson('/v2/users/getUnreadDirectsNumber', {
+    authToken: user.authToken,
+    '_method': 'get'
+  });
+  return response;
+}
+
 export async function markAllDirectsAsRead(user) {
   const response = await postJson('/v2/users/markAllDirectsAsRead', {
     authToken: user.authToken,

--- a/test/functional/posts.js
+++ b/test/functional/posts.js
@@ -968,6 +968,87 @@ describe('PostsController', () => {
         data.posts.attachments.should.eql(anotherPost.attachments)
       }
     })
+
+    describe('Destination feeds change', () => {
+      let luna, mars, yole, celestials, evilmartians, post;
+      beforeEach(async () => {
+        [luna, mars, yole] = await funcTestHelper.createTestUsers(3);
+        await funcTestHelper.mutualSubscriptions([luna, mars]);
+        await funcTestHelper.mutualSubscriptions([luna, yole]);
+        celestials = await funcTestHelper.createGroupAsync(luna, 'celestials');
+        evilmartians = await funcTestHelper.createGroupAsync(mars, 'evilmartians');
+      });
+
+      const updatePost = async (postObj, userContext, parameters) => {
+        const res = await funcTestHelper.updatePostAsync({ ...userContext, post: postObj }, parameters);
+        const body = await res.json();
+        if (res.status != 200) {
+          expect.fail(`Error updating post (${res.status}): ${body.err}`);
+        }
+        return body;
+      };
+
+      const postedToUsernames = (postResp) => {
+        const { posts: { postedTo }, subscriptions, subscribers, users } = postResp;
+        return postedTo
+          .map((feedId) => subscriptions.find((feed) => feed.id == feedId).user)
+          .map((userId) => [...users, ...subscribers].find((user) => user.id == userId).username);
+      };
+
+      describe('Luna creates post in their feed', () => {
+        beforeEach(async () => {
+          post = await funcTestHelper.createAndReturnPostToFeed([luna], luna, 'Post body');
+        });
+
+        it('should be able to change destinations of regular post', async () => {
+          let res = await updatePost(post, luna, { feeds: [luna.username, celestials.username] });
+          expect(postedToUsernames(res).sort(), 'to equal', [luna.username, celestials.username].sort());
+
+          res = await updatePost(post, luna, { feeds: [celestials.username] });
+          expect(postedToUsernames(res), 'to equal', [celestials.username]);
+
+          res = await updatePost(post, luna, { feeds: [luna.username] });
+          expect(postedToUsernames(res), 'to equal', [luna.username]);
+        });
+
+        it('should not be able to add a group to post when Luna not in the group', async () => {
+          const call = updatePost(post, luna, { feeds: [luna.username, evilmartians.username] });
+          await expect(call, 'to be rejected with', /\(403\)/);
+        });
+
+        it('should not be able to add a direct recipient to post', async () => {
+          const call = updatePost(post, luna, { feeds: [luna.username, mars.username] });
+          await expect(call, 'to be rejected with', /\(403\)/);
+        });
+      });
+
+      describe('Luna creates direct post', () => {
+        beforeEach(async () => {
+          post = await funcTestHelper.createAndReturnPostToFeed([mars], luna, 'Post body');
+        });
+
+        it('should be able to add recipient to direct post', async () => {
+          const res = await updatePost(post, luna, { feeds: [mars.username, yole.username] });
+          expect(postedToUsernames(res).sort(), 'to equal', [luna.username, mars.username, yole.username].sort());
+        });
+      });
+
+      describe('Luna creates direct post with two recipients', () => {
+        beforeEach(async () => {
+          post = await funcTestHelper.createAndReturnPostToFeed([mars, yole], luna, 'Post body');
+        });
+
+        it('should not be able to remove recipient from direct post', async () => {
+          const call = updatePost(post, luna, { feeds: [mars.username] });
+          await expect(call, 'to be rejected with', /\(403\)/);
+        });
+
+        it('should not be able to add a group as recipient', async () => {
+          const call = updatePost(post, luna, { feeds: [mars.username, yole.username, celestials.username] });
+          await expect(call, 'to be rejected with', /\(403\)/);
+        });
+      });
+    });
   })
 
   describe('#show()', () => {


### PR DESCRIPTION
This PR allows post authors to change the destination feeds of posts. See [RFC](https://docs.google.com/document/d/1GbVQJnE0b4isqzoxtFAkLgLx3gH7kbQakFez_NNCkNs/edit#heading=h.7bzlfbod8nlm) (in russian). The main changes includes:

* “Public directs” are not allowed anymore, post can be either strictly direct or regular post to user feed or groups.
* Post authors can change destionation feeds of post. Regular post must retains regular and direct post must retains direct. Also, the author of the direct post can only invite new participants of the conversation, but not delete the old ones.
* It is possible that after the update of the posts destinations it will become invisible or visible for the some users. Such users are received 'post:destroy' or 'post:new' realtime events instead of 'post:update'.