### PR TITLE
Implement searching for user's posts in group

### DIFF
--- a/app/controllers/api/v2/SearchController.js
+++ b/app/controllers/api/v2/SearchController.js
@@ -2,7 +2,6 @@
 import { dbAdapter } from '../../../models';
 import { NotFoundException, ForbiddenException } from '../../../support/exceptions';
 import { SearchQueryParser } from '../../../support/SearchQueryParser';
-import { SEARCH_SCOPES } from '../../../support/SearchConstants';
 import { serializePostsCollection } from '../../../serializers/v2/post';
 
 
@@ -44,59 +43,48 @@ export default class SearchController {
     const isAnonymous = !ctx.state.user;
     const visibleFeedIds = ctx.state.user ? [await ctx.state.user.getPostsTimelineIntId(), ...ctx.state.user.subscribedFeedIds] : [];
 
-    switch (preparedQuery.scope) {
-      case SEARCH_SCOPES.ALL_VISIBLE_POSTS: {
-        foundPosts = await dbAdapter.searchPosts(preparedQuery, currentUserId, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit);
-        break;
+    if (preparedQuery.group) {
+      targetGroup = await dbAdapter.getGroupByUsername(preparedQuery.group);
+
+      if (!targetGroup) {
+        throw new NotFoundException(`Group "${preparedQuery.group}" is not found`);
       }
 
-      case SEARCH_SCOPES.VISIBLE_USER_POSTS: {
-        if (preparedQuery.username === 'me') {
-          throw new NotFoundException(`Please sign in to use 'from:me' operator`);
-        }
+      const groupPostsFeedId = await targetGroup.getPostsTimelineId();
+      isSubscribed           = await dbAdapter.isUserSubscribedToTimeline(currentUserId, groupPostsFeedId);
 
-        targetUser = await dbAdapter.getUserByUsername(preparedQuery.username);
-
-        if (!targetUser) {
-          throw new NotFoundException(`User "${preparedQuery.username}" is not found`);
-        }
-
-        if (isAnonymous && targetUser.isProtected === '1') {
-          throw new ForbiddenException(`Please sign in to view user "${preparedQuery.username}"`);
-        }
-
-        if (targetUser.id != currentUserId) {
-          const userPostsFeedId = await targetUser.getPostsTimelineId();
-          isSubscribed          = await dbAdapter.isUserSubscribedToTimeline(currentUserId, userPostsFeedId);
-
-          if (!isSubscribed && targetUser.isPrivate == '1') {
-            throw new ForbiddenException(`You are not subscribed to user "${preparedQuery.username}"`);
-          }
-        }
-
-        foundPosts = await dbAdapter.searchUserPosts(preparedQuery, targetUser.id, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit);
-
-        break;
+      if (!isSubscribed && targetGroup.isPrivate == '1') {
+        throw new ForbiddenException(`You are not subscribed to group "${preparedQuery.group}"`);
       }
 
-      case SEARCH_SCOPES.VISIBLE_GROUP_POSTS: {
-        targetGroup = await dbAdapter.getGroupByUsername(preparedQuery.group);
-
-        if (!targetGroup) {
-          throw new NotFoundException(`Group "${preparedQuery.group}" is not found`);
-        }
-
-        const groupPostsFeedId = await targetGroup.getPostsTimelineId();
-        isSubscribed           = await dbAdapter.isUserSubscribedToTimeline(currentUserId, groupPostsFeedId);
-
-        if (!isSubscribed && targetGroup.isPrivate == '1') {
-          throw new ForbiddenException(`You are not subscribed to group "${preparedQuery.group}"`);
-        }
-
-        foundPosts = await dbAdapter.searchGroupPosts(preparedQuery, groupPostsFeedId, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit);
-
-        break;
+      foundPosts = await dbAdapter.searchGroupPosts(preparedQuery, groupPostsFeedId, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit);
+    } else if (preparedQuery.username) {
+      if (preparedQuery.username === 'me') {
+        throw new NotFoundException(`Please sign in to use 'from:me' operator`);
       }
+
+      targetUser = await dbAdapter.getUserByUsername(preparedQuery.username);
+
+      if (!targetUser) {
+        throw new NotFoundException(`User "${preparedQuery.username}" is not found`);
+      }
+
+      if (isAnonymous && targetUser.isProtected === '1') {
+        throw new ForbiddenException(`Please sign in to view user "${preparedQuery.username}"`);
+      }
+
+      if (targetUser.id != currentUserId) {
+        const userPostsFeedId = await targetUser.getPostsTimelineId();
+        isSubscribed          = await dbAdapter.isUserSubscribedToTimeline(currentUserId, userPostsFeedId);
+
+        if (!isSubscribed && targetUser.isPrivate == '1') {
+          throw new ForbiddenException(`You are not subscribed to user "${preparedQuery.username}"`);
+        }
+      }
+
+      foundPosts = await dbAdapter.searchUserPosts(preparedQuery, targetUser.id, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit);
+    } else {
+      foundPosts = await dbAdapter.searchPosts(preparedQuery, currentUserId, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit);
     }
 
     const isLastPage = foundPosts.length <= requestedLimit;

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -157,8 +157,14 @@ const searchTrait = (superClass) => class extends superClass {
       subQueries = [...subQueries, visiblePrivatePostsSubQuery, visiblePrivatePostsByCommentsSubQuery];
     }
 
+    let authorCondition = '';
+
+    if (authorId) {
+      authorCondition = `WHERE "found_posts"."user_id"='${authorId}'`;
+    }
+
     const res = await this.database.raw(
-      `select * from (${subQueries.join(' union ')}) as found_posts order by found_posts.bumped_at desc offset ${offset} limit ${limit}`
+      `select * from (${subQueries.join(' union ')}) as found_posts ${authorCondition} order by found_posts.bumped_at desc offset ${offset} limit ${limit}`
     );
     return res.rows;
   }

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -113,7 +113,7 @@ const searchTrait = (superClass) => class extends superClass {
     return res.rows;
   }
 
-  async searchGroupPosts(query, groupFeedId, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit) {
+  async searchGroupPosts(query, groupFeedId, authorId, visibleFeedIds, bannedUserIds, feedIntIdsBannedForUser, offset, limit) {
     const { textSearchConfigName } = this.database.client.config;
     const bannedUsersFilter = this._getPostsFromBannedUsersSearchFilterCondition(bannedUserIds, feedIntIdsBannedForUser);
     const bannedCommentAuthorFilter = this._getCommentsFromBannedUsersSearchFilterCondition(bannedUserIds);

--- a/app/support/SearchConstants.js
+++ b/app/support/SearchConstants.js
@@ -1,5 +1,0 @@
-export const SEARCH_SCOPES = {
-  ALL_VISIBLE_POSTS:   'default_search',
-  VISIBLE_GROUP_POSTS: 'group_posts',
-  VISIBLE_USER_POSTS:  'user_posts'
-}

--- a/app/support/SearchQueryParser.js
+++ b/app/support/SearchQueryParser.js
@@ -1,7 +1,7 @@
 /* eslint babel/semi: "error" */
 import { flow } from 'lodash';
+
 import { extractHashtagsWithIndices } from './hashtags';
-import { SEARCH_SCOPES } from './SearchConstants';
 
 
 const FROM_USERNAME_PATTERN             = 'from:\\s*(me|[A-Za-z0-9]{3,25})';
@@ -22,7 +22,6 @@ export class SearchQueryParser {
     query = decodeURIComponent(query);
 
     const parseResult = {
-      scope:    SEARCH_SCOPES.ALL_VISIBLE_POSTS,
       query,
       username: '',
       group:    '',
@@ -46,13 +45,11 @@ export class SearchQueryParser {
     }
 
     if (targetUsername) {
-      queryObject.scope = SEARCH_SCOPES.VISIBLE_USER_POSTS;
       queryObject.username = targetUsername;
       return;
     }
 
     if (targetGroupname) {
-      queryObject.scope = SEARCH_SCOPES.VISIBLE_GROUP_POSTS;
       queryObject.group = targetGroupname;
     }
   }

--- a/app/support/SearchQueryParser.js
+++ b/app/support/SearchQueryParser.js
@@ -46,7 +46,6 @@ export class SearchQueryParser {
 
     if (targetUsername) {
       queryObject.username = targetUsername;
-      return;
     }
 
     if (targetGroupname) {

--- a/test/functional/search.js
+++ b/test/functional/search.js
@@ -15,16 +15,15 @@ describe('SearchController', () => {
   before(async () => {
     await getSingleton();
     PubSub.setPublisher(new DummyPublisher());
+    await cleanDB($pg_database);
   });
-
-  beforeEach(() => cleanDB($pg_database));
 
   describe('#search()', () => {
     let lunaContext = {};
     let marsContext = {};
     const anonContext = {};
 
-    beforeEach(async () => {
+    before(async () => {
       [lunaContext, marsContext] = await Promise.all([
         funcTestHelper.createUserAsync('luna', 'pw'),
         funcTestHelper.createUserAsync('mars', 'pw')
@@ -78,7 +77,7 @@ describe('SearchController', () => {
     });
 
     describe('Luna is private', () => {
-      beforeEach(async () => {
+      before(async () => {
         await funcTestHelper.goPrivate(lunaContext);
       });
 

--- a/test/functional/search.js
+++ b/test/functional/search.js
@@ -1,6 +1,8 @@
 /* eslint-env node, mocha */
 /* global $pg_database */
 /* eslint babel/semi: "error" */
+import expect from 'unexpected';
+
 import cleanDB from '../dbCleaner';
 
 import { getSingleton } from '../../app/app';
@@ -37,59 +39,42 @@ describe('SearchController', () => {
 
     it('should search posts', async () => {
       const response = await funcTestHelper.performSearch(anonContext, 'hello');
-      response.should.not.be.empty;
-      response.should.have.property('posts');
-      response.posts.length.should.be.eql(2);
+      expect(response, 'to satisfy', { posts: [{}, {}] });
     });
 
     it('should search user\'s posts', async () => {
       const response = await funcTestHelper.performSearch(anonContext, 'from:luna hello');
-      response.should.not.be.empty;
-      response.should.have.property('posts');
-      response.posts.length.should.be.eql(1);
-      response.posts[0].body.should.be.eql('hello from luna');
+      expect(response, 'to satisfy', { posts: [{ body: 'hello from luna' }] });
     });
 
     it('should search own posts with from:me', async () => {
       const response = await funcTestHelper.performSearch(lunaContext, 'from:me hello');
-      response.should.not.be.empty;
-      response.should.have.property('posts');
-      response.posts.length.should.be.eql(1);
-      response.posts[0].body.should.be.eql('hello from luna');
+      expect(response, 'to satisfy', { posts: [{ body: 'hello from luna' }] });
     });
 
     it('should not search anonymously with from:me', async () => {
       const response = await funcTestHelper.performSearch(anonContext, 'from:me hello');
-      response.should.not.be.empty;
-      response.should.have.property('err');
+      expect(response, 'to have key', 'err');
     });
 
     it('should search hashtags with different casing', async () => {
       const response = await funcTestHelper.performSearch(anonContext, '#hashtaga');
-      response.should.not.be.empty;
-      response.should.have.property('posts');
-      response.posts.length.should.be.eql(2);
+      expect(response, 'to satisfy', { posts: [{}, {}] });
     });
 
     it('should return first page with isLastPage = false', async () => {
       const response = await funcTestHelper.performSearch(anonContext, 'from luna', { limit: 2, offset: 0 });
-      response.should.not.be.empty;
-      response.should.have.property('isLastPage');
-      response.isLastPage.should.be.eql(false);
+      expect(response, 'to satisfy', { isLastPage: false });
     });
 
     it('should return last page with isLastPage = true', async () => {
       const response = await funcTestHelper.performSearch(anonContext, 'from luna', { limit: 2, offset: 2 });
-      response.should.not.be.empty;
-      response.should.have.property('isLastPage');
-      response.isLastPage.should.be.eql(true);
+      expect(response, 'to satisfy', { isLastPage: true });
     });
 
     it('should return the only page with isLastPage = true', async () => {
       const response = await funcTestHelper.performSearch(anonContext, 'from luna');
-      response.should.not.be.empty;
-      response.should.have.property('isLastPage');
-      response.isLastPage.should.be.eql(true);
+      expect(response, 'to satisfy', { isLastPage: true });
     });
 
     describe('Luna is private', () => {
@@ -99,18 +84,12 @@ describe('SearchController', () => {
 
       it(`should search user's posts`, async () => {
         const response = await funcTestHelper.performSearch(lunaContext, 'from:luna hello');
-        response.should.not.be.empty;
-        response.should.have.property('posts');
-        response.posts.length.should.be.eql(1);
-        response.posts[0].body.should.be.eql('hello from luna');
+        expect(response, 'to satisfy', { posts: [{ body: 'hello from luna' }] });
       });
 
       it('should search own posts with from:me', async () => {
         const response = await funcTestHelper.performSearch(lunaContext, 'from:me hello');
-        response.should.not.be.empty;
-        response.should.have.property('posts');
-        response.posts.length.should.be.eql(1);
-        response.posts[0].body.should.be.eql('hello from luna');
+        expect(response, 'to satisfy', { posts: [{ body: 'hello from luna' }] });
       });
     });
   });

--- a/test/functional/search.js
+++ b/test/functional/search.js
@@ -1,95 +1,96 @@
 /* eslint-env node, mocha */
 /* global $pg_database */
-import cleanDB from '../dbCleaner'
+/* eslint babel/semi: "error" */
+import cleanDB from '../dbCleaner';
 
-import { getSingleton } from '../../app/app'
-import { DummyPublisher } from '../../app/pubsub'
-import { PubSub } from '../../app/models'
-import * as funcTestHelper from './functional_test_helper'
+import { getSingleton } from '../../app/app';
+import { DummyPublisher } from '../../app/pubsub';
+import { PubSub } from '../../app/models';
+import * as funcTestHelper from './functional_test_helper';
 
 
 describe('SearchController', () => {
   before(async () => {
-    await getSingleton()
-    PubSub.setPublisher(new DummyPublisher())
-  })
+    await getSingleton();
+    PubSub.setPublisher(new DummyPublisher());
+  });
 
-  beforeEach(() => cleanDB($pg_database))
+  beforeEach(() => cleanDB($pg_database));
 
   describe('#search()', () => {
-    let lunaContext = {}
-    let marsContext = {}
-    const anonContext = {}
+    let lunaContext = {};
+    let marsContext = {};
+    const anonContext = {};
 
     beforeEach(async () => {
       [lunaContext, marsContext] = await Promise.all([
         funcTestHelper.createUserAsync('luna', 'pw'),
         funcTestHelper.createUserAsync('mars', 'pw')
-      ])
+      ]);
       await Promise.all([
         funcTestHelper.createPostWithCommentsDisabled(lunaContext, 'hello from luna', false),
         funcTestHelper.createPostWithCommentsDisabled(lunaContext, '#hashTagA from luna', false),
         funcTestHelper.createPostWithCommentsDisabled(marsContext, 'hello from mars', false)
-      ])
-      await funcTestHelper.createPostWithCommentsDisabled(lunaContext, '#hashtaga from luna again', false)
-    })
+      ]);
+      await funcTestHelper.createPostWithCommentsDisabled(lunaContext, '#hashtaga from luna again', false);
+    });
 
     it('should search posts', async () => {
-      const response = await funcTestHelper.performSearch(anonContext, 'hello')
-      response.should.not.be.empty
-      response.should.have.property('posts')
-      response.posts.length.should.be.eql(2)
-    })
+      const response = await funcTestHelper.performSearch(anonContext, 'hello');
+      response.should.not.be.empty;
+      response.should.have.property('posts');
+      response.posts.length.should.be.eql(2);
+    });
 
     it('should search user\'s posts', async () => {
-      const response = await funcTestHelper.performSearch(anonContext, 'from:luna hello')
-      response.should.not.be.empty
-      response.should.have.property('posts')
-      response.posts.length.should.be.eql(1)
-      response.posts[0].body.should.be.eql('hello from luna')
-    })
+      const response = await funcTestHelper.performSearch(anonContext, 'from:luna hello');
+      response.should.not.be.empty;
+      response.should.have.property('posts');
+      response.posts.length.should.be.eql(1);
+      response.posts[0].body.should.be.eql('hello from luna');
+    });
 
     it('should search own posts with from:me', async () => {
-      const response = await funcTestHelper.performSearch(lunaContext, 'from:me hello')
-      response.should.not.be.empty
-      response.should.have.property('posts')
-      response.posts.length.should.be.eql(1)
-      response.posts[0].body.should.be.eql('hello from luna')
-    })
+      const response = await funcTestHelper.performSearch(lunaContext, 'from:me hello');
+      response.should.not.be.empty;
+      response.should.have.property('posts');
+      response.posts.length.should.be.eql(1);
+      response.posts[0].body.should.be.eql('hello from luna');
+    });
 
     it('should not search anonymously with from:me', async () => {
-      const response = await funcTestHelper.performSearch(anonContext, 'from:me hello')
-      response.should.not.be.empty
-      response.should.have.property('err')
-    })
+      const response = await funcTestHelper.performSearch(anonContext, 'from:me hello');
+      response.should.not.be.empty;
+      response.should.have.property('err');
+    });
 
     it('should search hashtags with different casing', async () => {
-      const response = await funcTestHelper.performSearch(anonContext, '#hashtaga')
-      response.should.not.be.empty
-      response.should.have.property('posts')
-      response.posts.length.should.be.eql(2)
-    })
+      const response = await funcTestHelper.performSearch(anonContext, '#hashtaga');
+      response.should.not.be.empty;
+      response.should.have.property('posts');
+      response.posts.length.should.be.eql(2);
+    });
 
     it('should return first page with isLastPage = false', async () => {
-      const response = await funcTestHelper.performSearch(anonContext, 'from luna', { limit: 2, offset: 0 })
-      response.should.not.be.empty
-      response.should.have.property('isLastPage')
-      response.isLastPage.should.be.eql(false)
-    })
+      const response = await funcTestHelper.performSearch(anonContext, 'from luna', { limit: 2, offset: 0 });
+      response.should.not.be.empty;
+      response.should.have.property('isLastPage');
+      response.isLastPage.should.be.eql(false);
+    });
 
     it('should return last page with isLastPage = true', async () => {
-      const response = await funcTestHelper.performSearch(anonContext, 'from luna', { limit: 2, offset: 2 })
-      response.should.not.be.empty
-      response.should.have.property('isLastPage')
-      response.isLastPage.should.be.eql(true)
-    })
+      const response = await funcTestHelper.performSearch(anonContext, 'from luna', { limit: 2, offset: 2 });
+      response.should.not.be.empty;
+      response.should.have.property('isLastPage');
+      response.isLastPage.should.be.eql(true);
+    });
 
     it('should return the only page with isLastPage = true', async () => {
-      const response = await funcTestHelper.performSearch(anonContext, 'from luna')
-      response.should.not.be.empty
-      response.should.have.property('isLastPage')
-      response.isLastPage.should.be.eql(true)
-    })
+      const response = await funcTestHelper.performSearch(anonContext, 'from luna');
+      response.should.not.be.empty;
+      response.should.have.property('isLastPage');
+      response.isLastPage.should.be.eql(true);
+    });
 
     describe('Luna is private', () => {
       beforeEach(async () => {
@@ -112,5 +113,5 @@ describe('SearchController', () => {
         response.posts[0].body.should.be.eql('hello from luna');
       });
     });
-  })
+  });
 });

--- a/test/functional/search.js
+++ b/test/functional/search.js
@@ -91,5 +91,21 @@ describe('SearchController', () => {
         expect(response, 'to satisfy', { posts: [{ body: 'hello from luna' }] });
       });
     });
+
+    describe('There is a group', () => {
+      before(async () => {
+        const group = await funcTestHelper.createGroupAsync(lunaContext, 'lunagroup');
+        await funcTestHelper.subscribeToAsync(marsContext, group);
+        await Promise.all([
+          funcTestHelper.createAndReturnPostToFeed(group, lunaContext, 'hello from luna'),
+          funcTestHelper.createAndReturnPostToFeed(group, marsContext, 'hello from mars'),
+        ]);
+      });
+
+      it('should find only post to group', async () => {
+        await expect(funcTestHelper.performSearch(anonContext, 'from:luna group:lunagroup hello'), 'when fulfilled', 'to satisfy', { posts: [{ body: 'hello from luna' }] });
+        await expect(funcTestHelper.performSearch(lunaContext, 'from:me group:lunagroup hello'), 'when fulfilled', 'to satisfy', { posts: [{ body: 'hello from luna' }] });
+      });
+    });
   });
 });

--- a/test/integration/support/DbAdapter/search.js
+++ b/test/integration/support/DbAdapter/search.js
@@ -639,65 +639,63 @@ describe('FullTextSearch', () => {
         return dbAdapter.searchUserPosts(query, (await targetUserPromise).id, [], await bannedUserIdsPromise, await feedsBannedForUser, 0, 30);
       };
 
-      describe('full text search', () => {
-        it('should not find post from banned user', async () => {
-          await _createPost(mars, 'Lazy green fox jumps over the #lazy dog');
-          await luna.ban('mars');
+      it('should not find post from banned user', async () => {
+        await _createPost(mars, 'Lazy green fox jumps over the #lazy dog');
+        await luna.ban('mars');
 
-          await Promise.all([
-            expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
-          ]);
-        });
+        await Promise.all([
+          expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
+        ]);
+      });
 
-        it("should not find post from banned user by banned user's comment match", async () => {
-          const post = await _createPost(mars, 'Lazy sloth');
-          await _createComment(mars, 'Lazy green fox jumps over the #lazy dog', post);
-          await luna.ban('mars');
+      it("should not find post from banned user by banned user's comment match", async () => {
+        const post = await _createPost(mars, 'Lazy sloth');
+        await _createComment(mars, 'Lazy green fox jumps over the #lazy dog', post);
+        await luna.ban('mars');
 
-          await Promise.all([
-            expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
-          ]);
-        });
+        await Promise.all([
+          expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
+        ]);
+      });
 
-        it("should not find post from banned user by other user's comment match", async () => {
-          const post = await _createPost(mars, 'Lazy sloth');
-          await _createComment(jupiter, 'Very #lazy fox', post);
-          await luna.ban('mars');
+      it("should not find post from banned user by other user's comment match", async () => {
+        const post = await _createPost(mars, 'Lazy sloth');
+        await _createComment(jupiter, 'Very #lazy fox', post);
+        await luna.ban('mars');
 
-          await Promise.all([
-            expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
-          ]);
-        });
+        await Promise.all([
+          expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
+        ]);
+      });
 
-        it("should not find post from banned user by viewer's comment match", async () => {
-          const post = await _createPost(mars, 'Lazy sloth');
-          await _createComment(luna, 'Very #lazy fox', post);
-          await luna.ban('mars');
+      it("should not find post from banned user by viewer's comment match", async () => {
+        const post = await _createPost(mars, 'Lazy sloth');
+        await _createComment(luna, 'Very #lazy fox', post);
+        await luna.ban('mars');
 
-          await Promise.all([
-            expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
-          ]);
-        });
+        await Promise.all([
+          expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
+        ]);
+      });
 
-        it("should not find visible post by banned user's comment match", async () => {
-          const post = await _createPost(jupiter, 'Lazy sloth');
-          await _createComment(mars, 'Very #lazy fox', post);
-          await luna.ban('mars');
+      it("should not find visible post by banned user's comment match", async () => {
+        const post = await _createPost(jupiter, 'Lazy sloth');
+        await _createComment(mars, 'Very #lazy fox', post);
+        await luna.ban('mars');
 
-          await Promise.all([
-            expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
-            expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
-          ]);
-        });
+        await Promise.all([
+          expect(_searchPublicUserPosts('from: mars fox', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars "fox"', luna), 'when fulfilled', 'to have length', 0),
+          expect(_searchPublicUserPosts('from: mars #lazy', luna), 'when fulfilled', 'to have length', 0),
+        ]);
       });
     });
 
@@ -966,10 +964,10 @@ describe('FullTextSearch', () => {
   });
 
   describe('group post search', () => {
-    let luna, mars, jupiter, post;
+    let luna, mars, jupiter;
 
     const _createGroupPost = async (author, groupPostsFeedId, text) => {
-      post = await author.newPost({ body: text, timelineIds: [groupPostsFeedId] });
+      const post = await author.newPost({ body: text, timelineIds: [groupPostsFeedId] });
       return post.create();
     };
 
@@ -987,17 +985,20 @@ describe('FullTextSearch', () => {
       mars = new User({ username: 'Mars', password: 'password' });
       jupiter = new User({ username: 'Jupiter', password: 'password' });
 
-      await luna.create();
-      await mars.create();
-      await jupiter.create();
+      await Promise.all([
+        luna.create(),
+        mars.create(),
+        jupiter.create(),
+      ]);
     });
 
     describe('public posts search with specified group', () => {
-      let group, groupTimelineId;
+      let groupTimelineId;
 
       beforeEach(async () => {
-        group = new Group({ username: 'search-dev' });
+        const group = new Group({ username: 'search-dev' });
         await group.create(luna.id, false);
+
         groupTimelineId = await group.getPostsTimelineId();
         return mars.subscribeTo(group);
       });
@@ -1012,139 +1013,66 @@ describe('FullTextSearch', () => {
         return dbAdapter.searchGroupPosts(query, groupPostsFeedId, null, [], bannedUserIds, await feedsBannedForUser, 0, 30);
       };
 
-      describe('full text search', () => {
-        it('should find post in specified group', async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
+      it('should find post in specified group', async () => {
+        const post = await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the #lazy dog');
 
-          const searchResults = await _searchPublicGroupPosts('group: search-dev fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
-
-        it('should find post in specified group by comment match', async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-          await _createComment(mars, 'Lazy green fox jumps over the lazy dog', post);
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
-
-        it("should find post in specified group by viewer's comment match", async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-          await _createComment(luna, 'Very lazy fox', post);
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
-
-        it('should find post only in specified group', async () => {
-          const group2 = new Group({ username: 'search-dev2' });
-          await group2.create(luna.id, false);
-          const group2TimelineId = await group2.getPostsTimelineId();
-          await mars.subscribeTo(group2);
-
-          await _createGroupPost(mars, group2TimelineId, 'Lazy green fox jumps over the lazy pig');
-          await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
+        await expect(_searchPublicGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
       });
 
-      describe('exact match search', () => {
-        it('should find post in specified group', async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
+      it('should find post in specified group by comment match', async () => {
+        const post = await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
+        await _createComment(mars, 'Lazy green fox jumps over the #lazy dog', post);
 
-          const searchResults = await _searchPublicGroupPosts('group: search-dev "fox"', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
-
-        it('should find post in specified group by comment match', async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-          await _createComment(mars, 'Lazy green fox jumps over the lazy dog', post);
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev "fox"', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
-
-        it("should find post in specified group by viewer's comment match", async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-          await _createComment(luna, 'Very lazy fox', post);
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev "fox"', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
-
-        it('should find post only in specified group', async () => {
-          const group2 = new Group({ username: 'search-dev2' });
-          await group2.create(luna.id, false);
-          const group2TimelineId = await group2.getPostsTimelineId();
-          await mars.subscribeTo(group2);
-
-          await _createGroupPost(mars, group2TimelineId, 'Lazy green fox jumps over the lazy pig');
-          await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev "fox"', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
+        await expect(_searchPublicGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
       });
 
-      describe('hashtag search', () => {
-        it('should find post in specified group', async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy green #fox jumps over the lazy dog');
+      it("should find post in specified group by viewer's comment match", async () => {
+        const post = await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
+        await _createComment(luna, 'Very #lazy fox', post);
 
-          const searchResults = await _searchPublicGroupPosts('group: search-dev #fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
+        await expect(_searchPublicGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+      });
 
-        it('should find post in specified group by comment match', async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-          await _createComment(mars, 'Lazy green #fox jumps over the lazy dog', post);
+      it('should find post only in specified group', async () => {
+        const group2 = new Group({ username: 'search-dev2' });
+        await group2.create(luna.id, false);
+        const group2TimelineId = await group2.getPostsTimelineId();
+        await mars.subscribeTo(group2);
 
-          const searchResults = await _searchPublicGroupPosts('group: search-dev #fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
+        await _createGroupPost(mars, group2TimelineId, 'Lazy green fox jumps over the #lazy pig');
+        const post = await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the #lazy dog');
 
-        it("should find post in specified group by viewer's comment match", async () => {
-          await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-          await _createComment(luna, 'Very lazy #fox', post);
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev #fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
-
-        it('should find post only in specified group', async () => {
-          const group2 = new Group({ username: 'search-dev2' });
-          await group2.create(luna.id, false);
-          const group2TimelineId = await group2.getPostsTimelineId();
-          await mars.subscribeTo(group2);
-
-          await _createGroupPost(mars, group2TimelineId, 'Lazy green #fox jumps over the lazy pig');
-          await _createGroupPost(mars, groupTimelineId, 'Lazy green #fox jumps over the lazy dog');
-
-          const searchResults = await _searchPublicGroupPosts('group: search-dev #fox', luna);
-          searchResults.length.should.eql(1);
-          searchResults[0].body.should.eql(post.body);
-        });
+        await expect(_searchPublicGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        await expect(_searchPublicGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+          .and('when fulfilled', 'to have an item satisfying', { body: post.body });
       });
     });
 
     describe('private posts search with specified group', () => {
-      let group, groupTimelineId;
+      let groupTimelineId;
 
       beforeEach(async () => {
-        group = new Group({ username: 'search-dev', isPrivate: '1' });
+        const group = new Group({ username: 'search-dev', isPrivate: '1' });
         await group.create(luna.id, false);
+
         groupTimelineId = await group.getPostsTimelineId();
         return mars.subscribeTo(group);
       });
@@ -1160,189 +1088,77 @@ describe('FullTextSearch', () => {
         return dbAdapter.searchGroupPosts(query, groupPostsFeedId, null, visibleFeedIds, bannedUserIds, await feedsBannedForUser, 0, 30);
       };
 
-      describe('full text search', () => {
-        describe('for group subscribers', () => {
-          it('should find post in specified group', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
+      describe('for group subscribers', () => {
+        it('should find post in specified group', async () => {
+          const post = await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the #lazy dog');
 
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it('should find post in specified group by comment match', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(mars, 'Lazy green fox jumps over the lazy dog', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it("should find post in specified group by viewer's comment match", async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(luna, 'Very lazy fox', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it('should find post only in specified group', async () => {
-            const group2 = new Group({ username: 'search-dev2' });
-            await group2.create(luna.id, false);
-            const group2TimelineId = await group2.getPostsTimelineId();
-            await mars.subscribeTo(group2);
-            await jupiter.subscribeTo(group2);
-
-            await _createGroupPost(mars, group2TimelineId, 'Lazy green fox jumps over the lazy pig');
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
+          await expect(_searchPrivateGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
         });
 
-        describe('for non-subscribers', () => {
-          it('should not find post in specified group', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
+        it('should find post in specified group by comment match', async () => {
+          const post = await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
+          await _createComment(mars, 'Lazy green fox jumps over the #lazy dog', post);
 
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev fox', jupiter);
-            searchResults.length.should.eql(0);
-          });
+          await expect(_searchPrivateGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        });
 
-          it('should not find post in specified group by comment match', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(mars, 'Lazy green fox jumps over the lazy dog', post);
+        it("should find post in specified group by viewer's comment match", async () => {
+          const post = await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
+          await _createComment(luna, 'Very #lazy fox', post);
 
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev fox', jupiter);
-            searchResults.length.should.eql(0);
-          });
+          await expect(_searchPrivateGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+        });
+
+        it('should find post only in specified group', async () => {
+          const group2 = new Group({ username: 'search-dev2' });
+          await group2.create(luna.id, false);
+          const group2TimelineId = await group2.getPostsTimelineId();
+          await mars.subscribeTo(group2);
+          await jupiter.subscribeTo(group2);
+
+          await _createGroupPost(mars, group2TimelineId, 'Lazy green fox jumps over the #lazy pig');
+          const post = await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the #lazy dog');
+
+          await expect(_searchPrivateGroupPosts('group: search-dev fox', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev "fox"', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
+          await expect(_searchPrivateGroupPosts('group: search-dev #lazy', luna), 'when fulfilled', 'to have length', 1)
+            .and('when fulfilled', 'to have an item satisfying', { body: post.body });
         });
       });
 
-      describe('exact match search', () => {
-        describe('for group subscribers', () => {
-          it('should find post in specified group', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
+      describe('for non-subscribers', () => {
+        it('should not find post in specified group', async () => {
+          await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the #lazy dog');
 
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev "fox"', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it('should find post in specified group by comment match', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(mars, 'Lazy green fox jumps over the lazy dog', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev "fox"', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it("should find post in specified group by viewer's comment match", async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(luna, 'Very lazy fox', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev "fox"', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it('should find post only in specified group', async () => {
-            const group2 = new Group({ username: 'search-dev2' });
-            await group2.create(luna.id, false);
-            const group2TimelineId = await group2.getPostsTimelineId();
-            await mars.subscribeTo(group2);
-            await jupiter.subscribeTo(group2);
-
-            await _createGroupPost(mars, group2TimelineId, 'Lazy green fox jumps over the lazy pig');
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev "fox"', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
+          await expect(_searchPrivateGroupPosts('group: search-dev fox', jupiter), 'when fulfilled', 'to have length', 0);
+          await expect(_searchPrivateGroupPosts('group: search-dev "fox"', jupiter), 'when fulfilled', 'to have length', 0);
+          await expect(_searchPrivateGroupPosts('group: search-dev #lazy', jupiter), 'when fulfilled', 'to have length', 0);
         });
 
-        describe('for non-subscribers', () => {
-          it('should not find post in specified group', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green fox jumps over the lazy dog');
+        it('should not find post in specified group by comment match', async () => {
+          const post = await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
+          await _createComment(mars, 'Lazy green fox jumps over the #lazy dog', post);
 
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev "fox"', jupiter);
-            searchResults.length.should.eql(0);
-          });
-
-          it('should not find post in specified group by comment match', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(mars, 'Lazy green fox jumps over the lazy dog', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev "fox"', jupiter);
-            searchResults.length.should.eql(0);
-          });
-        });
-      });
-
-      describe('hashtag search', () => {
-        describe('for group subscribers', () => {
-          it('should find post in specified group', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green #fox jumps over the lazy dog');
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev #fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it('should find post in specified group by comment match', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(mars, 'Lazy green #fox jumps over the lazy dog', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev #fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it("should find post in specified group by viewer's comment match", async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(luna, 'Very lazy #fox', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev #fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-
-          it('should find post only in specified group', async () => {
-            const group2 = new Group({ username: 'search-dev2' });
-            await group2.create(luna.id, false);
-            const group2TimelineId = await group2.getPostsTimelineId();
-            await mars.subscribeTo(group2);
-            await jupiter.subscribeTo(group2);
-
-            await _createGroupPost(mars, group2TimelineId, 'Lazy green #fox jumps over the lazy pig');
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green #fox jumps over the lazy dog');
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev #fox', luna);
-            searchResults.length.should.eql(1);
-            searchResults[0].body.should.eql(post.body);
-          });
-        });
-
-        describe('for non-subscribers', () => {
-          it('should not find post in specified group', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy green #fox jumps over the lazy dog');
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev #fox', jupiter);
-            searchResults.length.should.eql(0);
-          });
-
-          it('should not find post in specified group by comment match', async () => {
-            await _createGroupPost(mars, groupTimelineId, 'Lazy sloth');
-            await _createComment(mars, 'Lazy green #fox jumps over the lazy dog', post);
-
-            const searchResults = await _searchPrivateGroupPosts('group: search-dev #fox', jupiter);
-            searchResults.length.should.eql(0);
-          });
+          await expect(_searchPrivateGroupPosts('group: search-dev fox', jupiter), 'when fulfilled', 'to have length', 0);
+          await expect(_searchPrivateGroupPosts('group: search-dev "fox"', jupiter), 'when fulfilled', 'to have length', 0);
+          await expect(_searchPrivateGroupPosts('group: search-dev #lazy', jupiter), 'when fulfilled', 'to have length', 0);
         });
       });
     });

--- a/test/integration/support/DbAdapter/search.js
+++ b/test/integration/support/DbAdapter/search.js
@@ -809,7 +809,7 @@ describe('FullTextSearch', () => {
         const targetGroup = await dbAdapter.getGroupByUsername(query.group);
         const groupPostsFeedId = await targetGroup.getPostsTimelineId();
 
-        return dbAdapter.searchGroupPosts(query, groupPostsFeedId, [], await bannedUserIdsPromise, await feedsBannedForUser, 0, 30);
+        return dbAdapter.searchGroupPosts(query, groupPostsFeedId, null, [], await bannedUserIdsPromise, await feedsBannedForUser, 0, 30);
       };
 
       it('should not find post from banned user', async () => {
@@ -895,6 +895,7 @@ describe('FullTextSearch', () => {
         return dbAdapter.searchGroupPosts(
           query,
           groupPostsFeedId,
+          null,
           (await refetchedUserPromise).subscribedFeedIds,
           await bannedUserIdsPromise,
           await feedsBannedForUser,
@@ -1008,7 +1009,7 @@ describe('FullTextSearch', () => {
         const query = SearchQueryParser.parse(term);
         const targetGroup = await dbAdapter.getGroupByUsername(query.group);
         const groupPostsFeedId = await targetGroup.getPostsTimelineId();
-        return dbAdapter.searchGroupPosts(query, groupPostsFeedId, [], bannedUserIds, await feedsBannedForUser, 0, 30);
+        return dbAdapter.searchGroupPosts(query, groupPostsFeedId, null, [], bannedUserIds, await feedsBannedForUser, 0, 30);
       };
 
       describe('full text search', () => {
@@ -1156,7 +1157,7 @@ describe('FullTextSearch', () => {
         const query = SearchQueryParser.parse(term);
         const targetGroup = await dbAdapter.getGroupByUsername(query.group);
         const groupPostsFeedId = await targetGroup.getPostsTimelineId();
-        return dbAdapter.searchGroupPosts(query, groupPostsFeedId, visibleFeedIds, bannedUserIds, await feedsBannedForUser, 0, 30);
+        return dbAdapter.searchGroupPosts(query, groupPostsFeedId, null, visibleFeedIds, bannedUserIds, await feedsBannedForUser, 0, 30);
       };
 
       describe('full text search', () => {

--- a/test/unit/support/SearchQueryParser.js
+++ b/test/unit/support/SearchQueryParser.js
@@ -27,18 +27,7 @@ describe('SearchQueryParser', () => {
 
     forEach(expectations, (output, input) => {
       it(`should correctly parse "${input}"`, () => {
-        const result = SearchQueryParser.parse(input);
-
-        expect(result.scope, 'to equal', output.scope);
-        expect(result.query, 'to equal', output.query);
-
-        if ('username' in output) {
-          expect(result.username, 'to equal', output.username);
-        }
-
-        if ('group' in output) {
-          expect(result.group, 'to equal', output.group);
-        }
+        expect(SearchQueryParser.parse(input), 'to satisfy', output);
       });
     });
   });
@@ -49,18 +38,7 @@ describe('SearchQueryParser', () => {
 
     forEach(expectations, (output, input) => {
       it(`should correctly parse "${input}"`, () => {
-        const result = SearchQueryParser.parse(input, defaultUsername);
-
-        expect(result.scope, 'to equal', output.scope);
-        expect(result.query, 'to equal', output.query);
-
-        if ('username' in output) {
-          expect(result.username, 'to equal', output.username);
-        }
-
-        if ('group' in output) {
-          expect(result.group, 'to equal', output.group);
-        }
+        expect(SearchQueryParser.parse(input, defaultUsername), 'to satisfy', output);
       });
     });
   });

--- a/test/unit/support/SearchQueryParser.js
+++ b/test/unit/support/SearchQueryParser.js
@@ -4,7 +4,6 @@ import expect from 'unexpected';
 import { forEach } from 'lodash';
 
 import { SearchQueryParser } from '../../../app/support/SearchQueryParser';
-import { SEARCH_SCOPES } from '../../../app/support/SearchConstants';
 
 /**
  * Based on friendfeed.com search spec:
@@ -13,17 +12,17 @@ import { SEARCH_SCOPES } from '../../../app/support/SearchConstants';
 describe('SearchQueryParser', () => {
   describe('anonymous context', () => {
     const expectations = {
-      'test':                       { scope: SEARCH_SCOPES.ALL_VISIBLE_POSTS,   query: 'test' },
-      'foo -bar':                   { scope: SEARCH_SCOPES.ALL_VISIBLE_POSTS,   query: 'foo & !bar' },
-      '-foo bar':                   { scope: SEARCH_SCOPES.ALL_VISIBLE_POSTS,   query: '!foo & bar' },
-      'foo-bar':                    { scope: SEARCH_SCOPES.ALL_VISIBLE_POSTS,   query: 'foo-bar' },
-      'from:luna test':             { scope: SEARCH_SCOPES.VISIBLE_USER_POSTS,  query: 'test',      username: 'luna' },
-      'from:me foo':                { scope: SEARCH_SCOPES.VISIBLE_USER_POSTS,  query: 'foo',       username: 'me' },  // we handle this in controller explicitly
-      'test from:luna':             { scope: SEARCH_SCOPES.VISIBLE_USER_POSTS,  query: 'test',      username: 'luna' },
-      'from:luna foo bar':          { scope: SEARCH_SCOPES.VISIBLE_USER_POSTS,  query: 'foo & bar', username: 'luna' },
-      'foo from:luna bar':          { scope: SEARCH_SCOPES.VISIBLE_USER_POSTS,  query: 'foo & bar', username: 'luna' },
-      'group:solar-system foo bar': { scope: SEARCH_SCOPES.VISIBLE_GROUP_POSTS, query: 'foo & bar', group: 'solar-system' },
-      'foo group:solar-system bar': { scope: SEARCH_SCOPES.VISIBLE_GROUP_POSTS, query: 'foo & bar', group: 'solar-system' },
+      'test':                       { query: 'test' },
+      'foo -bar':                   { query: 'foo & !bar' },
+      '-foo bar':                   { query: '!foo & bar' },
+      'foo-bar':                    { query: 'foo-bar' },
+      'from:luna test':             { query: 'test',      username: 'luna' },
+      'from:me foo':                { query: 'foo',       username: 'me' },  // we handle this in controller explicitly
+      'test from:luna':             { query: 'test',      username: 'luna' },
+      'from:luna foo bar':          { query: 'foo & bar', username: 'luna' },
+      'foo from:luna bar':          { query: 'foo & bar', username: 'luna' },
+      'group:solar-system foo bar': { query: 'foo & bar', group: 'solar-system' },
+      'foo group:solar-system bar': { query: 'foo & bar', group: 'solar-system' },
     };
 
     forEach(expectations, (output, input) => {
@@ -33,11 +32,11 @@ describe('SearchQueryParser', () => {
         expect(result.scope, 'to equal', output.scope);
         expect(result.query, 'to equal', output.query);
 
-        if (output.scope === SEARCH_SCOPES.VISIBLE_USER_POSTS) {
+        if ('username' in output) {
           expect(result.username, 'to equal', output.username);
         }
 
-        if (output.scope === SEARCH_SCOPES.VISIBLE_GROUP_POSTS) {
+        if ('group' in output) {
           expect(result.group, 'to equal', output.group);
         }
       });
@@ -46,7 +45,7 @@ describe('SearchQueryParser', () => {
 
   describe('user context', () => {
     const defaultUsername = 'luna';
-    const expectations = { 'from:me test': { scope: SEARCH_SCOPES.VISIBLE_USER_POSTS, query: 'test', username: 'luna' } };
+    const expectations = { 'from:me test': { query: 'test', username: 'luna' } };
 
     forEach(expectations, (output, input) => {
       it(`should correctly parse "${input}"`, () => {
@@ -55,11 +54,11 @@ describe('SearchQueryParser', () => {
         expect(result.scope, 'to equal', output.scope);
         expect(result.query, 'to equal', output.query);
 
-        if (output.scope === SEARCH_SCOPES.VISIBLE_USER_POSTS) {
+        if ('username' in output) {
           expect(result.username, 'to equal', output.username);
         }
 
-        if (output.scope === SEARCH_SCOPES.VISIBLE_GROUP_POSTS) {
+        if ('group' in output) {
           expect(result.group, 'to equal', output.group);
         }
       });

--- a/test/unit/support/SearchQueryParser.js
+++ b/test/unit/support/SearchQueryParser.js
@@ -12,17 +12,18 @@ import { SearchQueryParser } from '../../../app/support/SearchQueryParser';
 describe('SearchQueryParser', () => {
   describe('anonymous context', () => {
     const expectations = {
-      'test':                       { query: 'test' },
-      'foo -bar':                   { query: 'foo & !bar' },
-      '-foo bar':                   { query: '!foo & bar' },
-      'foo-bar':                    { query: 'foo-bar' },
-      'from:luna test':             { query: 'test',      username: 'luna' },
-      'from:me foo':                { query: 'foo',       username: 'me' },  // we handle this in controller explicitly
-      'test from:luna':             { query: 'test',      username: 'luna' },
-      'from:luna foo bar':          { query: 'foo & bar', username: 'luna' },
-      'foo from:luna bar':          { query: 'foo & bar', username: 'luna' },
-      'group:solar-system foo bar': { query: 'foo & bar', group: 'solar-system' },
-      'foo group:solar-system bar': { query: 'foo & bar', group: 'solar-system' },
+      'test':                                { query: 'test' },
+      'foo -bar':                            { query: 'foo & !bar' },
+      '-foo bar':                            { query: '!foo & bar' },
+      'foo-bar':                             { query: 'foo-bar' },
+      'from:luna test':                      { query: 'test',      username: 'luna' },
+      'from:me foo':                         { query: 'foo',       username: 'me' },  // we handle this in controller explicitly
+      'test from:luna':                      { query: 'test',      username: 'luna' },
+      'from:luna foo bar':                   { query: 'foo & bar', username: 'luna' },
+      'foo from:luna bar':                   { query: 'foo & bar', username: 'luna' },
+      'group:solar-system foo bar':          { query: 'foo & bar', group: 'solar-system' },
+      'foo group:solar-system bar':          { query: 'foo & bar', group: 'solar-system' },
+      'foo group:solar-system bar from: me': { query: 'foo & bar', username: 'me', group: 'solar-system' },
     };
 
     forEach(expectations, (output, input) => {
@@ -34,7 +35,10 @@ describe('SearchQueryParser', () => {
 
   describe('user context', () => {
     const defaultUsername = 'luna';
-    const expectations = { 'from:me test': { query: 'test', username: 'luna' } };
+    const expectations = {
+      'from:me test':                     { query: 'test', username: 'luna' },
+      'from:me test group: solar-system': { query: 'test', username: 'luna', group: 'solar-system' },
+    };
 
     forEach(expectations, (output, input) => {
       it(`should correctly parse "${input}"`, () => {


### PR DESCRIPTION
This patchset implements simultaneous search with `group:` and `from:` conditions.

For example: `rust group:development from:indeyets`

Important commits are:

- faa86772
- 45e15e26
- 7019b77d

Other are either code-cleanups or optimizations