### PR TITLE
Add three homefeed selection modes

### DIFF
--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -17,7 +17,7 @@ export const ORD_CREATED = 'created';
  *
  * Displays posts from Posts/Directs feeds subscribed to by viewer.
  */
-export const HOMEFEED_MODE_ONLY_FRIENDS = 'only-friends';
+export const HOMEFEED_MODE_FRIENDS_ONLY = 'friends-only';
 
 /**
  * "Classic" homefeed mode
@@ -34,7 +34,7 @@ export const HOMEFEED_MODE_CLASSIC = 'classic';
  * from Comments/Likes feeds subscribed to by viewer. Also displays all posts
  * created by users subscribed to by viewer.
  */
-export const HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY = 'all-friends-activity';
+export const HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY = 'friends-all-activity';
 
 const config = configLoader();
 
@@ -162,9 +162,9 @@ function getCommonParams(ctx, defaultSort = ORD_UPDATED) {
   const withMyPosts = ['yes', 'true', '1', 'on'].includes((query['with-my-posts'] || '').toLowerCase());
   const sort = (query.sort === ORD_CREATED || query.sort === ORD_UPDATED) ? query.sort : defaultSort;
   const homefeedMode = [
-    HOMEFEED_MODE_ONLY_FRIENDS,
+    HOMEFEED_MODE_FRIENDS_ONLY,
     HOMEFEED_MODE_CLASSIC,
-    HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY,
+    HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
   ].includes(query['homefeed-mode']) ? query['homefeed-mode'] : HOMEFEED_MODE_CLASSIC;
   const hiddenCommentTypes = viewer ? viewer.getHiddenCommentTypes() : [];
   return { limit, offset, sort, homefeedMode, withMyPosts, hiddenCommentTypes, createdBefore, createdAfter };
@@ -236,7 +236,7 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
     timelineIds.length = 0;
     timelineIds.push(...destinations);
 
-    if (params.homefeedMode === HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY) {
+    if (params.homefeedMode === HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY) {
       timelineIds.push(...activities);
       const friendsIds = await dbAdapter.getUserFriendIds(viewerId);
       authorsIds.push(...friendsIds);

--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -12,6 +12,30 @@ import { userSerializerFunction } from '../../../serializers/v2/user';
 export const ORD_UPDATED = 'bumped';
 export const ORD_CREATED = 'created';
 
+/**
+ * "Only friends" homefeed mode
+ *
+ * Displays posts from Posts/Directs feeds subscribed to by viewer.
+ */
+export const HOMEFEED_MODE_ONLY_FRIENDS = 'only-friends';
+
+/**
+ * "Classic" homefeed mode
+ *
+ * Displays posts from Posts/Directs feeds and propagable posts
+ * from Comments/Likes feeds subscribed to by viewer.
+ */
+export const HOMEFEED_MODE_CLASSIC = 'classic';
+
+/**
+ * "All friends activity" homefeed mode
+ *
+ * Displays posts from Posts/Directs feeds and all (not only propagable) posts
+ * from Comments/Likes feeds subscribed to by viewer. Also displays all posts
+ * created by users subscribed to by viewer.
+ */
+export const HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY = 'all-friends-activity';
+
 const config = configLoader();
 
 export const bestOf = compose([
@@ -100,6 +124,7 @@ export const metatags = compose([
  * @param {string} [ctx.request.query.sort]           - Sort mode ('created' or 'updated')
  * @param {string} [ctx.request.query.with-my-posts]  - For filter/discussions only: return viewer's own
  *                                                      posts even without his likes or comments (default: no)
+ * @param {string} [ctx.request.query.homefeed-mode]  - For RiverOfNews only: homefeed selection mode
  * @param {string} [ctx.request.query.created-before] - Show only posts created before this datetime (ISO 8601)
  * @param {string} [ctx.request.query.created-after]  - Show only posts created after this datetime (ISO 8601)
  * @param {string} defaultSort                        - Default sort mode
@@ -136,8 +161,13 @@ function getCommonParams(ctx, defaultSort = ORD_UPDATED) {
 
   const withMyPosts = ['yes', 'true', '1', 'on'].includes((query['with-my-posts'] || '').toLowerCase());
   const sort = (query.sort === ORD_CREATED || query.sort === ORD_UPDATED) ? query.sort : defaultSort;
+  const homefeedMode = [
+    HOMEFEED_MODE_ONLY_FRIENDS,
+    HOMEFEED_MODE_CLASSIC,
+    HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY,
+  ].includes(query['homefeed-mode']) ? query['homefeed-mode'] : HOMEFEED_MODE_CLASSIC;
   const hiddenCommentTypes = viewer ? viewer.getHiddenCommentTypes() : [];
-  return { limit, offset, sort, withMyPosts, hiddenCommentTypes, createdBefore, createdAfter };
+  return { limit, offset, sort, homefeedMode, withMyPosts, hiddenCommentTypes, createdBefore, createdAfter };
 }
 
 async function genericTimeline(timeline, viewerId = null, params = {}) {
@@ -145,6 +175,7 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
     limit:              30,
     offset:             0,
     sort:               ORD_UPDATED,
+    homefeedMode:       HOMEFEED_MODE_CLASSIC,
     withLocalBumps:     false,  // consider viewer local bumps (for RiverOfNews)
     withoutDirects:     false,  // do not show direct messages (for Likes and Comments)
     withMyPosts:        false,  // show viewer's own posts even without his likes or comments (for MyDiscussions)
@@ -168,6 +199,12 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
 
   const timelineIds = [timeline.intId];
   const activityFeedIds = [];
+  const authorsIds = [];
+
+  if (params.withMyPosts) {
+    authorsIds.push(viewerId);
+  }
+
   const owner = await timeline.getUser();
   let canViewUser = true;
 
@@ -198,11 +235,22 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
     const { destinations, activities } = await dbAdapter.getSubscriprionsIntIds(viewerId);
     timelineIds.length = 0;
     timelineIds.push(...destinations);
-    activityFeedIds.push(...activities);
+
+    if (params.homefeedMode === HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY) {
+      timelineIds.push(...activities);
+      const friendsIds = await dbAdapter.getUserFriendIds(viewerId);
+      authorsIds.push(...friendsIds);
+
+      if (!authorsIds.includes(viewerId)) {
+        authorsIds.push(viewerId);
+      }
+    } else if (params.homefeedMode === HOMEFEED_MODE_CLASSIC) {
+      activityFeedIds.push(...activities);
+    }
   }
 
   const postsIds = canViewUser ?
-    await dbAdapter.getTimelinePostsIds(timeline.name, timelineIds, viewerId, { ...params, activityFeedIds, limit: params.limit + 1 }) :
+    await dbAdapter.getTimelinePostsIds(timeline.name, timelineIds, viewerId, { ...params, authorsIds, activityFeedIds, limit: params.limit + 1 }) :
     [];
 
   const isLastPage = postsIds.length <= params.limit;

--- a/test/functional/timelinesV2.js
+++ b/test/functional/timelinesV2.js
@@ -10,8 +10,8 @@ import { DummyPublisher } from '../../app/pubsub'
 import { PubSub, dbAdapter } from '../../app/models'
 import {
   HOMEFEED_MODE_CLASSIC,
-  HOMEFEED_MODE_ONLY_FRIENDS,
-  HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY,
+  HOMEFEED_MODE_FRIENDS_ONLY,
+  HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
 } from '../../app/controllers/api/v2/TimelinesController';
 import {
   createUserAsync,
@@ -133,13 +133,13 @@ describe('TimelinesControllerV2', () => {
           expect(homefeed.comments, 'to have length', 1);
         });
 
-        it('should not return post commented by friend in "only-friends" mode', async () => {
+        it('should not return post commented by friend in "friends-only" mode', async () => {
           const post1 = await createAndReturnPost(mars, 'Mars post');
           const post2 = await createAndReturnPost(luna, 'Luna post');
           const post3 = await createAndReturnPost(venus, 'Venus post');
           await createCommentAsync(mars, post3.id, 'Comment');
 
-          const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+          const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_FRIENDS_ONLY);
           expect(homefeed.timelines.posts, 'to equal', [post2.id, post1.id]);
           expect(homefeed.comments, 'to have length', 0);
         });
@@ -159,13 +159,13 @@ describe('TimelinesControllerV2', () => {
           expect(venusPost.likes, 'to have length', 1);
         });
 
-        it('should not return post liked by friend in "only-friends" mode', async () => {
+        it('should not return post liked by friend in "friends-only" mode', async () => {
           const post1 = await createAndReturnPost(mars, 'Mars post');
           const post2 = await createAndReturnPost(luna, 'Luna post');
           const post3 = await createAndReturnPost(venus, 'Venus post');
           await like(post3.id, mars.authToken);
 
-          const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+          const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_FRIENDS_ONLY);
           expect(homefeed.timelines.posts, 'to equal', [post2.id, post1.id]);
         });
 
@@ -243,11 +243,11 @@ describe('TimelinesControllerV2', () => {
             expect(homefeed.timelines.posts[0], 'to be', post.id);
           });
 
-          it('should not return post liked by Luna in "only-friends" mode', async () => {
+          it('should not return post liked by Luna in "friends-only" mode', async () => {
             const post = await createAndReturnPost(venus, 'Venus post');
             await like(post.id, luna.authToken);
 
-            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_FRIENDS_ONLY);
             expect(homefeed.timelines.posts, 'to be empty');
           });
 
@@ -260,11 +260,11 @@ describe('TimelinesControllerV2', () => {
             expect(homefeed.timelines.posts[0], 'to be', post.id);
           });
 
-          it('should not return post commented by Luna in "only-friends" mode', async () => {
+          it('should not return post commented by Luna in "friends-only" mode', async () => {
             const post = await createAndReturnPost(venus, 'Venus post');
             await createCommentAsync(luna, post.id, 'Comment');
 
-            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_FRIENDS_ONLY);
             expect(homefeed.timelines.posts, 'to be empty');
           });
         });
@@ -314,19 +314,19 @@ describe('TimelinesControllerV2', () => {
             expect(homefeed.timelines.posts[0], 'to equal', selenitesPost.id);
           });
 
-          it('should return timeline with liked posts from Celestials group in "all-friends-activity" mode', async () => {
+          it('should return timeline with liked posts from Celestials group in "friends-all-activity" mode', async () => {
             await like(celestialsPost.id, mars.authToken);
             await like(selenitesPost.id, mars.authToken);
 
-            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY);
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY);
             expect(homefeed.timelines.posts, 'to equal', [celestialsPost.id, selenitesPost.id]);
           });
 
-          it('should return timeline with Mars posts from Celestials group in "all-friends-activity" mode', async () => {
+          it('should return timeline with Mars posts from Celestials group in "friends-all-activity" mode', async () => {
             await subscribeToAsync(mars, { username: 'celestials' });
             const marsCelestialsPost = await createAndReturnPostToFeed({ username: 'celestials' }, mars, 'Post');
 
-            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY);
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY);
             expect(homefeed.timelines.posts, 'to equal', [marsCelestialsPost.id, selenitesPost.id]);
           });
         });

--- a/test/functional/timelinesV2.js
+++ b/test/functional/timelinesV2.js
@@ -9,6 +9,11 @@ import { getSingleton } from '../../app/app'
 import { DummyPublisher } from '../../app/pubsub'
 import { PubSub, dbAdapter } from '../../app/models'
 import {
+  HOMEFEED_MODE_CLASSIC,
+  HOMEFEED_MODE_ONLY_FRIENDS,
+  HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY,
+} from '../../app/controllers/api/v2/TimelinesController';
+import {
   createUserAsync,
   createAndReturnPost,
   subscribeToAsync,
@@ -128,6 +133,17 @@ describe('TimelinesControllerV2', () => {
           expect(homefeed.comments, 'to have length', 1);
         });
 
+        it('should not return post commented by friend in "only-friends" mode', async () => {
+          const post1 = await createAndReturnPost(mars, 'Mars post');
+          const post2 = await createAndReturnPost(luna, 'Luna post');
+          const post3 = await createAndReturnPost(venus, 'Venus post');
+          await createCommentAsync(mars, post3.id, 'Comment');
+
+          const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+          expect(homefeed.timelines.posts, 'to equal', [post2.id, post1.id]);
+          expect(homefeed.comments, 'to have length', 0);
+        });
+
         it('should return timeline with post liked by friend at first place (local bump)', async () => {
           const post1 = await createAndReturnPost(venus, 'Venus post');
           const post2 = await createAndReturnPost(mars, 'Mars post');
@@ -141,6 +157,16 @@ describe('TimelinesControllerV2', () => {
           expect(homefeed.timelines.posts[2], 'to be', post2.id);
           const venusPost = homefeed.posts.find((p) => p.id === post1.id);
           expect(venusPost.likes, 'to have length', 1);
+        });
+
+        it('should not return post liked by friend in "only-friends" mode', async () => {
+          const post1 = await createAndReturnPost(mars, 'Mars post');
+          const post2 = await createAndReturnPost(luna, 'Luna post');
+          const post3 = await createAndReturnPost(venus, 'Venus post');
+          await like(post3.id, mars.authToken);
+
+          const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+          expect(homefeed.timelines.posts, 'to equal', [post2.id, post1.id]);
         });
 
         it('should return timeline without post of banned user', async () => {
@@ -217,6 +243,14 @@ describe('TimelinesControllerV2', () => {
             expect(homefeed.timelines.posts[0], 'to be', post.id);
           });
 
+          it('should not return post liked by Luna in "only-friends" mode', async () => {
+            const post = await createAndReturnPost(venus, 'Venus post');
+            await like(post.id, luna.authToken);
+
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+            expect(homefeed.timelines.posts, 'to be empty');
+          });
+
           it('should return timeline with post commented by Luna', async () => {
             const post = await createAndReturnPost(venus, 'Venus post');
             await createCommentAsync(luna, post.id, 'Comment');
@@ -224,6 +258,14 @@ describe('TimelinesControllerV2', () => {
             const homefeed = await fetchHomefeed(luna);
             expect(homefeed.timelines.posts, 'to have length', 1);
             expect(homefeed.timelines.posts[0], 'to be', post.id);
+          });
+
+          it('should not return post commented by Luna in "only-friends" mode', async () => {
+            const post = await createAndReturnPost(venus, 'Venus post');
+            await createCommentAsync(luna, post.id, 'Comment');
+
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ONLY_FRIENDS);
+            expect(homefeed.timelines.posts, 'to be empty');
           });
         });
 
@@ -270,6 +312,22 @@ describe('TimelinesControllerV2', () => {
             const homefeed = await fetchHomefeed(luna);
             expect(homefeed.timelines.posts, 'to have length', 1);
             expect(homefeed.timelines.posts[0], 'to equal', selenitesPost.id);
+          });
+
+          it('should return timeline with liked posts from Celestials group in "all-friends-activity" mode', async () => {
+            await like(celestialsPost.id, mars.authToken);
+            await like(selenitesPost.id, mars.authToken);
+
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY);
+            expect(homefeed.timelines.posts, 'to equal', [celestialsPost.id, selenitesPost.id]);
+          });
+
+          it('should return timeline with Mars posts from Celestials group in "all-friends-activity" mode', async () => {
+            await subscribeToAsync(mars, { username: 'celestials' });
+            const marsCelestialsPost = await createAndReturnPostToFeed({ username: 'celestials' }, mars, 'Post');
+
+            const homefeed = await fetchHomefeed(luna, HOMEFEED_MODE_ALL_FRIENDS_ACTIVITY);
+            expect(homefeed.timelines.posts, 'to equal', [marsCelestialsPost.id, selenitesPost.id]);
           });
         });
       });
@@ -600,7 +658,7 @@ describe('TimelinesControllerV2', () => {
   });
 });
 
-const fetchHomefeed = _.partial(fetchTimeline, 'home');
+const fetchHomefeed = (viewerContext, mode = HOMEFEED_MODE_CLASSIC) => fetchTimeline(`home?homefeed-mode=${mode}`, viewerContext);
 const fetchMyDiscussions = _.partial(fetchTimeline, 'filter/discussions');
 const fetchMyDiscussionsWithMyPosts = _.partial(fetchTimeline, 'filter/discussions?with-my-posts=yes');
 const fetchDirects = _.partial(fetchTimeline, 'filter/directs');


### PR DESCRIPTION
The '/v2/timelines/home' request can have a 'homefeed-mode' GET-parameter with one of the following values:

• 'classic' (default) — a classic FriendFeed/FreeFeed mode, displays posts from Posts/Directs feeds and propagable posts from Comments/Likes feeds subscribed to by viewer.

• 'friends-only' mode displays posts from Posts/Directs feeds subscribed to by viewer only.

• 'friends-all-activity' mode displays posts from Posts/Directs feeds and all (not only propagable) posts from Comments/Likes feeds subscribed to by viewer. Also displays all posts created by users subscribed to by viewer.

A regular ban and private restrictions applies to each of these modes results.