### PR TITLE
Reduce visibility of groups not accessible by viewer

### DIFF
--- a/app/controllers/api/v2/EventsController.js
+++ b/app/controllers/api/v2/EventsController.js
@@ -55,7 +55,7 @@ export default class EventsController {
       events.length = params.limit;
     }
 
-    const serializedData = await serializeEvents(events);
+    const serializedData = await serializeEvents(events, ctx.state.user.id);
 
     ctx.body = {
       Notifications: serializedData.events,

--- a/app/controllers/api/v2/GroupsController.js
+++ b/app/controllers/api/v2/GroupsController.js
@@ -34,13 +34,14 @@ export default class GroupsController {
   }
 
   static async allGroups(ctx) {
-    const withProtected = !!ctx.state.user;
+    const { user: viewer } = ctx.state;
+    const withProtected = !!viewer;
     const groups = await dbAdapter.getAllGroups({ withProtected });
     ctx.body = { groups };
 
     const allUserIds = new Set(groups.map((it) => it.id));
 
-    const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds([...allUserIds]);
+    const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds([...allUserIds], viewer && viewer.id);
     Object.values(allGroupAdmins).forEach((ids) => ids.forEach((s) => allUserIds.add(s)));
 
     const [

--- a/app/controllers/api/v2/PostsController.js
+++ b/app/controllers/api/v2/PostsController.js
@@ -11,7 +11,7 @@ export const show = compose([
   postAccessRequired(),
   monitored('posts.show-v2'),
   async (ctx) => {
-    const { user:viewer, post } = ctx.state;
+    const { user: viewer, post } = ctx.state;
 
     const foldComments = ctx.request.query.maxComments !== 'all';
     const foldLikes = ctx.request.query.maxLikes !== 'all';
@@ -52,7 +52,7 @@ export const show = compose([
     postWithStuff.comments.forEach((c) => allUserIds.add(c.userId));
     postWithStuff.destinations.forEach((d) => allUserIds.add(d.user));
 
-    const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds([...allUserIds]);
+    const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds([...allUserIds], viewer && viewer.id);
     Object.values(allGroupAdmins).forEach((ids) => ids.forEach((s) => allUserIds.add(s)));
 
     const [

--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -248,7 +248,7 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
   allSubscribers.push(...timelines.subscribers);
   allSubscribers.forEach((s) => allUserIds.add(s));
 
-  const allGroupAdmins = canViewUser ? await dbAdapter.getGroupsAdministratorsIds([...allUserIds]) : {};
+  const allGroupAdmins = canViewUser ? await dbAdapter.getGroupsAdministratorsIds([...allUserIds], viewerId) : {};
   Object.values(allGroupAdmins).forEach((ids) => ids.forEach((s) => allUserIds.add(s)));
 
   const [

--- a/app/controllers/api/v2/UsersController.js
+++ b/app/controllers/api/v2/UsersController.js
@@ -132,7 +132,7 @@ export default class UsersController {
         dbAdapter.getUsersByIdsAssoc(allUIDs),
         dbAdapter.getUsersStatsAssoc(allUIDs),
       ]);
-      const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds(_.map(_.filter(allUsers, { type: 'group' }), 'id'));
+      const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds(_.map(_.filter(allUsers, { type: 'group' }), 'id'), user.id);
 
       const fillUser = getUserFiller(allUsers, allStats, allGroupAdmins);
 

--- a/app/serializers/v2/event.js
+++ b/app/serializers/v2/event.js
@@ -3,7 +3,7 @@ import { dbAdapter } from '../../models';
 import { userSerializerFunction } from './user';
 
 
-export async function serializeEvents(events) {
+export async function serializeEvents(events, viewerId = null) {
   const [userIdsMapping, postIdsMapping, commentIdsMapping] = await getIntIdsMappings(events);
 
   const serializedEvents = events.map((e) => {
@@ -23,7 +23,7 @@ export async function serializeEvents(events) {
 
   const allUserIds = new Set();
   Object.values(userIdsMapping).forEach((id) => allUserIds.add(id));
-  const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds([...allUserIds]);
+  const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds([...allUserIds], viewerId);
   Object.values(allGroupAdmins).forEach((ids) => ids.forEach((s) => allUserIds.add(s)));
 
   const [allUsersAssoc, allStatsAssoc] = await Promise.all([

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -87,8 +87,8 @@ export function userSerializerFunction(allUsers, allStats, allGroupAdmins = {}) 
  * @param {boolean} withAdmins
  * @returns {Array}
  */
-export async function serializeUsersByIds(userIds, withAdmins = true) {
-  const adminsAssoc = await dbAdapter.getGroupsAdministratorsIds(userIds);
+export async function serializeUsersByIds(userIds, withAdmins = true, viewerId = null) {
+  const adminsAssoc = await dbAdapter.getGroupsAdministratorsIds(userIds, viewerId);
 
   if (withAdmins) {
     // Complement userIds array by the group admins

--- a/app/support/DbAdapter/group-admins.js
+++ b/app/support/DbAdapter/group-admins.js
@@ -1,3 +1,5 @@
+import pgFormat from 'pg-format';
+
 ///////////////////////////////////////////////////
 // Group administrators
 ///////////////////////////////////////////////////
@@ -5,6 +7,66 @@
 const groupAdminTrait = (superClass) => class extends superClass {
   getGroupAdministratorsIds(groupId) {
     return this.database('group_admins').pluck('user_id').orderBy('created_at', 'desc').where('group_id', groupId)
+  }
+
+  /**
+   * Finds groups in given groupIds and returns plain object { [uuid]: boolean }
+   *
+   * Key is the group UID and 'true' value means that the viewer has access to
+   * this group i.e. one of following conditions is true:
+   *  - group is public
+   *  - group is protected and viewer is not anonymous
+   *  - group is private and viewer is subscriber of the group
+   *
+   * The returning object has only groups UIDs. Users UIDs in 'groupIds'
+   * argument are discards.
+   */
+  async getGroupsVisibility(groupIds, viewerId = null) {
+    if (groupIds.length === 0) {
+      return {};
+    }
+
+    let allGroups = [];
+
+    if (!viewerId) {
+    // Public groups only
+      ({ rows: allGroups } = await this.database.raw(
+        pgFormat(
+          `select
+          uid,
+          (not is_protected) as visible
+         from
+          users
+         where
+          type = 'group' and uid in (%L)`,
+          groupIds,
+        ),
+      ));
+    } else {
+    // Non-private groups and private groups where viewer is member
+      ({ rows: allGroups } = await this.database.raw(
+        pgFormat(
+          `select
+          g.uid,
+          (not g.is_private or s.user_id is not null) as visible
+         from 
+          users g
+          join feeds f on f.user_id = g.uid and f.name = 'Posts'
+          left join subscriptions s on s.feed_id = f.uid and s.user_id = %L
+         where 
+          g.type = 'group' and g.uid in (%L)`,
+          viewerId, groupIds,
+        ),
+      ));
+    }
+
+    const result = {};
+
+    for (const { uid, visible } of allGroups) {
+      result[uid] = visible;
+    }
+
+    return result;
   }
 
   /**

--- a/app/support/NotificationsDigest.js
+++ b/app/support/NotificationsDigest.js
@@ -42,7 +42,7 @@ export async function sendEmails() {
 
     debug(`[${u.username}] found ${events.length} notifications`);
 
-    const serializedEvents = await serializeEvents(events);
+    const serializedEvents = await serializeEvents(events, u.id);
     await sendEventsDigestEmail(u, serializedEvents.events, serializedEvents.users, serializedEvents.groups, digestInterval);
     debug(`[${u.username}] email is queued: OK`);
 

--- a/test/functional/private_groups_hide.js
+++ b/test/functional/private_groups_hide.js
@@ -1,0 +1,214 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected'
+
+
+import cleanDB from '../dbCleaner';
+import {
+  createTestUsers,
+  createGroupAsync,
+  groupToProtected,
+  groupToPrivate,
+  sendRequestToJoinGroup,
+  acceptRequestToJoinGroup,
+  performJSONRequest,
+} from './functional_test_helper';
+
+
+describe('Admins of private/protected groups', () => {
+  before(() => cleanDB($pg_database))
+
+  describe('Luna creates a public Selenites group, Mars and Venus are not members', () => {
+    let luna, mars, venus, selenites;
+    before(async () => {
+      [luna, mars, venus] = await createTestUsers(3);
+      selenites = await createGroupAsync(luna, 'selenites');
+    });
+
+    it('should return group admins to anonymous', async () => {
+      const resp = await getUserInfo(selenites);
+      expect(resp, 'to satisfy', {
+        users: {
+          id:             selenites.group.id,
+          administrators: [luna.user.id],
+        },
+        admins: [{ id: luna.user.id }],
+      });
+    });
+
+    it('should return group admins to Mars', async () => {
+      const resp = await getUserInfo(selenites, mars);
+      expect(resp, 'to satisfy', {
+        users: {
+          id:             selenites.group.id,
+          administrators: [luna.user.id],
+        },
+        admins: [{ id: luna.user.id }],
+      });
+    });
+
+    it('should return Selenites among Luna subscriptions to anonymous', async () => {
+      const resp = await getSubscriptionsOf(luna);
+      expect(resp, 'to satisfy', {
+        subscribers:   [{ id: selenites.group.id }],
+        subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
+      });
+    });
+
+    it('should return Selenites among Luna subscriptions to Mars', async () => {
+      const resp = await getSubscriptionsOf(luna, mars);
+      expect(resp, 'to satisfy', {
+        subscribers:   [{ id: selenites.group.id }],
+        subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
+      });
+    });
+
+    describe('group becomes protected', () => {
+      before(() => groupToProtected(selenites.group, luna));
+
+      it('should not return group admins to anonymous', async () => {
+        const resp = await getUserInfo(selenites);
+        expect(resp, 'to satisfy', {
+          users: {
+            id:             selenites.group.id,
+            administrators: [],
+          },
+          admins: [],
+        });
+      });
+
+      it('should return group admins to Mars', async () => {
+        const resp = await getUserInfo(selenites, mars);
+        expect(resp, 'to satisfy', {
+          users: {
+            id:             selenites.group.id,
+            administrators: [luna.user.id],
+          },
+          admins: [{ id: luna.user.id }],
+        });
+      });
+
+      it('should not return Selenites among Luna subscriptions to anonymous', async () => {
+        const resp = await getSubscriptionsOf(luna);
+        expect(resp, 'to satisfy', {
+          subscribers:   [],
+          subscriptions: [],
+        });
+      });
+
+      it('should return Selenites among Luna subscriptions to Mars', async () => {
+        const resp = await getSubscriptionsOf(luna, mars);
+        expect(resp, 'to satisfy', {
+          subscribers:   [{ id: selenites.group.id }],
+          subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
+        });
+      });
+    });
+
+    describe('group becomes private', () => {
+      before(() => groupToPrivate(selenites.group, luna));
+
+      it('should not return group admins to anonymous', async () => {
+        const resp = await getUserInfo(selenites);
+        expect(resp, 'to satisfy', {
+          users: {
+            id:             selenites.group.id,
+            administrators: [],
+          },
+          admins: [],
+        });
+      });
+
+      it('should not return group admins to Mars', async () => {
+        const resp = await getUserInfo(selenites, mars);
+        expect(resp, 'to satisfy', {
+          users: {
+            id:             selenites.group.id,
+            administrators: [],
+          },
+          admins: [],
+        });
+      });
+
+      it('should return group admins to Luna', async () => {
+        const resp = await getUserInfo(selenites, luna);
+        expect(resp, 'to satisfy', {
+          users: {
+            id:             selenites.group.id,
+            administrators: [luna.user.id],
+          },
+          admins: [{ id: luna.user.id }],
+        });
+      });
+
+
+      it('should not return Selenites among Luna subscriptions to anonymous', async () => {
+        const resp = await getSubscriptionsOf(luna);
+        expect(resp, 'to satisfy', {
+          subscribers:   [],
+          subscriptions: [],
+        });
+      });
+
+      it('should not return Selenites among Luna subscriptions to Mars', async () => {
+        const resp = await getSubscriptionsOf(luna, mars);
+        expect(resp, 'to satisfy', {
+          subscribers:   [],
+          subscriptions: [],
+        });
+      });
+
+      it('should return Selenites among Luna subscriptions to Luna', async () => {
+        const resp = await getSubscriptionsOf(luna, luna);
+        expect(resp, 'to satisfy', {
+          subscribers:   [{ id: selenites.group.id }],
+          subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
+        });
+      });
+    });
+
+    describe('Mars subscribes to group', () => {
+      before(async () => {
+        await sendRequestToJoinGroup(mars, selenites);
+        await acceptRequestToJoinGroup(luna, mars, selenites);
+      });
+
+      it('should return group admins to Mars', async () => {
+        const resp = await getUserInfo(selenites, mars);
+        expect(resp, 'to satisfy', {
+          users: {
+            id:             selenites.group.id,
+            administrators: [luna.user.id],
+          },
+          admins: [{ id: luna.user.id }],
+        });
+      });
+
+      it('should not return Selenites among Mars subscriptions to anonymous', async () => {
+        const resp = await getSubscriptionsOf(mars);
+        expect(resp, 'to satisfy', { subscribers: [], subscriptions: [] });
+      });
+
+      it('should not return Selenites among Mars subscriptions to Venus', async () => {
+        const resp = await getSubscriptionsOf(mars, venus);
+        expect(resp, 'to satisfy', { subscribers: [], subscriptions: [] });
+      });
+
+      it('should return Selenites among Mars subscriptions to Luna', async () => {
+        const resp = await getSubscriptionsOf(mars, luna);
+        expect(resp, 'to satisfy', {
+          subscribers:   [{ id: selenites.group.id }],
+          subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
+        });
+      });
+    });
+  });
+});
+
+function getUserInfo(userCtx, viewerCtx = null) {
+  return performJSONRequest('GET', `/v1/users/${userCtx.username}?authToken=${viewerCtx ? viewerCtx.authToken : ''}`);
+}
+
+function getSubscriptionsOf(userCtx, viewerCtx = null) {
+  return performJSONRequest('GET', `/v1/users/${userCtx.username}/subscriptions?authToken=${viewerCtx ? viewerCtx.authToken : ''}`);
+}

--- a/test/functional/private_groups_hide.js
+++ b/test/functional/private_groups_hide.js
@@ -12,18 +12,22 @@ import {
   sendRequestToJoinGroup,
   acceptRequestToJoinGroup,
   performJSONRequest,
+  createAndReturnPostToFeed,
 } from './functional_test_helper';
 
 
-describe('Admins of private/protected groups', () => {
+describe('Hide information of private/protected groups', () => {
   before(() => cleanDB($pg_database))
 
-  describe('Luna creates a public Selenites group, Mars and Venus are not members', () => {
-    let luna, mars, venus, selenites;
+  describe('Luna creates a public Selenites group and wrote post to group and her feed, Mars and Venus are not members', () => {
+    let luna, mars, venus, selenites, post;
     before(async () => {
       [luna, mars, venus] = await createTestUsers(3);
       selenites = await createGroupAsync(luna, 'selenites');
+      post = await createAndReturnPostToFeed([luna, selenites], luna, 'hi!');
     });
+
+    // Group info
 
     it('should return group admins to anonymous', async () => {
       const resp = await getUserInfo(selenites);
@@ -47,6 +51,8 @@ describe('Admins of private/protected groups', () => {
       });
     });
 
+    // Subscriptions
+
     it('should return Selenites among Luna subscriptions to anonymous', async () => {
       const resp = await getSubscriptionsOf(luna);
       expect(resp, 'to satisfy', {
@@ -63,8 +69,22 @@ describe('Admins of private/protected groups', () => {
       });
     });
 
+    // Post info
+
+    it('should return Selenites admins in post info response to anonymous', async () => {
+      const resp = await getPostInfo(post);
+      expect(resp, 'to satisfy', {
+        subscribers: expect.it('to have an item satisfying', {
+          id:             selenites.group.id,
+          administrators: [luna.user.id],
+        })
+      });
+    });
+
     describe('group becomes protected', () => {
       before(() => groupToProtected(selenites.group, luna));
+
+      // Group info
 
       it('should not return group admins to anonymous', async () => {
         const resp = await getUserInfo(selenites);
@@ -88,6 +108,8 @@ describe('Admins of private/protected groups', () => {
         });
       });
 
+      // Subscriptions
+
       it('should not return Selenites among Luna subscriptions to anonymous', async () => {
         const resp = await getSubscriptionsOf(luna);
         expect(resp, 'to satisfy', {
@@ -103,10 +125,34 @@ describe('Admins of private/protected groups', () => {
           subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
         });
       });
+
+      // Post info
+
+      it('should not return Selenites admins in post info response to anonymous', async () => {
+        const resp = await getPostInfo(post);
+        expect(resp, 'to satisfy', {
+          subscribers: expect.it('to have an item satisfying', {
+            id:             selenites.group.id,
+            administrators: [],
+          })
+        });
+      });
+
+      it('should return Selenites admins in post info response to Mars', async () => {
+        const resp = await getPostInfo(post, mars);
+        expect(resp, 'to satisfy', {
+          subscribers: expect.it('to have an item satisfying', {
+            id:             selenites.group.id,
+            administrators: [luna.user.id],
+          })
+        });
+      });
     });
 
     describe('group becomes private', () => {
       before(() => groupToPrivate(selenites.group, luna));
+
+      // Group info
 
       it('should not return group admins to anonymous', async () => {
         const resp = await getUserInfo(selenites);
@@ -141,6 +187,7 @@ describe('Admins of private/protected groups', () => {
         });
       });
 
+      // Subscriptions
 
       it('should not return Selenites among Luna subscriptions to anonymous', async () => {
         const resp = await getSubscriptionsOf(luna);
@@ -165,6 +212,38 @@ describe('Admins of private/protected groups', () => {
           subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
         });
       });
+
+      // Post info
+
+      it('should not return Selenites admins in post info response to anonymous', async () => {
+        const resp = await getPostInfo(post);
+        expect(resp, 'to satisfy', {
+          subscribers: expect.it('to have an item satisfying', {
+            id:             selenites.group.id,
+            administrators: [],
+          })
+        });
+      });
+
+      it('should not return Selenites admins in post info response to Mars', async () => {
+        const resp = await getPostInfo(post, mars);
+        expect(resp, 'to satisfy', {
+          subscribers: expect.it('to have an item satisfying', {
+            id:             selenites.group.id,
+            administrators: [],
+          })
+        });
+      });
+
+      it('should return Selenites admins in post info response to Luna', async () => {
+        const resp = await getPostInfo(post, luna);
+        expect(resp, 'to satisfy', {
+          subscribers: expect.it('to have an item satisfying', {
+            id:             selenites.group.id,
+            administrators: [luna.user.id],
+          })
+        });
+      });
     });
 
     describe('Mars subscribes to group', () => {
@@ -172,6 +251,8 @@ describe('Admins of private/protected groups', () => {
         await sendRequestToJoinGroup(mars, selenites);
         await acceptRequestToJoinGroup(luna, mars, selenites);
       });
+
+      // Group info
 
       it('should return group admins to Mars', async () => {
         const resp = await getUserInfo(selenites, mars);
@@ -183,6 +264,8 @@ describe('Admins of private/protected groups', () => {
           admins: [{ id: luna.user.id }],
         });
       });
+
+      // Subscriptions
 
       it('should not return Selenites among Mars subscriptions to anonymous', async () => {
         const resp = await getSubscriptionsOf(mars);
@@ -201,6 +284,18 @@ describe('Admins of private/protected groups', () => {
           subscriptions: expect.it('to have items satisfying', { user: selenites.group.id }),
         });
       });
+
+      // Post info
+
+      it('should return Selenites admins in post info response to Mars', async () => {
+        const resp = await getPostInfo(post, mars);
+        expect(resp, 'to satisfy', {
+          subscribers: expect.it('to have an item satisfying', {
+            id:             selenites.group.id,
+            administrators: [luna.user.id],
+          })
+        });
+      });
     });
   });
 });
@@ -211,4 +306,8 @@ function getUserInfo(userCtx, viewerCtx = null) {
 
 function getSubscriptionsOf(userCtx, viewerCtx = null) {
   return performJSONRequest('GET', `/v1/users/${userCtx.username}/subscriptions?authToken=${viewerCtx ? viewerCtx.authToken : ''}`);
+}
+
+function getPostInfo(post, viewerCtx = null) {
+  return performJSONRequest('GET', `/v2/posts/${post.id}?authToken=${viewerCtx ? viewerCtx.authToken : ''}`);
 }


### PR DESCRIPTION
Group is visible to viewer if one of following conditions is true:
   * group is public
   * group is protected and viewer is not anonymous
   * group is private and viewer is subscriber of the group

This PR:
 1. Shows group admins only in groups that are visible to viewer
 2. Do not shows invisible to viewer groups in user's subscriptions list
