### PR TITLE
Applications tokens

### DIFF
--- a/app/controllers/api/v1/BookmarkletController.js
+++ b/app/controllers/api/v1/BookmarkletController.js
@@ -11,7 +11,7 @@ import { wait as waitStream, pipeline } from 'promise-streams';
 import meter from 'stream-meter';
 import { parse as bytesParse } from 'bytes';
 
-import { Post, Comment } from '../../../models';
+import { Post, Comment, AppTokenV1 } from '../../../models';
 import { ForbiddenException } from '../../../support/exceptions';
 import { authRequired, monitored, inputSchemaRequired } from '../../middlewares';
 import { show as showPost } from '../v2/PostsController';
@@ -80,6 +80,8 @@ export const create = compose([
     }
 
     ctx.params.postId = post.id;
+    AppTokenV1.addLogPayload(ctx, { postId: post.id });
+
     await showPost(ctx);
   },
 ]);

--- a/app/controllers/api/v1/CommentsController.js
+++ b/app/controllers/api/v1/CommentsController.js
@@ -1,7 +1,7 @@
 import compose from 'koa-compose';
 import monitor from 'monitor-dog';
 
-import { dbAdapter, Comment } from '../../../models';
+import { dbAdapter, Comment, AppTokenV1 } from '../../../models';
 import { ForbiddenException, NotFoundException, BadRequestException } from '../../../support/exceptions';
 import { serializeComment } from '../../../serializers/v2/comment';
 import { authRequired, inputSchemaRequired, postAccessRequired, monitored } from '../../middlewares';
@@ -35,6 +35,7 @@ export const create = compose([
       throw new BadRequestException(`Can not create comment: ${e.message}`);
     }
 
+    AppTokenV1.addLogPayload(ctx, { commentId: comment.id });
     ctx.body = await serializeComment(comment);
   },
 ]);

--- a/app/controllers/api/v1/GroupsController.js
+++ b/app/controllers/api/v1/GroupsController.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { dbAdapter, Group, GroupSerializer } from '../../../models'
+import { dbAdapter, Group, GroupSerializer, AppTokenV1 } from '../../../models'
 import { EventService } from '../../../support/EventService'
 import { BadRequestException, NotFoundException, ForbiddenException }  from '../../../support/exceptions'
 
@@ -26,6 +26,7 @@ export default class GroupsController {
     await EventService.onGroupCreated(ctx.state.user.intId, group.intId);
     const json = await new GroupSerializer(group).promiseToJSON()
     ctx.body = json;
+    AppTokenV1.addLogPayload(ctx, { groupId: group.id });
   }
 
   static async sudoCreate(ctx) {

--- a/app/controllers/api/v1/PostsController.js
+++ b/app/controllers/api/v1/PostsController.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import monitor from 'monitor-dog';
 import compose from 'koa-compose';
 
-import { dbAdapter, Post } from '../../../models'
+import { dbAdapter, Post, AppTokenV1 } from '../../../models'
 import { ForbiddenException, NotAuthorizedException, NotFoundException, BadRequestException } from '../../../support/exceptions'
 import { postAccessRequired, authRequired, monitored, inputSchemaRequired } from '../../middlewares';
 import { show as showPost } from '../v2/PostsController';
@@ -40,6 +40,7 @@ export default class PostsController {
       }
 
       ctx.params.postId = newPost.id;
+      AppTokenV1.addLogPayload(ctx, { postId: newPost.id });
 
       await showPost(ctx);
     },

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -402,21 +402,27 @@ export default class UsersController {
     authRequired(),
     monitored('users.update'),
     async (ctx) => {
-      const { state: { user }, request: { body }, params } = ctx;
+      const { state: { user, authToken }, request: { body }, params } = ctx;
 
       if (params.userId !== user.id) {
         throw new NotAuthorizedException();
       }
 
-      const attrs = [
+      const attrNames = [
         'screenName',
-        'email',
         'isPrivate',
         'isProtected',
         'description',
         'frontendPreferences',
         'preferences',
-      ].reduce((acc, key) => {
+      ];
+
+      // Only full access tokens can change email
+      if (authToken.hasFullAccess()) {
+        attrNames.push('email');
+      }
+
+      const attrs = attrNames.reduce((acc, key) => {
         if (key in body.user) {
           acc[key] = ctx.request.body.user[key];
         }

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken'
 import _ from 'lodash'
 import compose from 'koa-compose';
 
-import { dbAdapter, MyProfileSerializer, User, Group } from '../../../models'
+import { dbAdapter, MyProfileSerializer, User, Group, AppTokenV1, SessionTokenV0 } from '../../../models'
 import { NotFoundException, ForbiddenException, ValidationException, NotAuthorizedException } from '../../../support/exceptions'
 import { EventService } from '../../../support/EventService'
 import { load as configLoader } from '../../../../config/config'
@@ -55,11 +55,11 @@ export default class UsersController {
       // if onboarding username is not found, just pass
     }
 
-    const { secret } = config;
-    const authToken = jwt.sign({ userId: user.id }, secret)
-
     const json = await new MyProfileSerializer(user).promiseToJSON()
+    const authToken = new SessionTokenV0(user.id).tokenString();
+
     ctx.body = { ...json, authToken };
+    AppTokenV1.addLogPayload(ctx, { userId: user.id });
 
     if (invitation) {
       await useInvitation(user, invitation, ctx.request.body.cancel_subscription);

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -190,6 +190,20 @@ export default class UsersController {
     },
   ]);
 
+  static showMe = compose([
+    authRequired(),
+    monitored('users.show-me'),
+    async (ctx) => {
+      const { user } = ctx.state;
+
+      const serUsers = await serializeUsersByIds([user.id]);
+      const users = serUsers.find((u) => u.id === user.id);
+      const admins = serUsers.filter((u) => u.type === 'user');
+
+      ctx.body = { users, admins, acceptsDirects: false };
+    },
+  ]);
+
   static subscribers = compose([
     targetUserRequired(),
     monitored('users.subscribers'),

--- a/app/controllers/api/v1/data-schemes/definitions.js
+++ b/app/controllers/api/v1/data-schemes/definitions.js
@@ -20,5 +20,10 @@ export default {
       { '$ref': '#/definitions/userName' },
       { '$ref': '#/definitions/groupName' }
     ]
-  }
+  },
+  nonEmptyString: {
+    type:      'string',
+    minLength: 1,
+    pattern:   '\\S'
+  },
 };

--- a/app/controllers/api/v2/AppTokensController.js
+++ b/app/controllers/api/v2/AppTokensController.js
@@ -1,0 +1,150 @@
+import { pick, difference } from 'lodash';
+import compose from 'koa-compose';
+import { Netmask } from 'netmask';
+
+import { authRequired, monitored, inputSchemaRequired } from '../../middlewares';
+import { AppTokenV1, dbAdapter } from '../../../models';
+import { ValidationException, NotFoundException, ForbiddenException } from '../../../support/exceptions';
+import { appTokensScopes } from '../../../models/app-tokens-scopes';
+import { appTokenCreateInputSchema, appTokenUpdateInputSchema } from './data-schemes/app-tokens';
+
+
+export const create = compose([
+  authRequired(),
+  inputSchemaRequired(appTokenCreateInputSchema),
+  monitored('app-tokens.create'),
+  async (ctx) => {
+    const { state: { user }, request: { body } } = ctx;
+
+    const validScopes = appTokensScopes.map(({ name }) => name);
+    const unknownScopes = difference(body.scopes, validScopes);
+
+    if (unknownScopes.length > 0) {
+      throw new ValidationException(`Unknown scopes: ${unknownScopes.join(', ')}`);
+    }
+
+    const invalidNetmasks = body.restrictions.netmasks.filter((mask) => {
+      try {
+        new Netmask(mask);
+        return false;
+      } catch (e) {
+        return true;
+      }
+    });
+
+    if (invalidNetmasks.length > 0) {
+      throw new ValidationException(`Invalid netmasks: ${invalidNetmasks.join(', ')}`);
+    }
+
+    const invalidOrigins = body.restrictions.origins.filter((o) => !/^https?:\/\/[^/]+$/.test(o));
+
+    if (invalidOrigins.length > 0) {
+      throw new ValidationException(`Invalid origins: ${invalidOrigins.join(', ')}`);
+    }
+
+    const token = new AppTokenV1({
+      userId:       user.id,
+      title:        body.title,
+      scopes:       body.scopes,
+      restrictions: body.restrictions,
+    });
+
+    await token.create();
+
+    ctx.body = {
+      token:       serializeAppToken(token),
+      tokenString: token.tokenString(),
+    };
+  },
+]);
+
+export const inactivate = compose([
+  authRequired(),
+  monitored('app-tokens.inactivate'),
+  async (ctx) => {
+    const { user } = ctx.state;
+    const token = await dbAdapter.getAppTokenById(ctx.params.tokenId);
+
+    if (!token || token.userId !== user.id) {
+      throw new NotFoundException('Token not found');
+    }
+
+    await token.inactivate();
+
+    ctx.body = {};
+  },
+]);
+
+export const reissue = compose([
+  authRequired(),
+  monitored('app-tokens.reissue'),
+  async (ctx) => {
+    const { user, authToken: currentToken } = ctx.state;
+    const token = await dbAdapter.getAppTokenById(ctx.params.tokenId);
+
+    if (!token || token.userId !== user.id || !token.isActive) {
+      throw new NotFoundException('Token not found');
+    }
+
+    if (
+      !currentToken.hasFullAccess()
+      && !(currentToken instanceof AppTokenV1 && currentToken.id === token.id)
+    ) {
+      throw new ForbiddenException('Access denied');
+    }
+
+    await token.reissue();
+
+    ctx.body = {
+      token:       serializeAppToken(token),
+      tokenString: token.tokenString(),
+    };
+  },
+]);
+
+export const update = compose([
+  authRequired(),
+  inputSchemaRequired(appTokenUpdateInputSchema),
+  monitored('app-tokens.update'),
+  async (ctx) => {
+    const { state: { user }, request: { body: { title } } } = ctx;
+    const token = await dbAdapter.getAppTokenById(ctx.params.tokenId);
+
+    if (!token || token.userId !== user.id || !token.isActive) {
+      throw new NotFoundException('Token not found');
+    }
+
+    await token.setTitle(title);
+
+    ctx.body = { token: serializeAppToken(token) };
+  },
+]);
+
+export const list = compose([
+  authRequired(),
+  monitored('app-tokens.update'),
+  async (ctx) => {
+    const { state: { user } } = ctx;
+
+    const tokens = await dbAdapter.listActiveAppTokens(user.id);
+
+    ctx.body = { tokens: tokens.map(serializeAppToken) };
+  },
+]);
+
+export const scopes = (ctx) => (ctx.body = { scopes: appTokensScopes });
+
+function serializeAppToken(token) {
+  return pick(token, [
+    'id',
+    'title',
+    'issue',
+    'createdAt',
+    'updatedAt',
+    'scopes',
+    'restrictions',
+    'lastUsedAt',
+    'lastIP',
+    'lastUserAgent',
+  ]);
+}

--- a/app/controllers/api/v2/AppTokensController.js
+++ b/app/controllers/api/v2/AppTokensController.js
@@ -1,11 +1,11 @@
 import { pick, difference } from 'lodash';
 import compose from 'koa-compose';
-import { Netmask } from 'netmask';
 
 import { authRequired, monitored, inputSchemaRequired } from '../../middlewares';
 import { AppTokenV1, dbAdapter } from '../../../models';
 import { ValidationException, NotFoundException, ForbiddenException } from '../../../support/exceptions';
 import { appTokensScopes } from '../../../models/app-tokens-scopes';
+import { Address } from '../../../support/ipv6';
 
 import { appTokenCreateInputSchema, appTokenUpdateInputSchema } from './data-schemes/app-tokens';
 
@@ -26,7 +26,7 @@ export const create = compose([
 
     const invalidNetmasks = body.restrictions.netmasks.filter((mask) => {
       try {
-        new Netmask(mask);
+        new Address(mask);
         return false;
       } catch (e) {
         return true;

--- a/app/controllers/api/v2/AppTokensController.js
+++ b/app/controllers/api/v2/AppTokensController.js
@@ -6,6 +6,7 @@ import { authRequired, monitored, inputSchemaRequired } from '../../middlewares'
 import { AppTokenV1, dbAdapter } from '../../../models';
 import { ValidationException, NotFoundException, ForbiddenException } from '../../../support/exceptions';
 import { appTokensScopes } from '../../../models/app-tokens-scopes';
+
 import { appTokenCreateInputSchema, appTokenUpdateInputSchema } from './data-schemes/app-tokens';
 
 

--- a/app/controllers/api/v2/UsersController.js
+++ b/app/controllers/api/v2/UsersController.js
@@ -87,7 +87,7 @@ export default class UsersController {
       requests: 'users.whoami-v2-requests'
     }),
     async (ctx) => {
-      const { user } = ctx.state;
+      const { state: { user, authToken } } = ctx;
 
       const [
         users,
@@ -150,6 +150,11 @@ export default class UsersController {
           group.requests = (pendingGroupRequests[group.id] || []).map(fillUser);
           return group;
         });
+
+      // Only full access tokens can see privateMeta
+      if (!authToken.hasFullAccess()) {
+        users.privateMeta = {};
+      }
 
       ctx.body = { users, subscribers, subscriptions, requests, managedGroups };
     },

--- a/app/controllers/api/v2/data-schemes/app-tokens.js
+++ b/app/controllers/api/v2/data-schemes/app-tokens.js
@@ -1,0 +1,71 @@
+import definitions from '../../v1/data-schemes/definitions';
+
+
+export const appTokenCreateInputSchema = {
+  '$schema': 'http://json-schema.org/schema#',
+
+  definitions,
+
+  type:     'object',
+  required: [
+    'title',
+    'scopes',
+    'restrictions',
+  ],
+  properties: {
+    title: {
+      type:      'string',
+      pattern:   '\\S',
+      minLength: 1,
+      maxLength: 250,
+    },
+    scopes: {
+      type:        'array',
+      items:       { '$ref': '#/definitions/nonEmptyString' },
+      uniqueItems: true,
+      minItems:    1,
+    },
+    restrictions: {
+      type:     'object',
+      required: [
+        'origins',
+        'netmasks',
+      ],
+      additionalProperties: false,
+      default:              { origins: [], netmasks: [] },
+
+      properties: {
+        origins: {
+          type:        'array',
+          items:       { '$ref': '#/definitions/nonEmptyString' },
+          uniqueItems: true,
+          default:     [],
+        },
+        netmasks: {
+          type:        'array',
+          items:       { '$ref': '#/definitions/nonEmptyString' },
+          uniqueItems: true,
+          default:     [],
+        }
+      }
+    }
+  },
+}
+
+export const appTokenUpdateInputSchema = {
+  '$schema': 'http://json-schema.org/schema#',
+
+  type:     'object',
+  required: [
+    'title',
+  ],
+
+  properties: {
+    title: {
+      type:      'string',
+      pattern:   '\\S',
+      minLength: 1,
+      maxLength: 250,
+    },
+  }
+};

--- a/app/controllers/middlewares/with-auth-token.js
+++ b/app/controllers/middlewares/with-auth-token.js
@@ -41,7 +41,7 @@ export async function withAuthToken(ctx, next) {
     // Update IP and User-Agent
     await authToken.registerUsage({
       ip:        ctx.ip,
-      userAgent: ctx.headers['user-agent'],
+      userAgent: ctx.headers['user-agent'] || '<undefined>',
     });
 
     await next();

--- a/app/controllers/middlewares/with-auth-token.js
+++ b/app/controllers/middlewares/with-auth-token.js
@@ -16,9 +16,15 @@ const sentryIsEnabled = 'sentryDsn' in config;
 const authDebug = createDebug('freefeed:authentication');
 
 export async function withAuthToken(ctx, next) {
-  const jwtToken = ctx.headers['x-authentication-token']
-  || ctx.request.body.authToken
-  || ctx.query.authToken;
+  let jwtToken;
+
+  if (ctx.headers['authorization'] && ctx.headers['authorization'].startsWith('Bearer ')) {
+    jwtToken = ctx.headers['authorization'].replace(/^Bearer\s+/, '');
+  } else {
+    jwtToken = ctx.headers['x-authentication-token']
+     || ctx.request.body.authToken
+     || ctx.query.authToken;
+  }
 
   const authData = await tokenFromJWT(
     jwtToken,

--- a/app/controllers/middlewares/with-auth-token.js
+++ b/app/controllers/middlewares/with-auth-token.js
@@ -1,0 +1,160 @@
+import { promisifyAll } from 'bluebird';
+import jwt from 'jsonwebtoken';
+import { Netmask } from 'netmask';
+import createDebug from 'debug';
+import Raven from 'raven';
+
+import { load as configLoader } from '../../../config/config';
+import { dbAdapter, SessionTokenV0, AppTokenV1 } from '../../models';
+import { ForbiddenException } from '../../support/exceptions';
+import { alwaysAllowedRoutes, appTokensScopes } from '../../models/app-tokens-scopes';
+
+
+promisifyAll(jwt);
+const config = configLoader();
+const sentryIsEnabled = 'sentryDsn' in config;
+const authDebug = createDebug('freefeed:authentication');
+
+export async function withAuthToken(ctx, next) {
+  const jwtToken = ctx.headers['x-authentication-token']
+  || ctx.request.body.authToken
+  || ctx.query.authToken;
+
+  const authData = await tokenFromJWT(
+    jwtToken,
+    {
+      headers:  ctx.headers,
+      remoteIP: ctx.ip,
+      route:    `${ctx.method} ${ctx._matchedRoute}`,
+    },
+  );
+
+  if (!authData) {
+    await next();
+    return;
+  }
+
+  ctx.state = { ...ctx.state, ...authData };
+  const { authToken } = authData;
+
+  if (authToken instanceof AppTokenV1) {
+    // Update IP and User-Agent
+    await authToken.registerUsage({
+      ip:        ctx.ip,
+      userAgent: ctx.headers['user-agent'],
+    });
+
+    await next();
+
+    try {
+      await authToken.logRequest(ctx);
+    } catch (e) {
+      // We should not break request at this step
+      // but we must log error
+      authDebug(`cannot log app token usage: ${e.message}`);
+
+      if (sentryIsEnabled) {
+        Raven.captureException(e, { extra: { err: `cannot log app token usage: ${e.message}` } });
+      }
+    }
+  } else {
+    await next();
+  }
+}
+
+/**
+ * Parses JWT, checks token permissions and returns { authToken: AuthToken, user: User }
+ * object or null. Null means that anonymous access is granted. This function
+ * throws ForbiddenException if the request cannot be proceed with this token.
+ *
+ * @param {string} jwtToken
+ * @param {object} context
+ * @throws {ForbiddenException}
+ */
+export async function tokenFromJWT(
+  jwtToken,
+  { // Extract from ctx data
+    headers = {},
+    remoteIP = '0.0.0.0',
+    route = '',
+  },
+) {
+  if (!jwtToken) {
+    return null;
+  }
+
+  authDebug('got JWT token', jwtToken);
+
+  let decoded = null;
+
+  try {
+    decoded = await jwt.verifyAsync(jwtToken, config.secret);
+  } catch (e) {
+    authDebug(`invalid JWT, the user will be treated as anonymous: ${e.message}`);
+    return null;
+  }
+
+  // Session token v0 (legacy)
+  if (!decoded.type && decoded.userId) {
+    const token = new SessionTokenV0(decoded.userId);
+    const user = await dbAdapter.getUserById(token.userId);
+
+    if (!user || !user.isActive) {
+      authDebug(`user ${token.userId} is not exists or is not active`);
+      return null;
+    }
+
+    authDebug(`authenticated as ${user.username} with ${token.constructor.name} token`);
+    return { authToken: token, user };
+  }
+
+  // Application token v1
+  if (decoded.type === AppTokenV1.TYPE) {
+    const token = await dbAdapter.getActiveAppTokenByIdAndIssue(decoded.id, decoded.issue);
+
+    if (!token) {
+      authDebug(`app token ${decoded.id} / ${decoded.issue} is not exists`);
+      throw new ForbiddenException(`token is invalid or outdated`);
+    }
+
+    // Restrictions (IPs and origins)
+    {
+      const { netmasks = [], origins = [] } = token.restrictions;
+
+      if (netmasks.length > 0 && !netmasks.some((mask) => new Netmask(mask).contains(remoteIP))) {
+        authDebug(`app token is not allowed from IP ${remoteIP}`)
+        throw new ForbiddenException(`token is not allowed from this IP`);
+      }
+
+      if (origins.length > 0 && !origins.includes(headers.origin)) {
+        authDebug(`app token is not allowed from origin ${headers.origin}`)
+        throw new ForbiddenException(`token is not allowed from this origin`);
+      }
+    }
+
+    // Route access
+    {
+      const routeAllowed = alwaysAllowedRoutes.includes(route)
+      || appTokensScopes.some(({ name, routes }) => token.scopes.includes(name) && routes.includes(route));
+
+      if (!routeAllowed) {
+        authDebug(`app token has no access to '${route}'`);
+        throw new ForbiddenException(`token has no access to this API method`);
+      }
+    }
+
+    const user = await dbAdapter.getUserById(token.userId);
+
+    if (!user || !user.isActive) {
+      authDebug(`user ${token.userId} is not exists or is not active`);
+      throw new ForbiddenException(`user is not exists`);
+    }
+
+    authDebug(`authenticated as ${user.username} with ${token.constructor.name} token`);
+    return { authToken: token, user };
+  }
+
+  // Unknow token
+  authDebug(`unknown token type: ${decoded.type}`);
+  return null;
+}

--- a/app/models.js
+++ b/app/models.js
@@ -13,6 +13,8 @@ import { addModel as groupModel } from './models/group';
 import { addModel as postModel } from './models/post';
 import { addModel as timelineModel } from './models/timeline';
 import { addModel as userModel } from './models/user';
+import { addAppTokenV1Model } from './models/auth-tokens';
+
 import { addSerializer as adminSerializer } from './serializers/v1/AdminSerializer';
 import { addSerializer as attachmentSerializer } from './serializers/v1/AttachmentSerializer';
 import { addSerializer as commentSerializer } from './serializers/v1/CommentSerializer';
@@ -56,6 +58,8 @@ export const Post          = postModel(dbAdapter);
 export const Timeline      = timelineModel(dbAdapter);
 export const Attachment    = attachmentModel(dbAdapter);
 export const Comment       = commentModel(dbAdapter);
+export { AuthToken, SessionTokenV0 } from './models/auth-tokens';
+export const AppTokenV1    = addAppTokenV1Model(dbAdapter);
 
 export const AdminSerializer               = adminSerializer();
 export const UserSerializer                = userSerializer();

--- a/app/models.js
+++ b/app/models.js
@@ -14,7 +14,6 @@ import { addModel as postModel } from './models/post';
 import { addModel as timelineModel } from './models/timeline';
 import { addModel as userModel } from './models/user';
 import { addAppTokenV1Model } from './models/auth-tokens';
-
 import { addSerializer as adminSerializer } from './serializers/v1/AdminSerializer';
 import { addSerializer as attachmentSerializer } from './serializers/v1/AttachmentSerializer';
 import { addSerializer as commentSerializer } from './serializers/v1/CommentSerializer';

--- a/app/models/app-tokens-scopes.js
+++ b/app/models/app-tokens-scopes.js
@@ -1,0 +1,138 @@
+export const alwaysAllowedRoutes = [
+  'GET /v1/users/me',
+  'POST /v2/app-tokens/:tokenId/reissue',
+];
+
+export const appTokensScopes = [
+  {
+    name:   'read-my-info',
+    title:  'Description of read-my-info',
+    routes: [
+      'GET /v2/users/whoami',
+      'GET /v2/managedGroups',
+      'GET /v2/users/blockedByMe',
+    ]
+  },
+  {
+    name:   'read-feeds',
+    title:  'Description of read-any-feeds',
+    routes: [
+      'GET /v2/timelines/home',
+      'GET /v2/timelines/filter/discussions',
+      'GET /v2/timelines/filter/directs',
+      'GET /v2/users/getUnreadDirectsNumber',
+      'GET /v2/timelines/:username',
+      'GET /v2/timelines/:username/likes',
+      'GET /v2/timelines/:username/comments',
+      'GET /v2/search',
+      'GET /v2/summary/:days',
+      'GET /v2/summary/:username/:days',
+      'GET /v2/bestof',
+      'GET /v2/timelines-rss/:username',
+      'GET /v2/posts/:postId',
+      'GET /v2/archives/post-by-old-name/:name',
+      'GET /v2/allGroups',
+      'GET /v2/comments/:commentId/likes',
+    ]
+  },
+  {
+    name:   'read-users-info',
+    title:  'Description of read-users-info',
+    routes: [
+      'GET /v1/users/:username',
+      'GET /v1/users/:username/subscribers',
+      'GET /v1/users/:username/subscriptions',
+    ]
+  },
+  {
+    name:   'read-realtime',
+    title:  'Description of read-realtime',
+    routes: [
+      'RT',
+    ]
+  },
+  {
+    name:   'manage-notifications',
+    title:  'Description of manage-notifications',
+    routes: [
+      'GET /v2/notifications',
+      'POST /v2/users/markAllNotificationsAsRead',
+      'GET /v2/users/getUnreadNotificationsNumber',
+    ]
+  },
+  {
+    name:   'manage-posts',
+    title:  'Description of manage-posts',
+    routes: [
+      'GET /v2/posts/:postId',
+      'GET /v2/users/markAllDirectsAsRead',
+      'GET /v2/comments/:commentId/likes',
+      'POST /v1/attachments',
+      'POST /v1/bookmarklet',
+      'POST /v1/posts',
+      'PUT /v1/posts/:postId',
+      'POST /v1/posts/:postId/disableComments',
+      'POST /v1/posts/:postId/enableComments',
+      'DELETE /v1/posts/:postId',
+      'POST /v1/comments',
+      'PUT /v1/comments/:commentId',
+      'DELETE /v1/comments/:commentId',
+      'POST /v1/posts/:postId/like',
+      'POST /v1/posts/:postId/unlike',
+      'POST /v2/comments/:commentId/like',
+      'POST /v2/comments/:commentId/unlike',
+    ]
+  },
+  {
+    name:   'manage-my-feeds',
+    title:  'Description of manage-my-feeds',
+    routes: [
+      'POST /v1/users/:userId/subscribe',
+      'POST /v1/users/:userId/unsubscribe',
+      'POST /v1/posts/:postId/hide',
+      'POST /v1/posts/:postId/unhide',
+      'POST /v1/users/:userId/ban',
+      'POST /v1/users/:userId/unban',
+      'POST /v1/users/:userId/sendRequest',
+      'POST /v2/requests/:followedUserName/revoke',
+    ]
+  },
+  {
+    name:   'manage-profile',
+    title:  'Description of manage-profile',
+    routes: [
+      'POST /v1/groups/:groupName/updateProfilePicture',
+      'POST /v1/users/updateProfilePicture',
+      'PUT /v1/users/:userId',
+    ]
+  },
+  {
+    name:   'manage-groups',
+    title:  'Description of manage-groups',
+    routes: [
+      'POST /v1/groups',
+      'POST /v1/groups/:groupName/subscribers/:adminName/admin',
+      'POST /v1/groups/:groupName/subscribers/:adminName/unadmin',
+      'POST /v1/groups/:groupName/sendRequest',
+      'POST /v1/groups/:groupName/acceptRequest/:userName',
+      'POST /v1/groups/:groupName/rejectRequest/:userName',
+      'POST /v1/groups/:groupName/unsubscribeFromGroup/:userName',
+    ]
+  },
+  {
+    name:   'manage-subscription-requests',
+    title:  'Description of manage-subscription-requests',
+    routes: [
+      'POST /v1/users/acceptRequest/:username',
+      'POST /v1/users/rejectRequest/:username',
+      'POST /v1/users/:username/unsubscribeFromMe',
+    ]
+  },
+  {
+    name:   'read-realtime',
+    title:  'Read realtime messages',
+    routes: [
+      'WS *',
+    ]
+  },
+];

--- a/app/models/app-tokens-scopes.js
+++ b/app/models/app-tokens-scopes.js
@@ -46,9 +46,9 @@ export const appTokensScopes = [
   },
   {
     name:   'read-realtime',
-    title:  'Description of read-realtime',
+    title:  'Read realtime messages',
     routes: [
-      'RT',
+      'WS *',
     ]
   },
   {
@@ -126,13 +126,6 @@ export const appTokensScopes = [
       'POST /v1/users/acceptRequest/:username',
       'POST /v1/users/rejectRequest/:username',
       'POST /v1/users/:username/unsubscribeFromMe',
-    ]
-  },
-  {
-    name:   'read-realtime',
-    title:  'Read realtime messages',
-    routes: [
-      'WS *',
     ]
   },
 ];

--- a/app/models/app-tokens-scopes.js
+++ b/app/models/app-tokens-scopes.js
@@ -6,7 +6,7 @@ export const alwaysAllowedRoutes = [
 export const appTokensScopes = [
   {
     name:   'read-my-info',
-    title:  'Description of read-my-info',
+    title:  'Read my user information',
     routes: [
       'GET /v2/users/whoami',
       'GET /v2/managedGroups',
@@ -15,7 +15,7 @@ export const appTokensScopes = [
   },
   {
     name:   'read-feeds',
-    title:  'Description of read-any-feeds',
+    title:  'Read feeds, including my feeds and direct messages',
     routes: [
       'GET /v2/timelines/home',
       'GET /v2/timelines/filter/discussions',
@@ -37,7 +37,7 @@ export const appTokensScopes = [
   },
   {
     name:   'read-users-info',
-    title:  'Description of read-users-info',
+    title:  'Read users\' information',
     routes: [
       'GET /v1/users/:username',
       'GET /v1/users/:username/subscribers',
@@ -53,7 +53,7 @@ export const appTokensScopes = [
   },
   {
     name:   'manage-notifications',
-    title:  'Description of manage-notifications',
+    title:  'Manage notifications',
     routes: [
       'GET /v2/notifications',
       'POST /v2/users/markAllNotificationsAsRead',
@@ -62,7 +62,7 @@ export const appTokensScopes = [
   },
   {
     name:   'manage-posts',
-    title:  'Description of manage-posts',
+    title:  'Manage (read, write and delete) posts, comments, and likes',
     routes: [
       'GET /v2/posts/:postId',
       'GET /v2/users/markAllDirectsAsRead',
@@ -85,7 +85,7 @@ export const appTokensScopes = [
   },
   {
     name:   'manage-my-feeds',
-    title:  'Description of manage-my-feeds',
+    title:  'Manage my subscriptions, hides, and bans',
     routes: [
       'POST /v1/users/:userId/subscribe',
       'POST /v1/users/:userId/unsubscribe',
@@ -99,7 +99,7 @@ export const appTokensScopes = [
   },
   {
     name:   'manage-profile',
-    title:  'Description of manage-profile',
+    title:  'Manage my and my groups profiles',
     routes: [
       'POST /v1/groups/:groupName/updateProfilePicture',
       'POST /v1/users/updateProfilePicture',
@@ -108,7 +108,7 @@ export const appTokensScopes = [
   },
   {
     name:   'manage-groups',
-    title:  'Description of manage-groups',
+    title:  'Manage groups',
     routes: [
       'POST /v1/groups',
       'POST /v1/groups/:groupName/subscribers/:adminName/admin',
@@ -121,7 +121,7 @@ export const appTokensScopes = [
   },
   {
     name:   'manage-subscription-requests',
-    title:  'Description of manage-subscription-requests',
+    title:  'Manage subscription requests',
     routes: [
       'POST /v1/users/acceptRequest/:username',
       'POST /v1/users/rejectRequest/:username',

--- a/app/models/auth-tokens.js
+++ b/app/models/auth-tokens.js
@@ -112,6 +112,13 @@ export function addAppTokenV1Model(dbAdapter) {
       await dbAdapter.registerAppTokenUsage(this.id, { ip, userAgent, debounce: appTokenUsageDebounce });
     }
 
+    static addLogPayload(ctx, payload) {
+      ctx.state.appTokenLogPayload = {
+        ...(ctx.state.appTokenLogPayload || {}),
+        ...payload,
+      };
+    }
+
     async logRequest(ctx) {
       if (['GET', 'HEAD', 'OPTIONS'].includes(ctx.method) || (ctx.status && ctx.status >= 400)) {
         return;

--- a/app/models/auth-tokens.js
+++ b/app/models/auth-tokens.js
@@ -1,0 +1,158 @@
+import _ from 'lodash';
+import jwt from 'jsonwebtoken'
+
+import { load as configLoader } from '../../config/config'
+
+
+const config = configLoader()
+
+const appTokenUsageDebounce = '10 sec'; // PostgreSQL 'interval' type syntax
+
+/**
+ * AuthToken
+ * The common subset of all token classes
+ */
+export class AuthToken {
+  userId;
+
+  constructor(userId) { this.userId = userId; }
+
+  hasFullAccess() { return false; }
+
+  tokenString() { return 'ABSTRACT TOKEN'; }
+}
+
+/**
+ * Session token v0 (legacy)
+ * Eternal and almighty pepyatka-like JWT-token
+ */
+export class SessionTokenV0 extends AuthToken {
+  hasFullAccess() {
+    return true;
+  }
+
+  tokenString() {
+    const { secret } = config;
+    return jwt.sign({ userId: this.userId }, secret);
+  }
+}
+
+
+export function addAppTokenV1Model(dbAdapter) {
+  /**
+   * Application token v1
+   */
+  return class AppTokenV1 extends AuthToken {
+    static TYPE = 'app.v1';
+
+    id;
+    title;
+    isActive = true;
+    issue = 1;
+    createdAt;
+    updatedAt;
+    scopes = [];
+    restrictions = {};
+    lastUsedAt = null;
+    lastIP = null;
+    lastUserAgent = null;
+
+    constructor(params) {
+      super(params.userId);
+
+      const fields = [
+        'id',
+        'userId',
+        'title',
+        'isActive',
+        'issue',
+        'createdAt',
+        'updatedAt',
+        'scopes',
+        'restrictions',
+        'lastUsedAt',
+        'lastIP',
+        'lastUserAgent',
+      ];
+
+      for (const f of fields) {
+        if (f in params) {
+          this[f] = params[f];
+        }
+      }
+
+      if (!this.restrictions.netmasks) {
+        this.restrictions.netmasks = [];
+      }
+
+      if (!this.restrictions.origins) {
+        this.restrictions.origins = [];
+      }
+    }
+
+    toString() {
+      return `${super.toString()}#${this.id}#${this.issue}`;
+    }
+
+    async create() {
+      this.id = await dbAdapter.createAppToken(this);
+
+      const newToken = await dbAdapter.getAppTokenById(this.id);
+      const fieldsToUpdate = [
+        'createdAt',
+        'updatedAt',
+      ];
+
+      for (const f of fieldsToUpdate) {
+        this[f] = newToken[f];
+      }
+    }
+
+    async registerUsage({ ip, userAgent }) {
+      await dbAdapter.registerAppTokenUsage(this.id, { ip, userAgent, debounce: appTokenUsageDebounce });
+    }
+
+    async logRequest(ctx) {
+      if (['GET', 'HEAD', 'OPTIONS'].includes(ctx.method) || (ctx.status && ctx.status >= 400)) {
+        return;
+      }
+
+      const payload = {
+        token_id:   this.id,
+        request:    `${ctx.method} ${ctx.url}`,
+        ip:         ctx.ip,
+        user_agent: ctx.headers['user-agent'],
+        extra:      {
+          ..._.pick(ctx.headers, ['x-real-ip', 'x-forwarded-for']),
+          ...(ctx.state.appTokenLogPayload || {}),
+        },
+      };
+
+      await dbAdapter.logAppTokenRequest(payload);
+    }
+
+    tokenString() {
+      const { secret } = config;
+      return jwt.sign({
+        type:   AppTokenV1.TYPE,
+        id:     this.id,
+        issue:  this.issue,
+        userId: this.userId,
+      }, secret)
+    }
+
+    async setTitle(title) {
+      await dbAdapter.updateAppToken(this.id, { title });
+      this.title = title;
+    }
+
+    async inactivate() {
+      await dbAdapter.updateAppToken(this.id, { isActive: false });
+      this.isActive = false;
+    }
+
+    async reissue() {
+      this.issue = await dbAdapter.reissueAppToken(this.id);
+    }
+  }
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -76,12 +76,6 @@ export default function (app) {
   InvitationsRoute(router);
   AppTokensRoute(router);
 
-  // Not Found route for API URIs
-  router.all('/v(\\d+)/*', (ctx) => {
-    ctx.status = 404;
-    ctx.body = { err: `API method not found: '${ctx.url}'` };
-  });
-
   app.use(koaStatic(`${__dirname}/../${config.attachments.storage.rootDir}`));
 
   app.use(async (ctx, next) => {
@@ -98,4 +92,15 @@ export default function (app) {
 
   app.use(router.routes());
   app.use(router.allowedMethods());
+
+  // Not Found middleware for API-like URIs
+  app.use(async (ctx, next) => {
+    if (/\/v\d+\//.test(ctx.url)) {
+      ctx.status = 404;
+      ctx.body = { err: `API method not found: '${ctx.url}'` };
+      return;
+    }
+
+    await next();
+  });
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -6,7 +6,6 @@ import Router from 'koa-router';
 
 import { load as configLoader } from '../config/config';
 
-import { dbAdapter } from './models';
 import { reportError } from './support/exceptions';
 import AttachmentsRoute from './routes/api/v1/AttachmentsRoute';
 import BookmarkletRoute from './routes/api/v1/BookmarkletRoute';
@@ -31,7 +30,6 @@ import NotificationsRoute from './routes/api/v2/NotificationsRoute';
 import CommentLikesRoute from './routes/api/v2/CommentLikesRoute';
 import InvitationsRoute from './routes/api/v2/InvitationsRoute';
 import AppTokensRoute from './routes/api/v2/AppTokens';
-
 import { withAuthToken } from './controllers/middlewares/with-auth-token';
 
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -95,9 +95,10 @@ export default function (app) {
   CommentLikesRoute(router);
   InvitationsRoute(router);
 
-  router.use('/v[0-9]+/*', (ctx) => {
+  // Not Found route for API URIs
+  router.all('/v(\\d+)/*', (ctx) => {
     ctx.status = 404;
-    ctx.body = { err: `API method not found: '${ctx.req.path}'` };
+    ctx.body = { err: `API method not found: '${ctx.url}'` };
   });
 
   app.use(koaStatic(`${__dirname}/../${config.attachments.storage.rootDir}`));

--- a/app/routes.js
+++ b/app/routes.js
@@ -30,6 +30,7 @@ import ArchivesRoute from './routes/api/v2/ArchivesRoute';
 import NotificationsRoute from './routes/api/v2/NotificationsRoute';
 import CommentLikesRoute from './routes/api/v2/CommentLikesRoute';
 import InvitationsRoute from './routes/api/v2/InvitationsRoute';
+import AppTokensRoute from './routes/api/v2/AppTokens';
 
 import { withAuthToken } from './controllers/middlewares/with-auth-token';
 
@@ -75,6 +76,7 @@ export default function (app) {
   NotificationsRoute(router);
   CommentLikesRoute(router);
   InvitationsRoute(router);
+  AppTokensRoute(router);
 
   // Not Found route for API URIs
   router.all('/v(\\d+)/*', (ctx) => {

--- a/app/routes/api/v1/UsersRoute.js
+++ b/app/routes/api/v1/UsersRoute.js
@@ -12,6 +12,7 @@ export default function addRoutes(app) {
   app.post('/v1/users/:username/unsubscribeFromMe', UsersController.unsubscribeUser);
   app.post('/v1/users/:username/sendRequest',       UsersController.sendRequest);
   app.get('/v1/users/whoami',                       deprecated('Please use /v2/users/whoami'));
+  app.get('/v1/users/me',                           UsersController.showMe);
   app.get('/v1/users/:username',                    UsersController.show);
   app.put('/v1/users/updatePassword',               UsersController.updatePassword);
   app.post('/v1/users/updateProfilePicture',        UsersController.updateProfilePicture);

--- a/app/routes/api/v2/AppTokens.js
+++ b/app/routes/api/v2/AppTokens.js
@@ -1,0 +1,18 @@
+import {
+  create,
+  inactivate,
+  reissue,
+  update,
+  scopes,
+  list,
+} from '../../../controllers/api/v2/AppTokensController';
+
+
+export default function addRoutes(app) {
+  app.get('/v2/app-tokens/scopes', scopes);
+  app.get('/v2/app-tokens', list);
+  app.post('/v2/app-tokens', create);
+  app.post('/v2/app-tokens/:tokenId/reissue', reissue);
+  app.put('/v2/app-tokens/:tokenId', update);
+  app.delete('/v2/app-tokens/:tokenId', inactivate);
+}

--- a/app/support/DbAdapter/app-tokens.js
+++ b/app/support/DbAdapter/app-tokens.js
@@ -1,4 +1,5 @@
 import { AppTokenV1 } from '../../models';
+
 import { prepareModelPayload, initObject } from './utils';
 
 

--- a/app/support/DbAdapter/app-tokens.js
+++ b/app/support/DbAdapter/app-tokens.js
@@ -1,0 +1,114 @@
+import { AppTokenV1 } from '../../models';
+import { prepareModelPayload, initObject } from './utils';
+
+
+const appTokensTrait = (superClass) => class extends superClass {
+  async createAppToken(payload) {
+    const preparedPayload = prepareModelPayload(payload, APP_TOKEN_COLUMNS, APP_TOKEN_COLUMNS_MAPPING);
+    const [id] = await this.database('app_tokens').returning('uid').insert(preparedPayload);
+    return id;
+  }
+
+  async getAppTokenById(uid) {
+    const row = await this.database('app_tokens').first().where({ uid })
+    return initAppTokenObject(row);
+  }
+
+  async getActiveAppTokenByIdAndIssue(uid, issue) {
+    const row = await this.database('app_tokens').first().where({ uid, issue, is_active: true })
+    return initAppTokenObject(row);
+  }
+
+  async registerAppTokenUsage(id, { ip, userAgent, debounce }) {
+    const sql = `
+      update app_tokens set 
+        last_ip = :ip, last_user_agent = :userAgent, last_used_at = now()
+      where
+        uid = :id and (last_ip <> :ip or last_user_agent <> :userAgent or last_used_at is null or last_used_at < now() - :debounce::interval)
+    `;
+    await this.database.raw(sql, { id, ip, userAgent, debounce });
+  }
+
+  updateAppToken(id, payload) {
+    const preparedPayload = prepareModelPayload(payload, APP_TOKEN_COLUMNS, APP_TOKEN_COLUMNS_MAPPING);
+    preparedPayload['updated_at'] = 'now';
+    return this.database('app_tokens').where('uid', id).update(preparedPayload);
+  }
+
+  async logAppTokenRequest(payload) {
+    await this.database('app_tokens_log').insert(payload);
+  }
+
+  async reissueAppToken(id) {
+    const { rows } = await this.database.raw(
+      `update app_tokens set issue = issue + 1, updated_at = default where uid = :id returning issue`,
+      { id },
+    );
+
+    if (rows.length === 0) {
+      throw new Error(`cannot find app token ${id}`);
+    }
+
+    return rows[0].issue;
+  }
+
+  async listActiveAppTokens(userId) {
+    const { rows } = await this.database.raw(`select * from app_tokens where user_id = :userId and is_active order by created_at desc`, { userId });
+    return rows.map((r) => initAppTokenObject(r));
+  }
+};
+
+export default appTokensTrait;
+
+/////////////////////////////
+
+function initAppTokenObject(row) {
+  if (!row) {
+    return null;
+  }
+
+  row = prepareModelPayload(row, APP_TOKEN_FIELDS, APP_TOKEN_FIELDS_MAPPING);
+  return initObject(AppTokenV1, row, row.id);
+}
+
+const APP_TOKEN_FIELDS = {
+  uid:             'id',
+  user_id:         'userId',
+  title:           'title',
+  is_active:       'isActive',
+  issue:           'issue',
+  created_at:      'createdAt',
+  updated_at:      'updatedAt',
+  scopes:          'scopes',
+  restrictions:    'restrictions',
+  last_used_at:    'lastUsedAt',
+  last_ip:         'lastIP',
+  last_user_agent: 'lastUserAgent',
+};
+
+const APP_TOKEN_FIELDS_MAPPING = {
+  created_at:   (time) =>  time ? time.toISOString() : undefined,
+  updated_at:   (time) =>  time ? time.toISOString() : undefined,
+  last_used_at: (time) =>  time ? time.toISOString() : null,
+};
+
+const APP_TOKEN_COLUMNS = {
+  id:            'uid',
+  userId:        'user_id',
+  title:         'title',
+  isActive:      'is_active',
+  issue:         'issue',
+  createdAt:     'created_at',
+  updatedAt:     'updated_at',
+  scopes:        'scopes',
+  restrictions:  'restrictions',
+  lastUsedAt:    'last_used_at',
+  lastIP:        'last_ip',
+  lastUserAgent: 'last_user_agent',
+};
+
+const APP_TOKEN_COLUMNS_MAPPING = {
+  createdAt:  (ts) => ts ? new Date(ts) : undefined,
+  updatedAt:  (ts) => ts ? new Date(ts) : undefined,
+  lastUsedAt: (ts) => ts ? new Date(ts) : null,
+};

--- a/app/support/DbAdapter/index.js
+++ b/app/support/DbAdapter/index.js
@@ -29,6 +29,7 @@ import commentLikesTrait from './comment-likes';
 import allGroupsTrait from './all-groups';
 import summaryTrait from './summary';
 import invitationsTrait from './invitations';
+import appTokensTrait from './app-tokens';
 
 
 promisifyAll(redis.RedisClient.prototype);
@@ -80,4 +81,5 @@ export const DbAdapter = _.flow([
   allGroupsTrait,
   summaryTrait,
   invitationsTrait,
+  appTokensTrait,
 ])(DbAdapterBase);

--- a/app/support/DbAdapter/utils.js
+++ b/app/support/DbAdapter/utils.js
@@ -4,21 +4,18 @@ import _ from 'lodash';
 export const unexistedUID = '00000000-0000-0000-C000-000000000046';
 
 export function initObject(classDef, attrs, id, params) {
-  return new classDef({ ...attrs, ...{ id }, ...params });
+  return new classDef({ ...attrs, id, ...params });
 }
 
 export function prepareModelPayload(payload, namesMapping, valuesMapping) {
-  return _.transform(payload, (result, val, key) => {
-    let mappedVal = val;
+  const result = {};
+  const keys = _.intersection(Object.keys(payload), Object.keys(namesMapping));
 
-    if (valuesMapping[key]) {
-      mappedVal = valuesMapping[key](val);
-    }
-
+  for (const key of keys) {
     const mappedKey = namesMapping[key];
+    const mappedVal = valuesMapping[key] ? valuesMapping[key](payload[key]) : payload[key];
+    result[mappedKey] = mappedVal;
+  }
 
-    if (mappedKey) {
-      result[mappedKey] = mappedVal;
-    }
-  });
+  return result;
 }

--- a/app/support/ipv6.js
+++ b/app/support/ipv6.js
@@ -1,0 +1,186 @@
+// Octal (with leading zero) and hex (0x...) syntaxes are not supported!
+const ip4Octet = `25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]`;
+
+export class Address {
+  bytes = [
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+  ];
+
+  maskBits = 128;
+
+  /**
+   * Parses the string representation of IPv6/IPv4 address
+   *
+   * @param {string} str
+   */
+  constructor(str) {
+    const origStr = str;
+    const assert = (test = false) => {
+      if (!test) {
+        throw new Error(`Invalid IP address syntax: ${origStr}`);
+      }
+    };
+
+    // Have a mask?
+    let withMask = false
+
+    {
+      const m = /(.+)\/([1-9]\d*)$/.exec(str);
+
+      if (m) {
+        withMask = true;
+        [, str] = m;
+        this.maskBits = parseInt(m[2], 10);
+        assert(this.maskBits <= 128);
+      }
+    }
+
+    if (str === '::') {
+      return;
+    }
+
+    // Have IPv4 tail?
+    const m = new RegExp(`(^|.*:)(${ip4Octet})[.](${ip4Octet})[.](${ip4Octet})[.](${ip4Octet})$`).exec(str);
+
+    if (m) {
+      if (!m[1] && withMask) {
+        this.maskBits += 12 * 8;
+        assert(this.maskBits <= 128);
+      }
+
+      // Make IPv6 address like ::ffff:x.x.x.x
+      str = [
+        m[1] || '::ffff:',
+        ((parseInt(m[2], 10) << 8) + parseInt(m[3], 10)).toString(16),
+        ':',
+        ((parseInt(m[4], 10) << 8) + parseInt(m[5], 10)).toString(16),
+      ].join('');
+    }
+
+    const parts = str.split('::');
+    assert(parts.length <= 2);
+
+    const bytesBlocks = parts.map((part) => {
+      return part === '' ? [] : part.split(':').reduce((acc, word) => {
+        assert(/^[0-9a-f]{1,4}$/i.test(word));
+        const p = parseInt(word, 16);
+        return [...acc, p >> 8, p & 0xff];
+      }, []);
+    });
+
+    if (bytesBlocks.length === 1) {
+      assert(bytesBlocks[0].length === this.bytes.length);
+
+      for (let i = 0; i < bytesBlocks[0].length; i++) {
+        this.bytes[i] = bytesBlocks[0][i];
+      }
+    } else {
+      assert(bytesBlocks[0].length + bytesBlocks[1].length < this.bytes.length);
+
+      for (let i = 0; i < bytesBlocks[0].length; i++) {
+        this.bytes[i] = bytesBlocks[0][i];
+      }
+
+      for (let i = 0; i < bytesBlocks[1].length; i++) {
+        this.bytes[this.bytes.length - bytesBlocks[1].length + i] = bytesBlocks[1][i];
+      }
+    }
+
+    return;
+  }
+
+  /**
+   * Returns true if address is IPv4 i.e. matches the '::ffff:0:0/96' mask
+   *
+   * @returns {boolean}
+   */
+  isIP4() {
+    return ip4Mask.contains(this);
+  }
+
+  /**
+   * Formats address to string
+   *
+   * @returns {string}
+   */
+  toString() {
+    if (this.isIP4()) {
+      const mask = this.maskBits === 128 ? '' : `/${this.maskBits - 96}`;
+      return this.bytes.slice(12).map((n) => n.toString(10)).join('.') + mask;
+    }
+
+    const words = [];
+
+    for (let i = 0; i < this.bytes.length; i += 2) {
+      words[i / 2] = (this.bytes[i] << 8) + this.bytes[i + 1];
+    }
+
+    // Looking for the zero-words sequence
+    // with the maximum length
+    let maxZStart = -1, maxZLength = 0;
+    let zStart = -1, zLength = 0;
+
+    for (let i = 0; i < words.length; i++) {
+      if (words[i] === 0) {
+        if (zStart < 0) {
+          zStart = i;
+        }
+
+        if (++zLength > maxZLength) {
+          maxZStart = zStart;
+          maxZLength = zLength;
+        }
+      } else {
+        zStart = -1;
+        zLength = 0;
+      }
+    }
+
+    if (maxZStart < 0) {
+      // No zero blocks
+      return words.map((w) => w.toString(16)).join(':');
+    }
+
+    const mask = this.maskBits === 128 ? '' : `/${this.maskBits}`;
+    return [
+      words.slice(0, maxZStart).map((w) => w.toString(16)).join(':'),
+      words.slice(maxZStart + maxZLength).map((w) => w.toString(16)).join(':'),
+    ].join('::') + mask;
+  }
+
+  /**
+   * Returns true if this mask contains the subj address/mask
+   *
+   * @param {Address} mask
+   * @returns {boolean}
+   */
+  contains(subj) {
+    if (this.maskBits > subj.maskBits) {
+      return false;
+    }
+
+    const maskBytes = this.maskBits >> 3;
+    const restBits = this.maskBits - (maskBytes << 3);
+
+    for (let i = 0; i < maskBytes; i++) {
+      if (subj.bytes[i] !== this.bytes[i]) {
+        return false;
+      }
+    }
+
+    if (restBits > 0) {
+      const diffByte = subj.bytes[maskBytes] ^ this.bytes[maskBytes];
+
+      if ((diffByte >>> (8 - restBits)) !== 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+const ip4Mask = new Address('::ffff:0:0/96');

--- a/config/environment.js
+++ b/config/environment.js
@@ -73,6 +73,10 @@ exports.init = async function (app) {
     }
   }
 
+  if (config.trustProxyHeaders) {
+    app.proxy = true;
+  }
+
   app.use(koaBody({
     multipart:  true,
     formLimit:  config.attachments.fileSizeLimit,

--- a/config/environments/console.js
+++ b/config/environments/console.js
@@ -25,6 +25,10 @@ export function getConfig() {
     appRoot:                   '.',
     acceptHashedPasswordsOnly: false,
 
+    // Configure koa app to trust proxy headers:
+    // X-Forwarded-Host, X-Forwarded-Proto and X-Forwarded-For
+    trustProxyHeaders: false,
+
     onboardingUsername: 'welcome',
     recaptcha:          { enabled: false },
 

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -27,6 +27,10 @@ export function getConfig() {
     appRoot:                   '.',
     acceptHashedPasswordsOnly: false,
 
+    // Configure koa app to trust proxy headers:
+    // X-Forwarded-Host, X-Forwarded-Proto and X-Forwarded-For
+    trustProxyHeaders: false,
+
     logResponseTime:    true,
     // disableRealtime: true,
     onboardingUsername: 'welcome',

--- a/config/environments/test.js
+++ b/config/environments/test.js
@@ -16,6 +16,10 @@ export function getConfig() {
     appRoot:                   '.',
     acceptHashedPasswordsOnly: false,
 
+    // Configure koa app to trust proxy headers:
+    // X-Forwarded-Host, X-Forwarded-Proto and X-Forwarded-For
+    trustProxyHeaders: false,
+
     // disableRealtime: true,
     onboardingUsername: 'welcome',
     recaptcha:          { enabled: false },

--- a/migrations/20181209090032_app_tokens.js
+++ b/migrations/20181209090032_app_tokens.js
@@ -1,0 +1,36 @@
+export async function up(knex) {
+  await knex.schema.createTable('app_tokens', (table) => {
+    table.uuid('uid').defaultTo(knex.raw('gen_random_uuid()')).notNullable().primary();
+    table.uuid('user_id').notNullable()
+      .references('uid').inTable('users')
+      .onUpdate('cascade').onDelete('cascade');
+    table.text('title').notNullable();
+    table.boolean('is_active').defaultTo(false).notNullable();
+    table.integer('issue').defaultTo(1).notNullable();
+    table.timestamp('created_at').defaultTo(knex.fn.now()).notNullable();
+    table.timestamp('updated_at').defaultTo(knex.fn.now()).notNullable();
+    table.specificType('scopes', 'text[]').defaultTo(knex.raw('ARRAY[]::text[]')).notNullable();
+    table.jsonb('restrictions').defaultTo('{}').notNullable();
+    // Last usage
+    table.timestamp('last_used_at');
+    table.specificType('last_ip', 'inet');
+    table.text('last_user_agent');
+  });
+
+  await knex.schema.createTable('app_tokens_log', (table) => {
+    table.bigIncrements('id').notNullable().primary();
+    table.uuid('token_id').notNullable()
+      .references('uid').inTable('app_tokens')
+      .onUpdate('cascade').onDelete('cascade');
+    table.text('request').notNullable();
+    table.timestamp('date').defaultTo(knex.fn.now()).notNullable();
+    table.specificType('ip', 'inet').notNullable();
+    table.text('user_agent').notNullable();
+    table.jsonb('extra').defaultTo('{}').notNullable();
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.dropTableIfExists('app_tokens_log');
+  await knex.schema.dropTableIfExists('app_tokens');
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "music-metadata": "~3.5.2",
     "mv": "2.1.1",
     "n3": "~1.0.4",
+    "netmask": "~1.0.6",
     "node-cache": "~4.2.0",
     "node-fetch": "~2.3.0",
     "nodemailer": "~4.6.8",
@@ -132,6 +133,7 @@
     "socket.io-client": "~2.2.0",
     "superagent": "1.8.3",
     "unexpected": "~10.39.0",
+    "unexpected-date": "~1.2.1",
     "unexpected-moment": "~3.2.1",
     "unexpected-sinon": "~10.10.1",
     "xml-parser": "~1.2.1"

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "music-metadata": "~3.5.2",
     "mv": "2.1.1",
     "n3": "~1.0.4",
-    "netmask": "~1.0.6",
     "node-cache": "~4.2.0",
     "node-fetch": "~2.3.0",
     "nodemailer": "~4.6.8",

--- a/test/functional/app-tokens.js
+++ b/test/functional/app-tokens.js
@@ -268,6 +268,28 @@ describe('App tokens controller', () => {
         });
       });
     });
+
+    describe('Token with IP restrictions', () => {
+      let token;
+      before(async () => {
+        token = new AppTokenV1({
+          userId:       luna.user.id,
+          title:        'My app',
+          scopes:       ['read-my-info'],
+          restrictions: { netmasks: ['127.0.0.1/24'] },
+        });
+        await token.create();
+      });
+
+      it('should allow "/v1/users/me" request with token', async () => {
+        const resp = await request(
+          'GET', `/v1/users/me`,
+          null,
+          { 'X-Authentication-Token': token.tokenString() },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 200 });
+      });
+    });
   });
 });
 

--- a/test/functional/app-tokens.js
+++ b/test/functional/app-tokens.js
@@ -7,6 +7,7 @@ import { getSingleton } from '../../app/app';
 import { AppTokenV1, dbAdapter, PubSub } from '../../app/models';
 import { appTokensScopes } from '../../app/models/app-tokens-scopes';
 import { PubSubAdapter } from '../../app/support/PubSubAdapter';
+
 import {
   performRequest,
   createTestUsers,

--- a/test/functional/app-tokens.js
+++ b/test/functional/app-tokens.js
@@ -1,0 +1,284 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../dbCleaner';
+import { AppTokenV1, dbAdapter } from '../../app/models';
+import { appTokensScopes } from '../../app/models/app-tokens-scopes';
+import { performRequest, createTestUsers } from './functional_test_helper';
+import { UUID, appTokenInfo } from './schemaV2-helper';
+
+
+describe('App tokens controller', () => {
+  before(() => cleanDB($pg_database));
+
+  describe('Luna and Mars creates tokens', () => {
+    let luna, lunaToken;
+    let mars, marsToken;
+    before(async () => {
+      [luna, mars] = await createTestUsers(2);
+      lunaToken = new AppTokenV1({
+        userId: luna.user.id,
+        title:  'My app',
+        scopes: ['read-my-info', 'manage-posts'],
+      });
+      marsToken = new AppTokenV1({
+        userId: mars.user.id,
+        title:  'My app',
+        scopes: ['read-my-info', 'manage-posts'],
+      });
+      await Promise.all([lunaToken, marsToken].map((t) => t.create()));
+    });
+
+    it('should create token', async () => {
+      const resp = await request(
+        'POST', '/v2/app-tokens',
+        {
+          title:  'App1',
+          scopes: ['read-my-info', 'manage-posts'],
+        },
+        { 'X-Authentication-Token': luna.authToken },
+      );
+
+      expect(resp, 'to satisfy', {
+        token: {
+          id:            expect.it('to satisfy', UUID),
+          title:         'App1',
+          issue:         1,
+          scopes:        ['read-my-info', 'manage-posts'],
+          lastUsedAt:    null,
+          lastIP:        null,
+          lastUserAgent: null,
+        },
+        tokenString: expect.it('to be a string'),
+      });
+    });
+
+    it('should return "whoami" data with token', async () => {
+      const resp = await request(
+        'GET', '/v2/users/whoami',
+        null,
+        { 'X-Authentication-Token': lunaToken.tokenString() },
+      );
+      expect(resp, 'to satisfy', { users: { id: luna.user.id } });
+    });
+
+    it('should reject "/v1/users/:username" request with token', async () => {
+      const resp = await request(
+        'GET', `/v1/users/${luna.username}`,
+        null,
+        { 'X-Authentication-Token': lunaToken.tokenString() },
+      );
+      expect(resp, 'to have key', 'err');
+    });
+
+    describe('Invalidation', () => {
+      after(async () => {
+        await dbAdapter.updateAppToken(lunaToken.id, { isActive: true });
+      });
+
+      it('should invalidate token', async () => {
+        const resp = await request(
+          'DELETE', `/v2/app-tokens/${lunaToken.id}`,
+          null,
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 200 });
+      });
+
+      it('should invalidate invalidated token', async () => {
+        const resp = await request(
+          'DELETE', `/v2/app-tokens/${lunaToken.id}`,
+          null,
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp.__httpStatus, 'to be', 200);
+      });
+
+      it('should not invalidate token of another user', async () => {
+        const resp = await request(
+          'DELETE', `/v2/app-tokens/${marsToken.id}`,
+          null,
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 404 });
+      });
+
+      it('should reject "whoami" request with invalidated token', async () => {
+        const resp = await request(
+          'GET', '/v2/users/whoami',
+          null,
+          { 'X-Authentication-Token': lunaToken.tokenString() },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 403 });
+      });
+    });
+
+    describe('Reissue', () => {
+      let newLunaTokenString;
+
+      after(async () => {
+        await dbAdapter.updateAppToken(lunaToken.id, { isActive: true, issue: 1 });
+      });
+
+      it('should reissue token', async () => {
+        const resp = await request(
+          'POST', `/v2/app-tokens/${lunaToken.id}/reissue`,
+          {},
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp, 'to satisfy', {
+          token: {
+            ...appTokenInfo,
+            id:    lunaToken.id,
+            issue: 2, // <-- this
+          },
+          tokenString: expect.it('to be a string'),
+        });
+
+        newLunaTokenString = resp.tokenString;
+      });
+
+      it('should not reissue token of another user', async () => {
+        const resp = await request(
+          'POST', `/v2/app-tokens/${marsToken.id}/reissue`,
+          {},
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 404 });
+      });
+
+      it('should reissue token being auhtenticated by itself', async () => {
+        const resp = await request(
+          'POST', `/v2/app-tokens/${lunaToken.id}/reissue`,
+          {},
+          { 'X-Authentication-Token': newLunaTokenString },
+        );
+        expect(resp, 'to satisfy', {
+          __httpStatus: 200,
+          token:        { issue: 3 },
+        });
+
+        newLunaTokenString = resp.tokenString;
+      });
+
+      it('should not reissue token being auhtenticated by another app token', async () => {
+        const newToken = new AppTokenV1({
+          userId: luna.user.id,
+          title:  'My app 2',
+          scopes: ['read-my-info', 'manage-posts'],
+        });
+        await newToken.create();
+
+        const resp = await request(
+          'POST', `/v2/app-tokens/${lunaToken.id}/reissue`,
+          {},
+          { 'X-Authentication-Token': newToken.tokenString() },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 403 });
+      });
+
+      it('should not reissue inactivated token', async () => {
+        await lunaToken.inactivate();
+
+        const resp = await request(
+          'POST', `/v2/app-tokens/${lunaToken.id}/reissue`,
+          {},
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 404 });
+      });
+    });
+
+    describe('Title change', () => {
+      after(async () => {
+        await dbAdapter.updateAppToken(lunaToken.id, { isActive: true });
+      });
+
+      it('should change token title', async () => {
+        const resp = await request(
+          'PUT', `/v2/app-tokens/${lunaToken.id}`,
+          { title: 'New token title' },
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp, 'to satisfy', {
+          __httpStatus: 200,
+          token:        { title: 'New token title' },
+        });
+      });
+
+      it('should not change inactivated token title', async () => {
+        await lunaToken.inactivate();
+
+        const resp = await request(
+          'PUT', `/v2/app-tokens/${lunaToken.id}`,
+          { title: 'New token title' },
+          { 'X-Authentication-Token': luna.authToken },
+        );
+        expect(resp, 'to satisfy', { __httpStatus: 404 });
+      });
+    });
+
+    describe('Scopes list', () => {
+      it('should return app tokens scopes list', async () => {
+        const resp = await request('GET', `/v2/app-tokens/scopes`);
+        expect(resp, 'to equal', { scopes: appTokensScopes, __httpStatus: 200 });
+      });
+    });
+
+    describe('Tokens list', () => {
+      before(async () => {
+        await $pg_database.raw(`delete from app_tokens where user_id = :userId`, { userId: mars.user.id });
+
+        for (let i = 0; i < 3; i++) {
+          const token = new AppTokenV1({
+            userId: mars.user.id,
+            title:  `My token #${i + 1}`,
+            scopes: ['read-my-info', 'manage-posts'],
+          });
+          await token.create(); // eslint-disable-line no-await-in-loop
+        }
+      });
+
+      it('should return list of tokens', async () => {
+        const resp = await request(
+          'GET', `/v2/app-tokens`,
+          null,
+          { 'X-Authentication-Token': mars.authToken },
+        );
+        expect(resp, 'to satisfy', {
+          tokens: [
+            { ...appTokenInfo, title: 'My token #3' },
+            { ...appTokenInfo, title: 'My token #2' },
+            { ...appTokenInfo, title: 'My token #1' },
+          ],
+        });
+      });
+    });
+  });
+});
+
+async function request(method, path, body, headers = {}) {
+  const resp = await performRequest(path, {
+    method,
+    body:    method === 'GET' ? null : JSON.stringify(body),
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+  });
+  const textResponse =  await resp.text();
+  let json;
+
+  try {
+    json = JSON.parse(textResponse);
+  } catch (e) {
+    json = {
+      err: `invalid JSON: ${e.message}`,
+      textResponse,
+    };
+  }
+
+  json.__httpStatus = resp.status;
+  return json;
+}

--- a/test/functional/common-routing.js
+++ b/test/functional/common-routing.js
@@ -27,4 +27,14 @@ describe('Common API routing', () => {
     const respData = await resp.json();
     expect(respData, 'to satisfy', { err: 'API method not found: \'/v1/unexisting/method\'' });
   });
+
+  it(`should response '200 OK' to OPTIONS request`, async () => {
+    const resp = await fetch(`${app.context.config.host}/v2/users/whoami`, { method: 'OPTIONS' });
+    expect(resp.status, 'to be', 200);
+  });
+
+  it(`should response '404 Not Found' to OPTIONS request if API method is not exists`, async () => {
+    const resp = await fetch(`${app.context.config.host}/v1/unexisting/method`, { method: 'OPTIONS' });
+    expect(resp.status, 'to be', 404);
+  });
 });

--- a/test/functional/common-routing.js
+++ b/test/functional/common-routing.js
@@ -6,17 +6,25 @@ import { getSingleton } from '../../app/app'
 import { version as serverVersion } from '../../package.json';
 
 
-describe('Server version header', () => {
+describe('Common API routing', () => {
   let app
 
   before(async () => {
     app = await getSingleton()
   })
 
-  it(`should publish the X-Freefeed-Server response header`, async () => {
+  it(`should publish the X-Freefeed-Server (server version) and Date response header`, async () => {
     const resp = await fetch(`${app.context.config.host}/v2/users/whoami`);
     expect(resp.status, 'to be', 401);
     expect(resp.headers.get('X-Freefeed-Server'), 'to be', serverVersion);
     expect(resp.headers.get('Access-Control-Expose-Headers'), 'to contain', 'X-Freefeed-Server');
+    expect(resp.headers.get('Access-Control-Expose-Headers'), 'to contain', 'Date');
+  });
+
+  it(`should return error if API method is not exists`, async () => {
+    const resp = await fetch(`${app.context.config.host}/v1/unexisting/method`);
+    expect(resp.status, 'to be', 404);
+    const respData = await resp.json();
+    expect(respData, 'to satisfy', { err: 'API method not found: \'/v1/unexisting/method\'' });
   });
 });

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -7,6 +7,11 @@ export const boolString = (v) => expect(v, 'to be a string').and('to be one of',
 
 export const timeStampString = (v) => expect(v, 'to be a string').and('to match', /^\d+$/);
 
+export const iso8601TimeString = (v) => {
+  const d = new Date(v);
+  return expect(d instanceof Date && !isNaN(d), 'to be true');
+};
+
 export const UUID = (v) => expect(v, 'to match', /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-(8|9|a|b)[a-f0-9]{3}-[a-f0-9]{12}$/);
 
 export const userBasic = {
@@ -217,3 +222,19 @@ export const userSubscriptionsResponse = {
 };
 
 export const userSubscribersResponse = { subscribers: expect.it('to be an array').and('to be empty').or('to have items satisfying', user) };
+
+export const appTokenInfo = {
+  id:           expect.it('to satisfy', UUID),
+  title:        expect.it('to be a string'),
+  issue:        expect.it('to be a number'),
+  createdAt:    expect.it('to satisfy', iso8601TimeString),
+  updatedAt:    expect.it('to satisfy', iso8601TimeString),
+  scopes:       expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
+  restrictions: expect.it('to exhaustively satisfy', {
+    netmasks: expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
+    origins:  expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
+  }),
+  lastUsedAt:    expect.it('to be null').or('to satisfy', iso8601TimeString),
+  lastIP:        expect.it('to be null').or('to be a string'),
+  lastUserAgent: expect.it('to be null').or('to be a string'),
+};

--- a/test/functional/users.js
+++ b/test/functional/users.js
@@ -291,6 +291,48 @@ describe('UsersController', () => {
     })
   })
 
+  describe('#showMe()', () => {
+    let authToken, luna;
+    const user = {
+      username: 'Luna',
+      password: 'password'
+    }
+
+    beforeEach(async () => {
+      luna = await funcTestHelper.createUserAsync(user.username, user.password);
+      ({ authToken } = luna);
+    });
+
+    it('should return current user for a valid user', async () => {
+      const resp = await funcTestHelper.performRequest('/v1/users/me', {
+        method:  'GET',
+        headers: {
+          'Content-Type':           'application/json',
+          'X-Authentication-Token': authToken,
+        },
+      });
+
+      expect(resp.status, 'to be', 200);
+      const respData = await resp.json();
+      expect(respData, 'to satisfy', {
+        users: {
+          ...schema.user,
+          id:       luna.user.id,
+          username: luna.username,
+        }
+      });
+    });
+
+    it('should not return user for an anonymous', async () => {
+      const resp = await funcTestHelper.performRequest('/v1/users/me', {
+        method:  'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      expect(resp.status, 'to be', 401);
+    });
+  });
+
   describe('#subscribe()', () => {
     let lunaContext = {}
     let marsContext = {}

--- a/test/integration/controllers/with-auth-tokens-middleware.js
+++ b/test/integration/controllers/with-auth-tokens-middleware.js
@@ -1,0 +1,210 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import unexpected from 'unexpected';
+import unexpectedDate from 'unexpected-date';
+import jwt from 'jsonwebtoken'
+import uuidv4 from 'uuid/v4';
+
+import { load as configLoader } from '../../../config/config'
+import cleanDB from '../../dbCleaner';
+import { User, SessionTokenV0, AppTokenV1, dbAdapter } from '../../../app/models';
+import { withAuthToken, tokenFromJWT } from '../../../app/controllers/middlewares/with-auth-token';
+
+
+const config = configLoader()
+
+const expect = unexpected.clone();
+expect.use(unexpectedDate);
+
+describe('tokenFromJWT', () => {
+  before(() => cleanDB($pg_database));
+
+  let luna, sessToken, appToken;
+  before(async () => {
+    luna = new User({ username: 'luna', password: 'pw' });
+    await luna.create();
+    sessToken = new SessionTokenV0(luna.id);
+    appToken = new AppTokenV1({
+      userId:       luna.id,
+      title:        'My app',
+      scopes:       ['read-my-info'],
+      restrictions: {
+        netmasks: ['127.0.0.1/24'],
+        origins:  ['https://localhost']
+      }
+    });
+    await appToken.create();
+  });
+
+  const defaultContext = () => ({
+    headers:  { origin: 'https://localhost' },
+    remoteIP: '127.0.0.1',
+    route:    'GET /v2/users/whoami',
+  });
+
+  describe('anonymous access', () => {
+    it('should give anonymous access without token', async () => {
+      const result = await tokenFromJWT('', defaultContext());
+      expect(result, 'to be null');
+    });
+  });
+
+  describe('SessionTokenV0', () => {
+    it('should give access with correct token', async () => {
+      const result = await tokenFromJWT(sessToken.tokenString(), defaultContext());
+      expect(result, 'to satisfy', { authToken: sessToken, user: { id: luna.id } });
+    });
+
+    it('should give anonymous access with incorrect token', async () => {
+      const { secret } = config;
+      const fakeTokenString = jwt.sign({ userId: uuidv4() }, secret);
+
+      const result = await tokenFromJWT(fakeTokenString, defaultContext());
+      expect(result, 'to be null');
+    });
+  });
+
+  describe('AppTokenV1', () => {
+    it('should not give access with invalid token ID', async () => {
+      const { secret } = config;
+      const fakeTokenString = jwt.sign({
+        type:   AppTokenV1.TYPE,
+        id:     uuidv4(),
+        issue:  appToken.issue,
+        userId: appToken.userId,
+      }, secret);
+
+      await expect(tokenFromJWT(fakeTokenString, defaultContext()), 'to be rejected with', { status: 403 });
+    });
+
+    it('should not give access with invalid token issue number', async () => {
+      const { secret } = config;
+      const fakeTokenString = jwt.sign({
+        type:   AppTokenV1.TYPE,
+        id:     appToken.id,
+        issue:  appToken.issue + 1,
+        userId: appToken.userId,
+      }, secret);
+
+      await expect(tokenFromJWT(fakeTokenString, defaultContext()), 'to be rejected with', { status: 403 });
+    });
+
+    it('should not give access from invalid IP address', async () => {
+      const ctx = defaultContext();
+      ctx.remoteIP = '127.0.1.1';
+
+      await expect(tokenFromJWT(appToken.tokenString(), ctx), 'to be rejected with', { status: 403 });
+    });
+
+    it('should not give access from invalid origin', async () => {
+      const ctx = defaultContext();
+      ctx.headers['origin'] = 'https://evil.com';
+
+      await expect(tokenFromJWT(appToken.tokenString(), ctx), 'to be rejected with', { status: 403 });
+    });
+
+    it('should not give access to the invalid route', async () => {
+      const ctx = defaultContext();
+      ctx.route = 'GET /v1/invalid';
+
+      await expect(tokenFromJWT(appToken.tokenString(), ctx), 'to be rejected with', { status: 403 });
+    });
+
+    it('should give access with correct context', async () => {
+      const result = await tokenFromJWT(appToken.tokenString(), defaultContext());
+      expect(result, 'to satisfy', { authToken: appToken, user: { id: luna.id } });
+    });
+
+    it('should give access to always allowed route', async () => {
+      const ctx = defaultContext();
+      ctx.route = 'GET /v1/users/me';
+      const result = await tokenFromJWT(appToken.tokenString(), ctx);
+      expect(result, 'to satisfy', { authToken: appToken, user: { id: luna.id } });
+    });
+  });
+});
+
+describe('withAuthToken middleware', () => {
+  before(() => cleanDB($pg_database));
+
+  let luna;
+  before(async () => {
+    luna = new User({ username: 'luna', password: 'pw' });
+    await luna.create();
+  });
+
+  describe('AppTokenV1', () => {
+    let token;
+
+    const context = () => ({
+      ip:            '127.0.0.127',
+      method:        'POST',
+      url:           '/v1/posts',
+      _matchedRoute: '/v1/posts',
+      headers:       {
+        'user-agent': 'Lynx browser, Linux',
+        'x-real-ip':  '127.0.0.128',
+        'origin':     'https://localhost',
+      },
+      request: { body: {} },
+      state:   {},
+    });
+
+
+    before(async () => {
+      token = new AppTokenV1({
+        userId:       luna.id,
+        title:        'My app',
+        scopes:       ['read-my-info', 'manage-posts'],
+        restrictions: {
+          netmasks: ['127.0.0.1/24'],
+          origins:  ['https://localhost']
+        }
+      });
+      await token.create();
+    });
+
+    it('should set last* fields of token', async () => {
+      const t1 = new AppTokenV1({
+        userId:       luna.id,
+        title:        'My app',
+        scopes:       ['read-my-info', 'manage-posts'],
+        restrictions: {
+          netmasks: ['127.0.0.1/24'],
+          origins:  ['https://localhost']
+        }
+      });
+      await t1.create();
+
+      const ctx = context();
+      ctx.headers['x-authentication-token'] = t1.tokenString();
+      await withAuthToken(ctx, () => null);
+
+      const t2 = await dbAdapter.getAppTokenById(t1.id);
+      expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+      expect(t2.lastIP, 'to be', ctx.ip);
+      expect(t2.lastUserAgent, 'to be', ctx.headers['user-agent']);
+    });
+
+    it('should not write log entry after GET requests', async () => {
+      const { rows: logRows } = await $pg_database.raw('select * from app_tokens_log where token_id = :id limit 1', { id: token.id });
+      expect(logRows, 'to be empty');
+    });
+
+    it('should write log entry after POST request', async () => {
+      const ctx = context();
+      ctx.headers['x-authentication-token'] = token.tokenString();
+      ctx.state.appTokenLogPayload = { postId: 'post1' };
+      await withAuthToken(ctx, () => null);
+
+      const { rows: logRows } = await $pg_database.raw('select * from app_tokens_log where token_id = :id limit 1', { id: token.id });
+      expect(logRows, 'to satisfy', [{
+        token_id:   token.id,
+        request:    'POST /v1/posts',
+        ip:         '127.0.0.127',
+        user_agent: 'Lynx browser, Linux',
+        extra:      { postId: 'post1', 'x-real-ip': '127.0.0.128' },
+      }]);
+    });
+  });
+});

--- a/test/integration/controllers/with-auth-tokens-middleware.js
+++ b/test/integration/controllers/with-auth-tokens-middleware.js
@@ -133,6 +133,35 @@ describe('withAuthToken middleware', () => {
     await luna.create();
   });
 
+  describe('Token souces', () => {
+    let authToken;
+    before(() => authToken = new SessionTokenV0(luna.id).tokenString());
+
+    it('should accept token in ctx.query.authToken', async () => {
+      const ctx = { query: { authToken }, request: { body: {} }, headers: {}, state: {} };
+      await withAuthToken(ctx, () => null);
+      expect(ctx.state, 'to satisfy', { user: { id: luna.id } });
+    });
+
+    it('should accept token in ctx.request.body.authToken', async () => {
+      const ctx = { query: { }, request: { body: { authToken } }, headers: {}, state: {} };
+      await withAuthToken(ctx, () => null);
+      expect(ctx.state, 'to satisfy', { user: { id: luna.id } });
+    });
+
+    it(`should accept token in 'x-authentication-token' header`, async () => {
+      const ctx = { query: { }, request: { body: { } }, headers: { 'x-authentication-token': authToken }, state: {} };
+      await withAuthToken(ctx, () => null);
+      expect(ctx.state, 'to satisfy', { user: { id: luna.id } });
+    });
+
+    it(`should accept token in 'authorization' header`, async () => {
+      const ctx = { query: { }, request: { body: { } }, headers: { 'authorization': `Bearer ${authToken}` }, state: {} };
+      await withAuthToken(ctx, () => null);
+      expect(ctx.state, 'to satisfy', { user: { id: luna.id } });
+    });
+  });
+
   describe('AppTokenV1', () => {
     let token;
 

--- a/test/integration/models/auth-tokens.js
+++ b/test/integration/models/auth-tokens.js
@@ -1,0 +1,222 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import _ from 'lodash';
+import unexpected from 'unexpected';
+import unexpectedDate from 'unexpected-date';
+import jwt from 'jsonwebtoken'
+
+import cleanDB from '../../dbCleaner';
+import { User, SessionTokenV0, AppTokenV1, dbAdapter } from '../../../app/models';
+import { load as configLoader } from '../../../config/config'
+
+
+const expect = unexpected.clone();
+expect.use(unexpectedDate);
+
+const config = configLoader()
+
+describe('Auth Tokens', () => {
+  before(() => cleanDB($pg_database));
+
+  let luna;
+  before(async () => {
+    luna = new User({ username: 'luna', password: 'pw' });
+    await luna.create();
+  });
+
+  describe('SessionTokenV0', () => {
+    let  token;
+
+    before(() => {
+      token = new SessionTokenV0(luna.id);
+    });
+
+    it('should have a full access', () => {
+      expect(token.hasFullAccess(), 'to be true');
+    });
+
+    it('should hold Luna user ID', () => {
+      expect(token.userId, 'to be', luna.id);
+    });
+
+    it('should make a valid JWT', async () => {
+      const jToken = token.tokenString();
+      const decoded = await jwt.verifyAsync(jToken, config.secret);
+      expect(decoded, 'to not have key', 'type');
+      expect(decoded.userId, 'to be', luna.id);
+    });
+  });
+
+  describe('AppTokenV1', () => {
+    describe('Luna creates a token with "read-my-info" and "manage-posts" rights', () => {
+      let token;
+      before(async () => {
+        token = new AppTokenV1({
+          userId:       luna.id,
+          title:        'My app',
+          scopes:       ['read-my-info', 'manage-posts'],
+          restrictions: {
+            netmasks: ['127.0.0.1/24'],
+            origins:  ['https://localhost'],
+          },
+        });
+        await token.create();
+      });
+
+      it('should load token by id', async () => {
+        const t2 = await dbAdapter.getAppTokenById(token.id);
+        expect(t2 instanceof AppTokenV1, 'to be true');
+        expect(t2, 'to satisfy', _.pick(token, ['id', 'title', 'userId', 'issue', 'scopes', 'restrictions']));
+      });
+
+      it('should load token by id and issue', async () => {
+        const t2 = await dbAdapter.getActiveAppTokenByIdAndIssue(token.id, token.issue);
+        expect(t2 instanceof AppTokenV1, 'to be true');
+        expect(t2, 'to satisfy', _.pick(token, ['id', 'title', 'userId', 'issue', 'scopes', 'restrictions']));
+      });
+
+      it('should not load token by id and invalid issue', async () => {
+        const t2 = await dbAdapter.getActiveAppTokenByIdAndIssue(token.id, token.issue + 1);
+        expect(t2, 'to be null');
+      });
+
+      it('should inactivate token', async () => {
+        const t = new AppTokenV1({
+          userId: luna.id,
+          title:  'My app',
+        });
+        await t.create();
+        expect(t.isActive, 'to be true');
+        await t.inactivate();
+        expect(t.isActive, 'to be false');
+      });
+
+      it('should not load inactive token', async () => {
+        const t = new AppTokenV1({
+          userId: luna.id,
+          title:  'My app',
+        });
+        await t.create();
+        await t.inactivate();
+        const t2 = await dbAdapter.getActiveAppTokenByIdAndIssue(t.id, t.issue);
+        expect(t2, 'to be null');
+      });
+
+      it('should not have full access', () => {
+        expect(token.hasFullAccess(), 'to be false');
+      });
+
+      it('should hold a Luna user ID', () => {
+        expect(token.userId, 'to be', luna.id);
+      });
+
+      it('should make a valid JWT', async () => {
+        const jToken = token.tokenString();
+        const decoded = await jwt.verifyAsync(jToken, config.secret);
+        expect(decoded, 'to satisfy', {
+          type:   AppTokenV1.TYPE,
+          userId: luna.id,
+        });
+        expect(decoded.userId, 'to be', luna.id);
+      });
+
+      it('should reissue token', async () => {
+        const { issue } = token;
+        await token.reissue();
+        expect(token.issue, 'to be', issue + 1);
+      });
+
+      it('should change token title', async () => {
+        const { title } = token;
+        await token.setTitle(`${title} updated`);
+        expect(token.title, 'to be', `${title} updated`);
+      });
+
+      it('should set last* fields', async () => {
+        const ip = '127.0.0.127';
+        const userAgent = 'Lynx browser, Linux';
+
+        await token.registerUsage({ ip, userAgent });
+
+        const t2 = await dbAdapter.getAppTokenById(token.id);
+        expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+        expect(t2.lastIP, 'to be', ip);
+        expect(t2.lastUserAgent, 'to be', userAgent);
+      });
+
+      describe('logRequest', () => {
+        beforeEach(() => $pg_database.raw('delete from app_tokens_log'));
+
+        it('should write log entry after POST request', async () => {
+          const ctx = {
+            ip:            '127.0.0.127',
+            method:        'POST',
+            url:           '/v1/posts',
+            _matchedRoute: '/v1/posts',
+            headers:       {
+              'user-agent': 'Lynx browser, Linux',
+              'x-real-ip':  '127.0.0.128',
+              'origin':     'https://localhost',
+            },
+            state: {},
+          };
+
+          ctx.state.appTokenLogPayload = { postId: 'post1' };
+          await token.logRequest(ctx);
+
+          const { rows: logRows } = await $pg_database.raw('select * from app_tokens_log where token_id = :id limit 1', { id: token.id });
+          expect(logRows, 'to satisfy', [{
+            token_id:   token.id,
+            request:    'POST /v1/posts',
+            ip:         '127.0.0.127',
+            user_agent: 'Lynx browser, Linux',
+            extra:      { postId: 'post1', 'x-real-ip': '127.0.0.128' },
+          }]);
+        });
+
+        it('should not write log entry after GET request', async () => {
+          const ctx = {
+            ip:            '127.0.0.127',
+            method:        'GET', // <-- here
+            url:           '/v1/posts',
+            _matchedRoute: '/v1/posts',
+            headers:       {
+              'user-agent': 'Lynx browser, Linux',
+              'x-real-ip':  '127.0.0.128',
+              'origin':     'https://localhost',
+            },
+            state: {},
+          };
+
+          ctx.state.appTokenLogPayload = { postId: 'post1' };
+          await token.logRequest(ctx);
+
+          const { rows: logRows } = await $pg_database.raw('select * from app_tokens_log where token_id = :id limit 1', { id: token.id });
+          expect(logRows, 'to be empty');
+        });
+
+        it('should not write log entry after unsuccessful request', async () => {
+          const ctx = {
+            ip:            '127.0.0.127',
+            method:        'POST',
+            url:           '/v1/posts',
+            _matchedRoute: '/v1/posts',
+            headers:       {
+              'user-agent': 'Lynx browser, Linux',
+              'x-real-ip':  '127.0.0.128',
+              'origin':     'https://localhost',
+            },
+            state:  {},
+            status: 422, // <-- here
+          };
+
+          ctx.state.appTokenLogPayload = { postId: 'post1' };
+          await token.logRequest(ctx);
+
+          const { rows: logRows } = await $pg_database.raw('select * from app_tokens_log where token_id = :id limit 1', { id: token.id });
+          expect(logRows, 'to be empty');
+        });
+      });
+    });
+  });
+});

--- a/test/unit/support/ipv6.js
+++ b/test/unit/support/ipv6.js
@@ -1,0 +1,202 @@
+/* eslint-env node, mocha */
+import expect from 'unexpected'
+
+import { Address } from '../../../app/support/ipv6';
+
+
+describe('IPv6 parser', () => {
+  describe('Just addresses', () => {
+    it(`should parse '::' address`, () => {
+      const addr = new Address('::');
+      expect(addr.bytes, 'to equal', [
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+      ]);
+    });
+
+    it(`should parse IPv4 address`, () => {
+      const addr = new Address('127.0.0.1');
+      expect(addr.bytes, 'to equal', [
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0,  0xff, 0xff,
+        127, 0, 0, 1]);
+      expect(addr.isIP4(), 'to be true');
+    });
+
+    it(`should parse IPv4 tail with '::' prefix`, () => {
+      const addr = new Address('::127.0.0.1');
+      expect(addr.bytes, 'to equal', [
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        127, 0, 0, 1
+      ]);
+      expect(addr.isIP4(), 'to be false');
+    });
+
+    it(`should parse full-length IPv6 address`, () => {
+      const addr = new Address('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210');
+      expect(addr.bytes, 'to equal', [
+        0xFE, 0xDC, 0xBA, 0x98,
+        0x76, 0x54, 0x32, 0x10,
+        0xFE, 0xDC, 0xBA, 0x98,
+        0x76, 0x54, 0x32, 0x10,
+      ]);
+      expect(addr.isIP4(), 'to be false');
+    });
+
+    it(`should parse full-length IPv6 address without leading zeros`, () => {
+      const addr = new Address('1080:0:0:0:8:800:200C:417A');
+      expect(addr.bytes, 'to equal', [
+        0x10, 0x80, 0, 0,
+        0, 0, 0, 0,
+        0, 0x8, 0x8, 0,
+        0x20, 0x0C, 0x41, 0x7A,
+      ]);
+      expect(addr.isIP4(), 'to be false');
+    });
+
+    it(`should parse IPv6 address with missing zero blocks [1]`, () => {
+      const addr = new Address('FEDC:BA98:7654::FEDC:BA98:7654:3210');
+      expect(addr.bytes, 'to equal', [
+        0xFE, 0xDC, 0xBA, 0x98,
+        0x76, 0x54, 0, 0,
+        0xFE, 0xDC, 0xBA, 0x98,
+        0x76, 0x54, 0x32, 0x10,
+      ]);
+      expect(addr.isIP4(), 'to be false');
+    });
+
+    it(`should parse IPv6 address with missing zero blocks [2]`, () => {
+      const addr = new Address('FF01::101');
+      expect(addr.bytes, 'to equal', [
+        0xff, 0x01, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0x01, 0x01,
+      ]);
+      expect(addr.isIP4(), 'to be false');
+    });
+
+    it(`should parse IPv6 address with missing zero blocks at start`, () => {
+      const addr = new Address('::101');
+      expect(addr.bytes, 'to equal', [
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0x01, 0x01,
+      ]);
+      expect(addr.isIP4(), 'to be false');
+    });
+
+    it(`should parse IPv6 address with missing zero blocks at end`, () => {
+      const addr = new Address('FF01::');
+      expect(addr.bytes, 'to equal', [
+        0xff, 0x01, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+      ]);
+      expect(addr.isIP4(), 'to be false');
+    });
+
+    it(`should parse IPv4-in-IPv6 address`, () => {
+      const addr = new Address('::FFFF:129.144.52.38');
+      expect(addr.bytes, 'to equal', [
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0xff, 0xff,
+        129, 144, 52, 38,
+      ]);
+      expect(addr.isIP4(), 'to be true');
+    });
+
+    it(`should parse IPv4-in-IPv6 address in hex form`, () => {
+      const addr = new Address('::FFFF:8190:3426');
+      expect(addr.bytes, 'to equal', [
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0xff, 0xff,
+        0x81, 0x90, 0x34, 0x26,
+      ]);
+      expect(addr.isIP4(), 'to be true');
+    });
+  });
+
+  describe('Masks', () => {
+    it(`should parse IPv4 address with mask`, () => {
+      const addr = new Address('127.0.0.1/24');
+      expect(addr.maskBits, 'to be', 24 + 96);
+    });
+
+    it(`should parse IPv4-in-IPv6 address with mask`, () => {
+      const addr = new Address('::FFFF:129.144.52.38/120');
+      expect(addr.maskBits, 'to be', 120);
+    });
+
+    it(`should parse IPv6 address with mask`, () => {
+      const addr = new Address('FF01::/64');
+      expect(addr.maskBits, 'to be', 64);
+    });
+  });
+
+  describe('toString', () => {
+    it(`should stringify IPv4 address`, () => {
+      const addr = new Address('127.0.0.1');
+      expect(addr.toString(), 'to be', '127.0.0.1');
+    });
+
+    it(`should stringify full-length IPv6 address`, () => {
+      const addr = new Address('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210');
+      expect(addr.toString(), 'to be', 'fedc:ba98:7654:3210:fedc:ba98:7654:3210');
+    });
+
+    it(`should stringify IPv6 address with zero blocks`, () => {
+      const addr = new Address('::101');
+      expect(addr.toString(), 'to be', '::101');
+    });
+
+    it(`should stringify IPv4 mask`, () => {
+      const addr = new Address('127.0.0.1/8');
+      expect(addr.toString(), 'to be', '127.0.0.1/8');
+    });
+
+    it(`should stringify IPv6 mask`, () => {
+      const addr = new Address('FF01::/64');
+      expect(addr.toString(), 'to be', 'ff01::/64');
+    });
+  });
+
+  describe('contains', () => {
+    it(`address always contains itself`, () => {
+      expect(new Address('127.0.0.1').contains(new Address('127.0.0.1')), 'to be true');
+    });
+
+    it(`mask always contains itself`, () => {
+      expect(new Address('127.0.0.1/8').contains(new Address('127.0.0.1/8')), 'to be true');
+    });
+
+    it(`should not contain wider mask`, () => {
+      expect(new Address('127.0.0.1/16').contains(new Address('127.0.0.1/8')), 'to be false');
+    });
+
+    it(`should contain address`, () => {
+      expect(new Address('127.0.0.1/16').contains(new Address('127.0.10.18')), 'to be true');
+    });
+
+    it(`should not contain address not in mask`, () => {
+      expect(new Address('127.0.0.1/16').contains(new Address('127.1.10.18')), 'to be false');
+    });
+
+    it(`should contain address with not byte-aligned mask`, () => {
+      expect(new Address('127.0.0.0/15').contains(new Address('127.1.10.18')), 'to be true');
+    });
+
+    it(`should not contain address not in mask with not byte-aligned mask`, () => {
+      expect(new Address('127.0.0.0/15').contains(new Address('127.3.10.18')), 'to be false');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4508,11 +4508,6 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
-netmask@~1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
-  integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
-
 next-tick@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4508,6 +4508,11 @@ negotiator@0.6.1:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
   integrity sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=
 
+netmask@~1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
+  integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
+
 next-tick@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
@@ -6722,6 +6727,11 @@ unexpected-bluebird@2.9.34-longstack2:
   version "2.9.34-longstack2"
   resolved "https://registry.yarnpkg.com/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz#49acac753b0556ded6025210ee96182307d2b2c9"
   integrity sha1-SaysdTsFVt7WAlIQ7pYYIwfSssk=
+
+unexpected-date@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/unexpected-date/-/unexpected-date-1.2.1.tgz#7ad75dfc1ce08f4674a6d8066466debbbef87357"
+  integrity sha1-etdd/Bzgj0Z0ptgGZGbeu774c1c=
 
 unexpected-moment@~3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Server-side support of application tokens based on [this proposal](https://paper.dropbox.com/doc/FreeFeed--AbMAcrvnuQxbKAMLlTraJr1MAg-kRUQMDV0AltuhQfCxFwic).

There are two types of tokens: legacy session tokens (SessionTokenV0 model) and application tokens (AppTokenV1 model). Both models shares some methods: .tokenString() returns JWT of the token and .hasFullAccess() returns true/false if token has/hasn't unlimited acces to all user's data and API methods. 

SessionTokenV0 always has a full access, AppTokenV1 always has not. Some API methods has a restricted functionality with AppTokenV1:
 * Whoami does not return privateMeta data;
 * 'PUT /v1/users/:userId' does not update email with app token.

AppTokenV1 can be restricted by the following parameters:
 * API scopes (see app/models/app-tokens-scopes.js). Scope is a set of API routes available for this token;
 * Masks of the allowed remote IP addresses;
 * Origins of the allowed CORS requests.

Regardless of the scopes specified for the token, some API methods are always available:
 * 'GET /v1/users/me' — this method returns the same data as 'GET /v1/users/:username' but for the current user. It can be used as the lightweight version of 'whoami'.
 * 'POST /v2/app-tokens/:tokenId/reissue' — app token can reissue itself (and only itself). The other /v2/app-tokens API methods are available only for the full access (session) tokens.

TODO: we need to human-readable descriptions of the API scopes (see app/models/app-tokens-scopes.js).