### PR TITLE
Add a 'GET /v2/everything' API method

### DIFF
--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -250,7 +250,7 @@ async function genericTimeline(timeline, viewerId = null, params = {}) {
   }
 
   const postsIds = canViewUser ?
-    await dbAdapter.getTimelinePostsIds(timeline.name, timelineIds, viewerId, { ...params, authorsIds, activityFeedIds, limit: params.limit + 1 }) :
+    await dbAdapter.getTimelinePostsIds(timelineIds, viewerId, { ...params, authorsIds, activityFeedIds, limit: params.limit + 1 }) :
     [];
 
   const isLastPage = postsIds.length <= params.limit;

--- a/app/routes/api/v2/TimelinesRoute.js
+++ b/app/routes/api/v2/TimelinesRoute.js
@@ -1,9 +1,10 @@
-import { bestOf, ownTimeline, userTimeline, metatags } from '../../../controllers/api/v2/TimelinesController';
+import { bestOf, everything, ownTimeline, userTimeline, metatags } from '../../../controllers/api/v2/TimelinesController';
 import { timelineRSS } from '../../../controllers/api/v2/TimelinesRSS';
 
 
 export default function addRoutes(app) {
   app.get('/v2/bestof',                       bestOf);
+  app.get('/v2/everything',                   everything);
   app.get('/v2/timelines/home',               ownTimeline('RiverOfNews', { withLocalBumps: true }));
   app.get('/v2/timelines/filter/discussions', ownTimeline('MyDiscussions'));
   app.get('/v2/timelines/filter/directs',     ownTimeline('Directs'));

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -235,7 +235,7 @@ const postsTrait = (superClass) => class extends superClass {
   /**
    * Returns UIDs of timelines posts
    */
-  async getTimelinePostsIds(timelineName, timelineIntIds, viewerId = null, params = {}) {
+  async getTimelinePostsIds(timelineIntIds, viewerId = null, params = {}) {
     params = {
       limit:           30,
       offset:          0,

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -190,6 +190,12 @@ export const timelineResponse = {
   isLastPage: expect.it('to be a boolean'),
 };
 
+export const everythingResponse = {
+  ...timelineResponse,
+  timelines: expect.it('to be null'),
+  admins:    expect.it('to be an array').and('to be empty'),
+};
+
 export const allGroupsResponse = {
   withProtected: expect.it('to be a boolean'),
   groups:        expect.it('to be an array').and('to be empty').or('to have items satisfying', {

--- a/test/functional/timelines-everything.js
+++ b/test/functional/timelines-everything.js
@@ -1,0 +1,95 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected'
+
+import cleanDB from '../dbCleaner';
+import * as schema from './schemaV2-helper';
+import { performRequest, createTestUsers, createAndReturnPost, goProtected, goPrivate, unbanUser, banUser } from './functional_test_helper';
+
+
+describe('TimelinesControllerV2: Everything', () => {
+  // Luna is public, Mars is protected, Venus is private
+  let luna, mars, venus;
+  const posts = [];
+  before(async () => {
+    await cleanDB($pg_database);
+
+    ([luna, mars, venus] = await createTestUsers(3));
+    await goProtected(mars);
+    await goPrivate(venus);
+
+    // Luna, Mars and Venus wrote two post each in their feeds
+    for (let i = 0; i < 2; i++) {
+      posts.push(await createAndReturnPost(luna, 'Post')); // eslint-disable-line no-await-in-loop
+      posts.push(await createAndReturnPost(mars, 'Post')); // eslint-disable-line no-await-in-loop
+      posts.push(await createAndReturnPost(venus, 'Post')); // eslint-disable-line no-await-in-loop
+    }
+
+    // We will receive posts in reverse order
+    posts.reverse();
+  });
+
+  it('should return public posts to anonymous viewer', async () => {
+    const resp = await fetchEverything(null);
+    const publicPosts = posts.filter((p) => p.createdBy === luna.user.id);
+    expect(resp.posts, 'to equal', publicPosts);
+  });
+
+  it('should return public and protected posts to Luna', async () => {
+    const resp = await fetchEverything(luna);
+    const nonPrivatePosts = posts.filter((p) => p.createdBy === luna.user.id || p.createdBy === mars.user.id);
+    expect(resp.posts, 'to equal', nonPrivatePosts);
+  });
+
+  it('should return all posts to Venus', async () => {
+    const resp = await fetchEverything(venus);
+    expect(resp.posts, 'to equal', posts);
+  });
+
+  describe('Luna bans Mars', () => {
+    before(() => banUser(luna, mars));
+    after(() => unbanUser(luna, mars));
+
+    it('should return public posts to anonymous viewer', async () => {
+      const resp = await fetchEverything(null);
+      const publicPosts = posts.filter((p) => p.createdBy === luna.user.id);
+      expect(resp.posts, 'to equal', publicPosts);
+    });
+
+    it('should return Luna posts to Luna', async () => {
+      const resp = await fetchEverything(luna);
+      const nonPrivatePosts = posts.filter((p) => p.createdBy === luna.user.id);
+      expect(resp.posts, 'to equal', nonPrivatePosts);
+    });
+
+    it('should return Mars posts to Mars', async () => {
+      const resp = await fetchEverything(mars);
+      const nonPrivatePosts = posts.filter((p) => p.createdBy === mars.user.id);
+      expect(resp.posts, 'to equal', nonPrivatePosts);
+    });
+
+    it('should return all posts to Venus', async () => {
+      const resp = await fetchEverything(venus);
+      expect(resp.posts, 'to equal', posts);
+    });
+  });
+});
+
+async function fetchEverything(viewerContext = null) {
+  const headers = {};
+
+  if (viewerContext) {
+    headers['X-Authentication-Token'] = viewerContext.authToken;
+  }
+
+  const response = await performRequest(`/v2/everything`, {  headers });
+  const feed = await response.json();
+
+  // console.log(feed);
+  if (response.status !== 200) {
+    expect.fail('HTTP error (code {0}): {1}', response.status, feed.err);
+  }
+
+  expect(feed, 'to exhaustively satisfy', schema.everythingResponse);
+  return feed;
+}


### PR DESCRIPTION
This method returns all posts in the system except those that the current viewer cannot see because of privacy and bans.

The structure of method's response is the same as of other timeline responses but the top-level 'timelines' field is always null.