### PR TITLE
Add a 'homefeed-mode' parameter to the realtime room name

### DIFF
--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -3,7 +3,12 @@ import { escape as urlEscape } from 'querystring';
 import _ from 'lodash';
 import compose from 'koa-compose';
 
-import { dbAdapter } from '../../../models';
+import {
+  dbAdapter,
+  HOMEFEED_MODE_CLASSIC,
+  HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
+  HOMEFEED_MODE_FRIENDS_ONLY,
+} from '../../../models';
 import { load as configLoader } from '../../../../config/config';
 import { serializePostsCollection, serializePost, serializeComment, serializeAttachment } from '../../../serializers/v2/post';
 import { monitored, authRequired, targetUserRequired } from '../../middlewares';
@@ -12,30 +17,6 @@ import { userSerializerFunction } from '../../../serializers/v2/user';
 
 export const ORD_UPDATED = 'bumped';
 export const ORD_CREATED = 'created';
-
-/**
- * "Only friends" homefeed mode
- *
- * Displays posts from Posts/Directs feeds subscribed to by viewer.
- */
-export const HOMEFEED_MODE_FRIENDS_ONLY = 'friends-only';
-
-/**
- * "Classic" homefeed mode
- *
- * Displays posts from Posts/Directs feeds and propagable posts
- * from Comments/Likes feeds subscribed to by viewer.
- */
-export const HOMEFEED_MODE_CLASSIC = 'classic';
-
-/**
- * "All friends activity" homefeed mode
- *
- * Displays posts from Posts/Directs feeds and all (not only propagable) posts
- * from Comments/Likes feeds subscribed to by viewer. Also displays all posts
- * created by users subscribed to by viewer.
- */
-export const HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY = 'friends-all-activity';
 
 const config = configLoader();
 

--- a/app/models.js
+++ b/app/models.js
@@ -70,3 +70,9 @@ export const CommentSerializer             = commentSerializer();
 export const PubsubCommentSerializer       = pubsubCommentSerializer();
 export const PostSerializer                = postSerializer();
 export const TimelineSerializer            = timelineSerializer();
+
+export {
+  HOMEFEED_MODE_CLASSIC,
+  HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
+  HOMEFEED_MODE_FRIENDS_ONLY
+} from './models/timeline';

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -7,7 +7,12 @@ import { PubSub as pubSub } from '../models';
 import { getRoomsOfPost } from '../pubsub-listener';
 import { EventService } from '../support/EventService';
 import { List, intersection as listIntersection } from '../support/open-lists';
-import { HOMEFEED_MODE_CLASSIC, HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY } from './timeline';
+
+import {
+  HOMEFEED_MODE_FRIENDS_ONLY,
+  HOMEFEED_MODE_CLASSIC,
+  HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
+} from './timeline';
 
 
 export function addModel(dbAdapter) {
@@ -398,6 +403,21 @@ export function addModel(dbAdapter) {
         ]),
         'RiverOfNews',
       );
+    }
+
+    /**
+     * Same as getRiverOfNewsTimelines but returns the { [mode]: Timeline[] } hash
+     *
+     * @return {Object.<string, Timeline[]>}
+     */
+    async getRiverOfNewsTimelinesByModes() {
+      const keys = [
+        HOMEFEED_MODE_FRIENDS_ONLY,
+        HOMEFEED_MODE_CLASSIC,
+        HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
+      ];
+      const values = await Promise.all(keys.map((k) => this.getRiverOfNewsTimelines(k)));
+      return _.zipObject(keys, values);
     }
 
     /**

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -704,9 +704,10 @@ export function addModel(dbAdapter) {
         dbAdapter.statsLikeCreated(user.id),
       ]);
 
-      if (this.isPropagable === '1') {
-        // Local bumps
-        const prevRONs = await this.getRiverOfNewsTimelines();
+      // Local bumps
+      // We bump post in the widest homefeed mode (HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY)
+      {
+        const prevRONs = await this.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY);
         const prevRONsOwners = _.map(prevRONs, 'userId');
         const usersSubscribedToLikeFeed = await dbAdapter.getUsersSubscribedToTimelines([likesTimeline.id]);
         usersSubscribedToLikeFeed.push(user.id); // user always implicitly subscribed to their feeds

--- a/app/models/timeline.js
+++ b/app/models/timeline.js
@@ -1,6 +1,30 @@
 /* eslint babel/semi: "error" */
 import _ from 'lodash';
 
+/**
+ * "Only friends" homefeed mode
+ *
+ * Displays posts from Posts/Directs feeds subscribed to by viewer.
+ */
+export const HOMEFEED_MODE_FRIENDS_ONLY = 'friends-only';
+
+/**
+ * "Classic" homefeed mode
+ *
+ * Displays posts from Posts/Directs feeds and propagable posts
+ * from Comments/Likes feeds subscribed to by viewer.
+ */
+export const HOMEFEED_MODE_CLASSIC = 'classic';
+
+/**
+ * "All friends activity" homefeed mode
+ *
+ * Displays posts from Posts/Directs feeds and all (not only propagable) posts
+ * from Comments/Likes feeds subscribed to by viewer. Also displays all posts
+ * created by users subscribed to by viewer.
+ */
+export const HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY = 'friends-all-activity';
+
 
 export function addModel(dbAdapter) {
   class Timeline {

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -135,10 +135,9 @@ export default class PubsubListener {
       });
 
       const channelLists = await Promise.all(channelListsPromises);
-      await Promise.all(flatten(channelLists).map(async (channelId) => {
-        await socket.joinAsync(channelId);
-        debug(`${debugPrefix}: successfully subscribed to ${channelId}`);
-      }));
+      const roomsToSubscribe = flatten(channelLists);
+      await socket.joinAsync(roomsToSubscribe);
+      debug(`${debugPrefix}: successfully subscribed to ${roomsToSubscribe.join(', ')}`);
 
       const rooms = buildGroupedListOfSubscriptions(socket);
 

--- a/test/functional/local-bumps.js
+++ b/test/functional/local-bumps.js
@@ -154,8 +154,8 @@ describe('Local bumps', () => {
               await helper.subscribeToAsync(luna, celestials);
             });
 
-            it("should not bump liked post in the Luna's homefeed", async () => {
-              await expectHomefeed(luna, [...groupDefaultFeed, ...lunaDefaultHomefeed]);
+            it("should bump liked post in the Luna's homefeed", async () => {
+              await expectHomefeed(luna, bump(marsPostsInGroup[0], [...groupDefaultFeed, ...lunaDefaultHomefeed]));
             });
           });
         });

--- a/test/functional/timelinesV2.js
+++ b/test/functional/timelinesV2.js
@@ -7,13 +7,13 @@ import _ from 'lodash'
 import cleanDB from '../dbCleaner'
 import { getSingleton } from '../../app/app'
 import { DummyPublisher } from '../../app/pubsub'
-import { PubSub, dbAdapter } from '../../app/models'
 import {
+  PubSub,
+  dbAdapter,
   HOMEFEED_MODE_CLASSIC,
   HOMEFEED_MODE_FRIENDS_ONLY,
   HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
-} from '../../app/controllers/api/v2/TimelinesController';
-
+} from '../../app/models'
 import {
   createUserAsync,
   createAndReturnPost,

--- a/test/functional/timelinesV2.js
+++ b/test/functional/timelinesV2.js
@@ -14,6 +14,7 @@ import {
   HOMEFEED_MODE_FRIENDS_ONLY,
   HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
 } from '../../app/models'
+
 import {
   createUserAsync,
   createAndReturnPost,

--- a/test/integration/models/post/riverOfNews.js
+++ b/test/integration/models/post/riverOfNews.js
@@ -1,0 +1,140 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected'
+
+import cleanDB from '../../../dbCleaner'
+import {
+  dbAdapter,
+  User,
+  Group,
+  HOMEFEED_MODE_FRIENDS_ONLY,
+  HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY,
+  HOMEFEED_MODE_CLASSIC,
+} from '../../../../app/models'
+
+
+describe('Post getRiverOfNewsTimelines method', () => {
+  describe('Luna subscribed to Mars and Selenites and not subscribed to Venus and Celestials', () => {
+    let luna, mars, venus, selenites, celestials;
+    before(async () => {
+      await cleanDB($pg_database);
+      luna = new User({ username: 'luna', password: 'pw' });
+      mars = new User({ username: 'mars', password: 'pw' });
+      venus = new User({ username: 'venus', password: 'pw' });
+      selenites = new Group({ username: 'selenites' });
+      celestials = new Group({ username: 'celestials' });
+      await Promise.all([
+        luna.create(),
+        mars.create(),
+        venus.create(),
+      ]);
+      await Promise.all([
+        selenites.create(luna.id),
+        celestials.create(venus.id),
+      ]);
+
+      // Luna subscribed to Mars and Selenites
+      await luna.subscribeTo(mars);
+      await luna.subscribeTo(selenites);
+    });
+
+    it('shold bring post from Mars to Luna RoN in any mode', async () => {
+      const post = await createPost(mars);
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ONLY),
+        'to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_CLASSIC),
+        'to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY),
+        'to have an item satisfying', { userId: luna.id },
+      );
+    });
+
+    it('shold bring post from Venus to Selenites to Luna RoN in any mode', async () => {
+      const post = await createPost(venus, [selenites]);
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ONLY),
+        'to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_CLASSIC),
+        'to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY),
+        'to have an item satisfying', { userId: luna.id },
+      );
+    });
+
+    it('shold bring post from Venus liked by Mars to Luna RoN in wide and normal mode', async () => {
+      let post = await createPost(venus);
+      await post.addLike(mars);
+      post = await reloadPost(post);
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ONLY),
+        'not to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_CLASSIC),
+        'to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY),
+        'to have an item satisfying', { userId: luna.id },
+      );
+    });
+
+    it('shold bring post from Venus to Celestials liked by Mars to Luna RoN in wide mode', async () => {
+      let post = await createPost(venus, [celestials]);
+      await post.addLike(mars);
+      post = await reloadPost(post);
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ONLY),
+        'not to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_CLASSIC),
+        'not to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY),
+        'to have an item satisfying', { userId: luna.id },
+      );
+    });
+
+    it('shold bring post from Mars to Celestials  to Luna RoN in wide mode', async () => {
+      const post = await createPost(mars, [celestials]);
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ONLY),
+        'not to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_CLASSIC),
+        'not to have an item satisfying', { userId: luna.id },
+      );
+      expect(
+        await post.getRiverOfNewsTimelines(HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY),
+        'to have an item satisfying', { userId: luna.id },
+      );
+    });
+  });
+});
+
+async function createPost(author, feedOwners = []) {
+  if (feedOwners.length === 0) {
+    feedOwners.push(author);
+  }
+
+  const timelines = await Promise.all(feedOwners.map((u) => u.getPostsTimeline()));
+  const post = await author.newPost({ body: 'post', timelineIds: timelines.map((t) => t.id) });
+  await post.create();
+  return post;
+}
+
+async function reloadPost(post) {
+  return await dbAdapter.getPostById(post.id);
+}


### PR DESCRIPTION
Subscribing to the RiverOfNews realtime client can use 'timeline:UUID' room (the classic homefeed mode) or  'timeline:UUID?homefeed-mode=MODE' for the specific homefeed mode.