### PR TITLE
Add a global configurable timeout to all search SQL queries

### DIFF
--- a/app/support/DbAdapter/index.js
+++ b/app/support/DbAdapter/index.js
@@ -54,6 +54,8 @@ class DbAdapterBase {
 
     promisifyAll(this.cache);
     promisifyAll(this.memoryCache);
+
+    this.searchQueriesTimeout = config.performance.searchQueriesTimeout;
   }
 }
 

--- a/config/environments/console.js
+++ b/config/environments/console.js
@@ -116,5 +116,10 @@ export function getConfig() {
     options: {}
   };
 
+  config.performance = {
+    // PostgreSQL 'statement_timeout' for search queries in milliseconds (0 => no timeout)
+    searchQueriesTimeout: 0,
+  };
+
   return config;
 }

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -124,6 +124,11 @@ export function getConfig() {
     options: {}
   };
 
+  config.performance = {
+    // PostgreSQL 'statement_timeout' for search queries in milliseconds (0 => no timeout)
+    searchQueriesTimeout: 0,
+  };
+
   config.postgres = postgresConfig;
 
   return config;

--- a/config/environments/test.js
+++ b/config/environments/test.js
@@ -92,6 +92,11 @@ export function getConfig() {
     options: {}
   };
 
+  config.performance = {
+    // PostgreSQL 'statement_timeout' for search queries in milliseconds (0 => no timeout)
+    searchQueriesTimeout: 0,
+  };
+
   config.postgres = postgresConfig;
 
   return config;


### PR DESCRIPTION
Since search-related SQL queries are not optimal at this time, a hard timeout can prevent the server from hanging up.