### PR TITLE
Add API for app tokens to get info about itself and reissue itself

### DIFF
--- a/app/controllers/api/v2/AppTokensController.js
+++ b/app/controllers/api/v2/AppTokensController.js
@@ -97,7 +97,7 @@ export const reissue = compose([
     await token.reissue();
 
     ctx.body = {
-      token:       serializeAppToken(token),
+      token:       serializeAppToken(token, !currentToken.hasFullAccess()),
       tokenString: token.tokenString(),
     };
   },
@@ -129,23 +129,23 @@ export const list = compose([
 
     const tokens = await dbAdapter.listActiveAppTokens(user.id);
 
-    ctx.body = { tokens: tokens.map(serializeAppToken) };
+    ctx.body = { tokens: tokens.map((t) => serializeAppToken(t)) };
   },
 ]);
 
 export const scopes = (ctx) => (ctx.body = { scopes: appTokensScopes });
 
-function serializeAppToken(token) {
+function serializeAppToken(token, restricted = false) {
   return pick(token, [
     'id',
-    'title',
+    restricted || 'title',
     'issue',
     'createdAt',
     'updatedAt',
     'scopes',
     'restrictions',
-    'lastUsedAt',
-    'lastIP',
-    'lastUserAgent',
+    restricted || 'lastUsedAt',
+    restricted || 'lastIP',
+    restricted || 'lastUserAgent',
   ]);
 }

--- a/app/models/app-tokens-scopes.js
+++ b/app/models/app-tokens-scopes.js
@@ -1,5 +1,6 @@
 export const alwaysAllowedRoutes = [
   'GET /v1/users/me',
+  'GET /v2/app-tokens/current',
   'POST /v2/app-tokens/:tokenId/reissue',
 ];
 

--- a/app/models/app-tokens-scopes.js
+++ b/app/models/app-tokens-scopes.js
@@ -1,7 +1,7 @@
 export const alwaysAllowedRoutes = [
   'GET /v1/users/me',
   'GET /v2/app-tokens/current',
-  'POST /v2/app-tokens/:tokenId/reissue',
+  'POST /v2/app-tokens/current/reissue',
 ];
 
 export const appTokensScopes = [

--- a/app/routes/api/v2/AppTokens.js
+++ b/app/routes/api/v2/AppTokens.js
@@ -6,6 +6,7 @@ import {
   scopes,
   list,
   current,
+  reissueCurrent,
 } from '../../../controllers/api/v2/AppTokensController';
 
 
@@ -14,6 +15,7 @@ export default function addRoutes(app) {
   app.get('/v2/app-tokens', list);
   app.post('/v2/app-tokens', create);
   app.get('/v2/app-tokens/current', current);
+  app.post('/v2/app-tokens/current/reissue', reissueCurrent);
   app.post('/v2/app-tokens/:tokenId/reissue', reissue);
   app.put('/v2/app-tokens/:tokenId', update);
   app.delete('/v2/app-tokens/:tokenId', inactivate);

--- a/app/routes/api/v2/AppTokens.js
+++ b/app/routes/api/v2/AppTokens.js
@@ -5,6 +5,7 @@ import {
   update,
   scopes,
   list,
+  current,
 } from '../../../controllers/api/v2/AppTokensController';
 
 
@@ -12,6 +13,7 @@ export default function addRoutes(app) {
   app.get('/v2/app-tokens/scopes', scopes);
   app.get('/v2/app-tokens', list);
   app.post('/v2/app-tokens', create);
+  app.get('/v2/app-tokens/current', current);
   app.post('/v2/app-tokens/:tokenId/reissue', reissue);
   app.put('/v2/app-tokens/:tokenId', update);
   app.delete('/v2/app-tokens/:tokenId', inactivate);

--- a/test/functional/app-tokens.js
+++ b/test/functional/app-tokens.js
@@ -181,7 +181,7 @@ describe('App tokens controller', () => {
 
       it('should reissue token being auhtenticated by itself', async () => {
         const resp = await performJSONRequest(
-          'POST', `/v2/app-tokens/${lunaToken.id}/reissue`,
+          'POST', `/v2/app-tokens/current/reissue`,
           {},
           { 'X-Authentication-Token': newLunaTokenString },
         );
@@ -191,22 +191,6 @@ describe('App tokens controller', () => {
         });
 
         newLunaTokenString = resp.tokenString;
-      });
-
-      it('should not reissue token being auhtenticated by another app token', async () => {
-        const newToken = new AppTokenV1({
-          userId: luna.user.id,
-          title:  'My app 2',
-          scopes: ['read-my-info', 'manage-posts'],
-        });
-        await newToken.create();
-
-        const resp = await performJSONRequest(
-          'POST', `/v2/app-tokens/${lunaToken.id}/reissue`,
-          {},
-          { 'X-Authentication-Token': newToken.tokenString() },
-        );
-        expect(resp, 'to satisfy', { __httpCode: 403 });
       });
 
       it('should not reissue inactivated token', async () => {

--- a/test/functional/app-tokens.js
+++ b/test/functional/app-tokens.js
@@ -85,6 +85,24 @@ describe('App tokens controller', () => {
       expect(resp, 'to have key', 'err');
     });
 
+    it('should return current app token', async () => {
+      const resp = await performJSONRequest(
+        'GET', `/v2/app-tokens/current`,
+        null,
+        { 'X-Authentication-Token': lunaToken.tokenString() },
+      );
+      expect(resp, 'to satisfy', { __httpCode: 200, token: { ...appTokenInfoRestricted, id: lunaToken.id } });
+    });
+
+    it('should not return current app token being used with session token', async () => {
+      const resp = await performJSONRequest(
+        'GET', `/v2/app-tokens/current`,
+        null,
+        { 'X-Authentication-Token': luna.authToken },
+      );
+      expect(resp, 'to satisfy', { __httpCode: 400 });
+    });
+
     describe('Invalidation', () => {
       after(async () => {
         await dbAdapter.updateAppToken(lunaToken.id, { isActive: true });

--- a/test/functional/app-tokens.js
+++ b/test/functional/app-tokens.js
@@ -18,7 +18,7 @@ import {
   updateUserAsync,
   whoami,
 } from './functional_test_helper';
-import { UUID, appTokenInfo } from './schemaV2-helper';
+import { UUID, appTokenInfo, appTokenInfoRestricted } from './schemaV2-helper';
 import Session from './realtime-session';
 
 
@@ -169,7 +169,7 @@ describe('App tokens controller', () => {
         );
         expect(resp, 'to satisfy', {
           __httpCode: 200,
-          token:      { issue: 3 },
+          token:      { ...appTokenInfoRestricted, issue: 3 },
         });
 
         newLunaTokenString = resp.tokenString;

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -227,9 +227,8 @@ export const userSubscriptionsResponse = {
 
 export const userSubscribersResponse = { subscribers: expect.it('to be an array').and('to be empty').or('to have items satisfying', user) };
 
-export const appTokenInfo = {
+export const appTokenInfoRestricted = {
   id:           expect.it('to satisfy', UUID),
-  title:        expect.it('to be a string'),
   issue:        expect.it('to be a number'),
   createdAt:    expect.it('to satisfy', iso8601TimeString),
   updatedAt:    expect.it('to satisfy', iso8601TimeString),
@@ -238,6 +237,16 @@ export const appTokenInfo = {
     netmasks: expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
     origins:  expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
   }),
+  // Restricted fields
+  title:         expect.it('to be undefined'),
+  lastUsedAt:    expect.it('to be undefined'),
+  lastIP:        expect.it('to be undefined'),
+  lastUserAgent: expect.it('to be undefined'),
+};
+
+export const appTokenInfo = {
+  ...appTokenInfoRestricted,
+  title:         expect.it('to be a string'),
   lastUsedAt:    expect.it('to be null').or('to satisfy', iso8601TimeString),
   lastIP:        expect.it('to be null').or('to be a string'),
   lastUserAgent: expect.it('to be null').or('to be a string'),


### PR DESCRIPTION
Two methods was added:
 * `GET /v2/app-tokens/current` returns information about the current app token. The returning information is restricted and does not include token title, lastUsedAt, lastIP, lastUserAgent
* `POST /v2/app-tokens/current/reissue` reissues the current app tokens.

These API methods are always available regardless of the token access scopes.

💥 The '/v2/app-tokens/:tokenId/reissue' route is not available for app tokens anymore. They should use only /current routes to get info about itself and to reissue itself.