### PR TITLE
Remove all RiverOfNews feeds from the posts table

### DIFF
--- a/migrations/20200414105735_remove_ron_feeds.js
+++ b/migrations/20200414105735_remove_ron_feeds.js
@@ -1,0 +1,12 @@
+// Remove all RiverOfNews feeds from the posts table. We don't need them anymore
+// because of dynamic building of homefeeds.
+//
+// It is a long running (minutes) and non-reversible migration.
+export async function up(knex) {
+  await knex.raw(`with rons as (select array_agg(id) as ids from feeds where name = 'RiverOfNews')
+  update posts set feed_ids = posts.feed_ids - rons.ids from rons where posts.feed_ids && rons.ids`);
+}
+
+export async function down() {
+  // do nothing
+}


### PR DESCRIPTION
We don't need them anymore because of dynamic building of homefeeds.

It is a long running (minutes) and non-reversible migration.