### PR TITLE
Use CTE in search SQL query for better performance

### DIFF
--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -241,7 +241,7 @@ const searchTrait = (superClass) =>
         // user_id <> '222-222-222'`. It is better to filter `feed_ids &&` first
         // and `user_id <>` later. We force this order using the CTE (inPostsSQL
         // is mostly about `feed_ids &&` conditions).
-        inPostsSQL !== 'true' && `with posts as (select * from posts p where ${inPostsSQL})`,
+        inPostsSQL !== 'true' && `with posts as materialized (select * from posts p where ${inPostsSQL})`,
         fullPostsSQL,
         fullCommentsSQL && `union\n${fullCommentsSQL}`,
         `order by date desc limit ${+limit} offset ${+offset}`

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -67,7 +67,7 @@ const timelinesPostsTrait = (superClass) => class extends superClass {
       if (!wideSelect) {
         // Request with CTE for the relatively small feed
         return pgFormat(`
-          with posts as (
+          with posts as materialized (
             select p.* from 
               posts p
             where ${selectSQL}


### PR DESCRIPTION
It is about queries like `in:user -from:user`. PostgreSQL optimizer cannot properly optimize conditions like `where feed_ids && '{111}' and user_id <> '222-222-222'`. It is better to filter `feed_ids &&` first and `user_id <>` later. We force this order using the CTE.

⚠ Warning! PostgreSQL 12 required!