### PR TITLE
Use DB time to prevent synchronization issues

### DIFF
--- a/app/support/DbAdapter/index.js
+++ b/app/support/DbAdapter/index.js
@@ -33,6 +33,7 @@ import externalAuthTrait from './external-auth';
 import serverInfoTrait from './server-info';
 import searchTrait from './search';
 import { withDbHelpers } from './utils';
+import nowTrait from './now';
 
 
 promisifyAll(redis.RedisClient.prototype);
@@ -88,4 +89,5 @@ export const DbAdapter = _.flow([
   externalAuthTrait,
   serverInfoTrait,
   searchTrait,
+  nowTrait,
 ])(DbAdapterBase);

--- a/app/support/DbAdapter/now.js
+++ b/app/support/DbAdapter/now.js
@@ -1,0 +1,16 @@
+///////////////////////////////////////////////////
+// Now
+///////////////////////////////////////////////////
+
+export default function nowTrait(superClass) {
+  return class extends superClass {
+    /**
+     * Returns the current database time as ISO 8601 string
+     *
+     * This method exists for testing purposes, you should not use it in app code!
+     */
+    now() {
+      return this.database.getOne('select now()');
+    }
+  };
+}

--- a/app/support/DbAdapter/unread-directs.js
+++ b/app/support/DbAdapter/unread-directs.js
@@ -4,11 +4,9 @@
 
 const unreadDirectsTrait = (superClass) => class extends superClass {
   markAllDirectsAsRead(userId) {
-    const currentTime = new Date().toISOString()
-
-    const payload = { directs_read_at: currentTime }
-
-    return this.database('users').where('uid', userId).update(payload)
+    return this.database.raw(
+      `update users set directs_read_at = now() where uid = :userId`,
+      { userId });
   }
 
   async getUnreadDirectsNumber(userId) {

--- a/migrations/20200606144812_read_at_defaults.js
+++ b/migrations/20200606144812_read_at_defaults.js
@@ -1,0 +1,17 @@
+export const up = (knex) => knex.schema.raw(`do $$begin
+  update users set notifications_read_at = created_at where notifications_read_at is null;
+  alter table users alter column notifications_read_at set default now();
+  alter table users alter column notifications_read_at set not null;
+
+  update users set directs_read_at = created_at where directs_read_at is null;
+  alter table users alter column directs_read_at set default now();
+  alter table users alter column directs_read_at set not null;
+end$$`);
+
+export const down = (knex) => knex.schema.raw(`do $$begin
+  alter table users alter column notifications_read_at drop not null;
+  alter table users alter column notifications_read_at drop default;
+
+  alter table users alter column directs_read_at drop not null;
+  alter table users alter column directs_read_at drop default;
+end$$`);

--- a/test/integration/controllers/with-auth-tokens-middleware.js
+++ b/test/integration/controllers/with-auth-tokens-middleware.js
@@ -211,8 +211,11 @@ describe('withAuthToken middleware', () => {
       ctx.headers['x-authentication-token'] = t1.tokenString();
       await withAuthToken(ctx, () => null);
 
-      const t2 = await dbAdapter.getAppTokenById(t1.id);
-      expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+      const [t2, now] = await Promise.all([
+        dbAdapter.getAppTokenById(t1.id),
+        dbAdapter.now(),
+      ]);
+      expect(new Date(t2.lastUsedAt), 'to be close to', now);
       expect(t2.lastIP, 'to be', ctx.ip);
       expect(t2.lastUserAgent, 'to be', ctx.headers['user-agent']);
     });

--- a/test/integration/models/auth-tokens.js
+++ b/test/integration/models/auth-tokens.js
@@ -136,8 +136,11 @@ describe('Auth Tokens', () => {
 
         await token.registerUsage({ ip, userAgent });
 
-        const t2 = await dbAdapter.getAppTokenById(token.id);
-        expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+        const [t2, now] = await Promise.all([
+          dbAdapter.getAppTokenById(token.id),
+          dbAdapter.now(),
+        ]);
+        expect(new Date(t2.lastUsedAt), 'to be close to', now);
         expect(t2.lastIP, 'to be', ip);
         expect(t2.lastUserAgent, 'to be', userAgent);
       });
@@ -147,8 +150,11 @@ describe('Auth Tokens', () => {
 
         await token.registerUsage({ ip });
 
-        const t2 = await dbAdapter.getAppTokenById(token.id);
-        expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+        const [t2, now] = await Promise.all([
+          dbAdapter.getAppTokenById(token.id),
+          dbAdapter.now(),
+        ]);
+        expect(new Date(t2.lastUsedAt), 'to be close to', now);
         expect(t2.lastIP, 'to be', ip);
         expect(t2.lastUserAgent, 'to be', '');
       });


### PR DESCRIPTION
In general the DB and app servers may have slightly different times. If so,  we cannot just use app's `new Date()` to safe update or query the DB.