### PR TITLE
Add hide lists for home feeds

### DIFF
--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -184,6 +184,7 @@ async function genericTimeline(timeline = null, viewerId = null, params = {}) {
 
   const timelineIds = timeline ? [timeline.intId] : null;
   const activityFeedIds = [];
+  const activityHideIds = [];
   const authorsIds = [];
   let activityOnPropagable = true;
 
@@ -212,14 +213,17 @@ async function genericTimeline(timeline = null, viewerId = null, params = {}) {
 
       if (params.homefeedMode === HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY) {
         activityOnPropagable = false;
-        activityFeedIds.push(...activities);
         const friendsIds = await dbAdapter.getHomeFeedSubscriptions(timeline.id);
         authorsIds.push(...friendsIds);
 
         if (!authorsIds.includes(viewerId)) {
           authorsIds.push(viewerId);
         }
-      } else if (params.homefeedMode === HOMEFEED_MODE_CLASSIC) {
+      }
+
+      if (params.homefeedMode !== HOMEFEED_MODE_FRIENDS_ONLY) {
+        const hideIntIds = await dbAdapter.getHomeFeedHideListPostIntIds(timeline);
+        activityHideIds.push(...hideIntIds);
         activityFeedIds.push(...activities);
       }
     }
@@ -232,6 +236,7 @@ async function genericTimeline(timeline = null, viewerId = null, params = {}) {
       authorsIds,
       activityFeedIds,
       activityOnPropagable,
+      activityHideIds,
       limit: params.limit + 1,
     }) : [];
 

--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -211,7 +211,7 @@ async function genericTimeline(timeline = null, viewerId = null, params = {}) {
 
       if (params.homefeedMode === HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY) {
         timelineIds.push(...activities);
-        const friendsIds = await dbAdapter.getUserFriendIds(viewerId);
+        const friendsIds = await dbAdapter.getHomeFeedSubscriptions(timeline.id);
         authorsIds.push(...friendsIds);
 
         if (!authorsIds.includes(viewerId)) {

--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -185,6 +185,7 @@ async function genericTimeline(timeline = null, viewerId = null, params = {}) {
   const timelineIds = timeline ? [timeline.intId] : null;
   const activityFeedIds = [];
   const authorsIds = [];
+  let activityOnPropagable = true;
 
   if (params.withMyPosts) {
     authorsIds.push(viewerId);
@@ -210,7 +211,8 @@ async function genericTimeline(timeline = null, viewerId = null, params = {}) {
       }
 
       if (params.homefeedMode === HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY) {
-        timelineIds.push(...activities);
+        activityOnPropagable = false;
+        activityFeedIds.push(...activities);
         const friendsIds = await dbAdapter.getHomeFeedSubscriptions(timeline.id);
         authorsIds.push(...friendsIds);
 
@@ -225,8 +227,13 @@ async function genericTimeline(timeline = null, viewerId = null, params = {}) {
 
 
   const postsIds = (!timeline || await timeline.canShow(viewerId)) ?
-    await dbAdapter.getTimelinePostsIds(timelineIds, viewerId, { ...params, authorsIds, activityFeedIds, limit: params.limit + 1 }) :
-    [];
+    await dbAdapter.getTimelinePostsIds(timelineIds, viewerId, {
+      ...params,
+      authorsIds,
+      activityFeedIds,
+      activityOnPropagable,
+      limit: params.limit + 1,
+    }) : [];
 
   const isLastPage = postsIds.length <= params.limit;
 

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -594,11 +594,13 @@ export async function getRoomsOfPost(post) {
     if (t.isRiverOfNews()) {
       const inNarrowMode = riverOfNewsFeedsByModes[HOMEFEED_MODE_FRIENDS_ONLY].some((f) => f.id === t.id);
       const inClassicMode = riverOfNewsFeedsByModes[HOMEFEED_MODE_CLASSIC].some((f) => f.id === t.id);
-      return [
+      return t.isInherent ? [
         `timeline:${t.id}?homefeed-mode=${HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY}`,
-        inClassicMode && `timeline:${t.id}`, // Default mode
+        inClassicMode && `timeline:${t.id}`, // Default mode for inherent feed
         inClassicMode && `timeline:${t.id}?homefeed-mode=${HOMEFEED_MODE_CLASSIC}`,
         inNarrowMode && `timeline:${t.id}?homefeed-mode=${HOMEFEED_MODE_FRIENDS_ONLY}`,
+      ] : [
+        inNarrowMode && `timeline:${t.id}`, // The only available mode for auxiliary feed
       ];
     }
 

--- a/app/support/DbAdapter/index.js
+++ b/app/support/DbAdapter/index.js
@@ -33,6 +33,7 @@ import externalAuthTrait from './external-auth';
 import serverInfoTrait from './server-info';
 import searchTrait from './search';
 import { withDbHelpers } from './utils';
+import nowTrait from './now';
 
 
 promisifyAll(redis.RedisClient.prototype);
@@ -88,4 +89,5 @@ export const DbAdapter = _.flow([
   externalAuthTrait,
   serverInfoTrait,
   searchTrait,
+  nowTrait,
 ])(DbAdapterBase);

--- a/app/support/DbAdapter/now.js
+++ b/app/support/DbAdapter/now.js
@@ -1,0 +1,16 @@
+///////////////////////////////////////////////////
+// Now
+///////////////////////////////////////////////////
+
+export default function nowTrait(superClass) {
+  return class extends superClass {
+    /**
+     * Returns the current database time as ISO 8601 string
+     *
+     * This method exists for testing purposes, you should not use it in app code!
+     */
+    now() {
+      return this.database.getOne('select now()');
+    }
+  };
+}

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -16,7 +16,7 @@ import {
 import { List } from '../open-lists';
 import { Comment } from '../../models';
 
-import { sqlIn, sqlNotIn, sqlIntarrayIn } from './utils';
+import { sqlIn, sqlNotIn, sqlIntarrayIn, andJoin, orJoin } from './utils';
 
 ///////////////////////////////////////////////////
 // Search
@@ -372,32 +372,6 @@ const searchTrait = (superClass) =>
   };
 
 export default searchTrait;
-
-function joinThem(array, joinBy, defaultValue, shortcutValue, skipValue) {
-  if (array.some((x) => x === shortcutValue)) {
-    return shortcutValue;
-  }
-
-  const parts = array.filter((x) => !!x && x !== skipValue);
-
-  if (parts.length === 0) {
-    return defaultValue;
-  }
-
-  if (parts.length === 1) {
-    return parts[0];
-  }
-
-  return `(${parts.join(` ${joinBy} `)})`;
-}
-
-function andJoin(array, def = 'true') {
-  return joinThem(array, 'and', def, 'false', 'true');
-}
-
-function orJoin(array, def = 'false') {
-  return joinThem(array, 'or', def, 'true', 'false');
-}
 
 function walkWithScope(tokens, action) {
   let currentScope = IN_ALL;

--- a/app/support/DbAdapter/unread-directs.js
+++ b/app/support/DbAdapter/unread-directs.js
@@ -4,11 +4,9 @@
 
 const unreadDirectsTrait = (superClass) => class extends superClass {
   markAllDirectsAsRead(userId) {
-    const currentTime = new Date().toISOString()
-
-    const payload = { directs_read_at: currentTime }
-
-    return this.database('users').where('uid', userId).update(payload)
+    return this.database.raw(
+      `update users set directs_read_at = now() where uid = :userId`,
+      { userId });
   }
 
   async getUnreadDirectsNumber(userId) {

--- a/app/support/DbAdapter/utils.js
+++ b/app/support/DbAdapter/utils.js
@@ -98,3 +98,29 @@ export function withDbHelpers(db) {
   Object.setPrototypeOf(wrapper, db); // eslint-disable-line prefer-reflect
   return wrapper;
 }
+
+function joinThem(array, joinBy, defaultValue, shortcutValue, skipValue) {
+  if (array.some((x) => x === shortcutValue)) {
+    return shortcutValue;
+  }
+
+  const parts = array.filter((x) => !!x && x !== skipValue);
+
+  if (parts.length === 0) {
+    return defaultValue;
+  }
+
+  if (parts.length === 1) {
+    return parts[0];
+  }
+
+  return `(${parts.join(` ${joinBy} `)})`;
+}
+
+export function andJoin(array, def = 'true') {
+  return joinThem(array, 'and', def, 'false', 'true');
+}
+
+export function orJoin(array, def = 'false') {
+  return joinThem(array, 'or', def, 'true', 'false');
+}

--- a/app/support/exceptions.js
+++ b/app/support/exceptions.js
@@ -22,9 +22,9 @@ export function reportError(ctx) {
       }
     }
 
-    if ('internalQuery' in err) {
+    if ('internalQuery' in err || err.message.includes('when compiling RAW query')) {
       // looks like postgres err
-      Reflect.deleteProperty(err, 'message');  // do not expose DB internals
+      err.message = 'Dadabase-related internal error'; // do not expose DB internals
     }
 
     if (err && 'message' in err && err.message) {

--- a/migrations/20200606144812_read_at_defaults.js
+++ b/migrations/20200606144812_read_at_defaults.js
@@ -1,0 +1,17 @@
+export const up = (knex) => knex.schema.raw(`do $$begin
+  update users set notifications_read_at = created_at where notifications_read_at is null;
+  alter table users alter column notifications_read_at set default now();
+  alter table users alter column notifications_read_at set not null;
+
+  update users set directs_read_at = created_at where directs_read_at is null;
+  alter table users alter column directs_read_at set default now();
+  alter table users alter column directs_read_at set not null;
+end$$`);
+
+export const down = (knex) => knex.schema.raw(`do $$begin
+  alter table users alter column notifications_read_at drop not null;
+  alter table users alter column notifications_read_at drop default;
+
+  alter table users alter column directs_read_at drop not null;
+  alter table users alter column directs_read_at drop default;
+end$$`);

--- a/test/functional/multi-homefeeds.js
+++ b/test/functional/multi-homefeeds.js
@@ -662,6 +662,30 @@ describe(`Multiple home feeds API`, () => {
         await lunaSession.sendAsync('unsubscribe', { timeline: [secondaryHomeFeedId] });
         expect(event, 'to be fulfilled');
       });
+
+      it(`should not deliver 'comment:new' event to main home feed when Jupiter comments Venus' post`, async () => {
+        // Venus is friend of Luna but main home feed is not subscribed to Venus. So Venus is in main home feed hide list.
+        await lunaSession.sendAsync('subscribe', { timeline: [mainHomeFeedId] });
+        const event = lunaSession.notReceive('comment:new');
+        await Promise.all([
+          createCommentAsync(jupiter, venusPost.id, 'Comment'),
+          event,
+        ]);
+        await lunaSession.sendAsync('unsubscribe', { timeline: [mainHomeFeedId] });
+        await expect(event, 'to be fulfilled');
+      });
+
+      it(`should deliver 'comment:new' event to main home feed when Jupiter comments Saturn's post`, async () => {
+        // Saturn is not a friend of Luna, so Saturn is not in main home feed hide list.
+        await lunaSession.sendAsync('subscribe', { timeline: [mainHomeFeedId] });
+        const event = lunaSession.receive('comment:new');
+        await Promise.all([
+          createCommentAsync(jupiter, saturnPost.id, 'Comment'),
+          event,
+        ]);
+        await lunaSession.sendAsync('unsubscribe', { timeline: [mainHomeFeedId] });
+        await expect(event, 'to be fulfilled');
+      });
     });
   });
 });

--- a/test/integration/controllers/with-auth-tokens-middleware.js
+++ b/test/integration/controllers/with-auth-tokens-middleware.js
@@ -211,8 +211,11 @@ describe('withAuthToken middleware', () => {
       ctx.headers['x-authentication-token'] = t1.tokenString();
       await withAuthToken(ctx, () => null);
 
-      const t2 = await dbAdapter.getAppTokenById(t1.id);
-      expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+      const [t2, now] = await Promise.all([
+        dbAdapter.getAppTokenById(t1.id),
+        dbAdapter.now(),
+      ]);
+      expect(new Date(t2.lastUsedAt), 'to be close to', now);
       expect(t2.lastIP, 'to be', ctx.ip);
       expect(t2.lastUserAgent, 'to be', ctx.headers['user-agent']);
     });

--- a/test/integration/models/auth-tokens.js
+++ b/test/integration/models/auth-tokens.js
@@ -136,8 +136,11 @@ describe('Auth Tokens', () => {
 
         await token.registerUsage({ ip, userAgent });
 
-        const t2 = await dbAdapter.getAppTokenById(token.id);
-        expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+        const [t2, now] = await Promise.all([
+          dbAdapter.getAppTokenById(token.id),
+          dbAdapter.now(),
+        ]);
+        expect(new Date(t2.lastUsedAt), 'to be close to', now);
         expect(t2.lastIP, 'to be', ip);
         expect(t2.lastUserAgent, 'to be', userAgent);
       });
@@ -147,8 +150,11 @@ describe('Auth Tokens', () => {
 
         await token.registerUsage({ ip });
 
-        const t2 = await dbAdapter.getAppTokenById(token.id);
-        expect(new Date(t2.lastUsedAt), 'to be close to', new Date());
+        const [t2, now] = await Promise.all([
+          dbAdapter.getAppTokenById(token.id),
+          dbAdapter.now(),
+        ]);
+        expect(new Date(t2.lastUsedAt), 'to be close to', now);
         expect(t2.lastIP, 'to be', ip);
         expect(t2.lastUserAgent, 'to be', '');
       });

--- a/test/integration/models/multi-homefeeds.js
+++ b/test/integration/models/multi-homefeeds.js
@@ -455,7 +455,7 @@ describe(`Multiple home feeds`, () => {
     });
 
     it(`should return all hide lists for the given feeds`, async () => {
-      const lists = await dbAdapter.getHomeFeedHideLists([
+      const lists = await dbAdapter.getHomeFeedsHideLists([
         mainHomeFeedLuna.id,
         secondaryHomeFeedLuna.id,
         mainHomeFeedMars.id,

--- a/test/integration/models/multi-homefeeds.js
+++ b/test/integration/models/multi-homefeeds.js
@@ -453,5 +453,20 @@ describe(`Multiple home feeds`, () => {
         expect(hides, 'when sorted', 'to equal', expected.sort());
       }
     });
+
+    it(`should return all hide lists for the given feeds`, async () => {
+      const lists = await dbAdapter.getHomeFeedHideLists([
+        mainHomeFeedLuna.id,
+        secondaryHomeFeedLuna.id,
+        mainHomeFeedMars.id,
+        secondaryHomeFeedMars.id,
+      ]);
+      expect(lists, 'to satisfy', {
+        [mainHomeFeedLuna.id]:      expect.it('when sorted', 'to equal', [jupiter.id].sort()),
+        [secondaryHomeFeedLuna.id]: expect.it('when sorted', 'to equal', [mars.id, venus.id].sort()),
+        [mainHomeFeedMars.id]:      expect.it('when sorted', 'to equal', [].sort()),
+        [secondaryHomeFeedMars.id]: expect.it('when sorted', 'to equal', [luna.id, venus.id, saturn.id].sort()),
+      });
+    });
   });
 });

--- a/test/integration/models/multi-homefeeds.js
+++ b/test/integration/models/multi-homefeeds.js
@@ -305,7 +305,7 @@ describe(`Multiple home feeds`, () => {
         secondaryHomeFeed,
       ] =
       await Promise.all([
-        await luna.getRiverOfNewsTimeline(),
+        luna.getRiverOfNewsTimeline(),
         luna.createHomeFeed('The Second One'),
       ]);
     });
@@ -371,6 +371,87 @@ describe(`Multiple home feeds`, () => {
           { user_id: jupiter.id, homefeed_ids: [secondaryHomeFeed.id] },
           { user_id: saturn.id, homefeed_ids: [secondaryHomeFeed.id] },
         ].sort((a, b) => a.user_id.localeCompare(b.user_id)));
+    });
+  });
+
+  describe('Hide lists', () => {
+    before(() => cleanDB($pg_database));
+
+    let luna, mars, venus, jupiter, saturn,
+      mainHomeFeedLuna,
+      secondaryHomeFeedLuna,
+      mainHomeFeedMars,
+      secondaryHomeFeedMars;
+
+    before(async () => {
+      luna = new User({ username: 'luna', password: 'pw' });
+      mars = new User({ username: 'mars', password: 'pw' });
+      venus = new User({ username: 'venus', password: 'pw' });
+      jupiter = new User({ username: 'jupiter', password: 'pw' });
+      saturn = new User({ username: 'saturn', password: 'pw' });
+      await Promise.all([
+        luna.create(),
+        mars.create(),
+        venus.create(),
+        jupiter.create(),
+        saturn.create(),
+      ]);
+      [
+        mainHomeFeedLuna,
+        secondaryHomeFeedLuna,
+        mainHomeFeedMars,
+        secondaryHomeFeedMars,
+      ] =
+      await Promise.all([
+        luna.getRiverOfNewsTimeline(),
+        luna.createHomeFeed('The Second One'),
+        mars.getRiverOfNewsTimeline(),
+        mars.createHomeFeed('The Second One'),
+      ]);
+
+      await Promise.all([
+        luna.subscribeTo(mars),
+        luna.subscribeTo(venus),
+        luna.subscribeTo(jupiter),
+        mars.subscribeTo(luna),
+        mars.subscribeTo(venus),
+        mars.subscribeTo(saturn),
+      ]);
+
+      await mainHomeFeedLuna.updateHomeFeedSubscriptions([mars.id, venus.id]);
+      await secondaryHomeFeedLuna.updateHomeFeedSubscriptions([jupiter.id]);
+    });
+
+    function usersPostIntIds(users) {
+      return Promise.all(users.map((u) => u.getPostsTimelineIntId()));
+    }
+
+    it(`should return hide lists for Luna's home feeds`, async () => {
+      {
+        const hides = await dbAdapter.getHomeFeedHideListPostIntIds(mainHomeFeedLuna);
+        const expected = await usersPostIntIds([jupiter]);
+        expect(hides, 'when sorted', 'to equal', expected.sort());
+      }
+
+      {
+        const hides = await dbAdapter.getHomeFeedHideListPostIntIds(secondaryHomeFeedLuna);
+        const expected = await usersPostIntIds([mars, venus]);
+        expect(hides, 'when sorted', 'to equal', expected.sort());
+      }
+    });
+
+    it(`should return hide lists for Mars' home feeds`, async () => {
+      {
+        const hides = await dbAdapter.getHomeFeedHideListPostIntIds(mainHomeFeedMars);
+        const expected = await usersPostIntIds([]);
+        expect(hides, 'when sorted', 'to equal', expected.sort());
+      }
+
+      {
+        const hides = await dbAdapter.getHomeFeedHideListPostIntIds(secondaryHomeFeedMars);
+        const expected = await usersPostIntIds([luna, venus, saturn]);
+        expect(hides, 'when sorted', 'to equal', expected.sort());
+      }
     });
   });
 });


### PR DESCRIPTION
Let S is subscriptions of the given home feed and F is all subscriptions of the home feed owner. Then H = F - S is a home feed's _hide list_. 

Posts published to H's 'Posts' feeds and not published to the S' 'Posts' feeds will not be present in home feed. So if user is subscribed to X but exclude them from the main home feed, the X's posts will not appear in the main home feed.

These hide  lists only make sense for the main (inherent) home feeds. The auxiliary feeds are always working in HOMEFEED_MODE_FRIENDS_ONLY mode and showing posts only from S.

The hide list algorithms are pretty similar to our client-side user hides and we should merge them in the future.
