### PR TITLE
Send realtime event on group updated_at change

### DIFF
--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -129,6 +129,8 @@ export function addModel(dbAdapter) {
         EventService.onCommentChanged(this, true),
       ]);
 
+      await pubSub.updateGroupTimes(postDestFeeds.map((f) => f.userId));
+
       monitor.increment('users.comments');
     }
 

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -159,6 +159,8 @@ export function addModel(dbAdapter) {
         dbAdapter.statsPostCreated(this.userId),
       ]);
 
+      await pubSub.updateGroupTimes(destFeeds.map((f) => f.userId));
+
       return this;
     }
 
@@ -577,6 +579,8 @@ export function addModel(dbAdapter) {
       ];
 
       await Promise.all(promises);
+
+      await pubSub.updateGroupTimes(timelineOwnersIds);
     }
 
     async getOmittedComments() {

--- a/app/pubsub-stub.js
+++ b/app/pubsub-stub.js
@@ -30,4 +30,6 @@ export default class pubSubStub {
   savePost() {}
 
   unsavePost() {}
+
+  updateGroupTimes() {}
 }

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -20,6 +20,7 @@ export class DummyPublisher {
   globalUserUpdated() {}
   postSaved() {}
   postUnsaved() {}
+  groupTimesUpdated() {}
 }
 
 export default class pubSub {
@@ -125,5 +126,9 @@ export default class pubSub {
     const user = await dbAdapter.getUserById(userId);
     const payload = JSON.stringify(serializeUser(user));
     await this.publisher.globalUserUpdated(payload);
+  }
+
+  async updateGroupTimes(groupIds) {
+    await this.publisher.groupTimesUpdated(JSON.stringify({ groupIds }));
   }
 }

--- a/app/support/PubSubAdapter.js
+++ b/app/support/PubSubAdapter.js
@@ -15,6 +15,7 @@ export const eventNames = {
   COMMENT_LIKE_ADDED:   'comment_like:new',
   COMMENT_LIKE_REMOVED: 'comment_like:remove',
   GLOBAL_USER_UPDATED:  'global:user:update',
+  GROUP_TIMES_UPDATED:  ':GROUP_TIMES_UPDATED',
 }
 
 export class PubSubAdapter {
@@ -96,6 +97,10 @@ export class PubSubAdapter {
 
   globalUserUpdated(payload) {
     return this._publish(eventNames.GLOBAL_USER_UPDATED, payload);
+  }
+
+  groupTimesUpdated(payload) {
+    return this._publish(eventNames.GROUP_TIMES_UPDATED, payload);
   }
 
   ///////////////////////////////////////////////////


### PR DESCRIPTION
Groups updated_at field changes when the new post or comment creates in the group. In this case all group subscribers now receives the 'user:update' event with the 'updatedGroups' field that contains an array of serialized updated groups.

It should help to keep up-to-date the groups list in the right column. Closes #FreeFeed/issues/19 (it will need also client support)