### PR TITLE
Improve search: search by exact word form, by prefix and with word order operator

### DIFF
--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -10,9 +10,8 @@ import {
   Condition,
   IN_ALL,
   ScopeStart,
-  Text,
-  AnyText,
-  InScope
+  InScope,
+  SeqTexts
 } from '../search/query-tokens';
 import { List } from '../open-lists';
 import { Comment } from '../../models';
@@ -409,11 +408,7 @@ function getTSQuery(tokens, targetScope) {
   const result = [];
 
   walkWithScope(tokens, (token, currentScope) => {
-    if (token instanceof AnyText && currentScope === targetScope) {
-      result.push(token.toTSQuery());
-    }
-
-    if (token instanceof Text && currentScope === targetScope) {
+    if (token instanceof SeqTexts && currentScope === targetScope) {
       result.push(token.toTSQuery());
     }
 

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -10,6 +10,7 @@ import {
   Condition,
   IN_ALL,
   ScopeStart,
+  Text,
   AnyText,
   InScope
 } from '../search/query-tokens';
@@ -412,8 +413,12 @@ function getTSQuery(tokens, targetScope) {
       result.push(token.toTSQuery());
     }
 
+    if (token instanceof Text && currentScope === targetScope) {
+      result.push(token.toTSQuery());
+    }
+
     if (token instanceof InScope && token.scope === targetScope) {
-      result.push(...token.anyTexts.map((t) => t.toTSQuery()));
+      result.push(token.text.toTSQuery());
     }
   });
 

--- a/app/support/search/query-syntax.md
+++ b/app/support/search/query-syntax.md
@@ -6,12 +6,15 @@ You can put the minus sign (`-`) right before the text term or operator to _excl
 
 ## Text terms
 
-The text term is a word without whitespaces (like `cat`, or `#mouse` or even `http://freefeed.net/`) or a double-quoted string that can include spaces: `"cat mouse"`. Putting text in double quotes tells search engine to search these words in the specific order.
+The text term is a word without whitespaces (like `cat`, or `#mouse` or even `http://freefeed.net/`) or a double-quoted string that can include spaces: `"cat mouse"`. Putting text in double quotes tells search engine to search these words in the specific order and in exact word forms. It is also possible to search words by prefix (not in double quotes): `cat*`.
 
-By default _all_ text terms in query will be searched (AND operator is implied). You can use the "pipe" symbol (`|`) to search _any_ of them: `cat | mouse` will find documents with "cat" OR with "mouse". Two important rules about this operator:
+By default _all_ text terms in query will be searched (AND is implied). You can use the "pipe" symbol (`|`) to search _any_ of them: `cat | mouse` will find documents with "cat" OR with "mouse". To search words in the specific order use the "plus" symbol (`+`): `cat + mouse` means these two words standing next to each other in that order.
 
-1. The OR operator ranked higher than AND: `cat mouse | dog` means 'the documents with "cat" AND ("mouse" OR "dog")'.
-2. You can use the OR operator only with the text terms, not with the other operators.
+Two important rules about the `+` and `|` symbols:
+
+1. The `|` symbol has the higest priority: `cat mouse | dog` means 'the documents with "cat" AND ("mouse" OR "dog")'; `cat + mouse | dog` means 'the documents with "cat" FOLLOWEB_BY ("mouse" OR "dog")'.
+2. The AND symbol has the lowest priority: `cat + mouse dog` means 'the documents with ("cat" FOLLOWEB_BY "mouse") AND "dog"'.
+3. You can use the `|` and `+` symbols only between the text terms, not with the other operators.
 
 ## Operators
 

--- a/app/support/search/query-tokens.ts
+++ b/app/support/search/query-tokens.ts
@@ -71,10 +71,10 @@ export class Text implements Token {
               : token.text;
           return pgFormat(`%L::tsquery`, exactText);
         } else if (token instanceof Link) {
-          return pgFormat('phraseto_tsquery(%L, %L)', ftsCfg, linkToText(token));
+          return exactPhraseToTSQuery(linkToText(token));
         }
 
-        return pgFormat('phraseto_tsquery(%L, %L)', ftsCfg, token.text);
+        return exactPhraseToTSQuery(token.text);
       }).filter(Boolean);
 
       if (queries.length === 0) {
@@ -157,4 +157,8 @@ export function trimText(text: string) {
   }
 
   return text.replace(trimTextRe, '$1');
+}
+
+function exactPhraseToTSQuery(text: string): string {
+  return pgFormat(`regexp_replace(phraseto_tsquery('simple', %L)::text, '''([^ ])', '''=\\1', 'g')::tsquery`, text);
 }

--- a/app/support/search/query-tokens.ts
+++ b/app/support/search/query-tokens.ts
@@ -31,6 +31,16 @@ export class Pipe implements Token {
 }
 
 /**
+ * Plus represents the plus symbol (`+`). This token is used only on initial
+ * parsing phase, the Plus-joined tokens are converting to SeqTexts later.
+ */
+export class Plus implements Token {
+  getComplexity() {
+    return 0;
+  }
+}
+
+/**
  * ScopeStart marks the start of global query scope.
  */
 export class ScopeStart implements Token {
@@ -141,6 +151,25 @@ export class AnyText implements Token {
   toTSQuery() {
     const parts = this.children.map((t) => t.toTSQuery());
     return parts.length > 1 ? `(${parts.join(' || ')})` : parts[0];
+  }
+}
+
+/**
+ * SeqTexts contains one or more AnyText tokens. The query will find them in the
+ * specific order. Even a single AnyText must be wrapped in SeqTexts.
+ */
+export class SeqTexts implements Token {
+  constructor(
+    public children: AnyText[],
+  ) { }
+
+  getComplexity() {
+    return this.children.reduce((acc, t) => acc + t.getComplexity(), 0);
+  }
+
+  toTSQuery() {
+    const parts = this.children.map((t) => t.toTSQuery());
+    return parts.length > 1 ? `(${parts.join(' <-> ')})` : parts[0];
   }
 }
 

--- a/app/support/search/to-tsvector.ts
+++ b/app/support/search/to-tsvector.ts
@@ -18,7 +18,7 @@ export function toTSVector(text: string) {
         ? token.text.replace(/[_-]/g, '') // join parts of hashtag to ignore separators
         : token.text;
       return pgFormat(
-        `(to_tsvector(%L, %L)::text || ' ' || %L)::tsvector`,
+        `(to_tsvector_with_exact(%L, %L)::text || ' ' || %L)::tsvector`,
         ftsCfg,
         token.text.substring(1).replace(/[_-]+/g, ' '), // convert separated text to phrase
         `'${exactText}':1`
@@ -26,11 +26,11 @@ export function toTSVector(text: string) {
     }
 
     if (token instanceof Link) {
-      return pgFormat(`to_tsvector(%L, %L)`, ftsCfg, linkToText(token));
+      return pgFormat(`to_tsvector_with_exact(%L, %L)`, ftsCfg, linkToText(token));
     }
 
     const trimmedText = token.text.trim();
-    return trimmedText && pgFormat('to_tsvector(%L, %L)', ftsCfg, trimmedText);
+    return trimmedText && pgFormat('to_tsvector_with_exact(%L, %L)', ftsCfg, trimmedText);
   }).filter(Boolean);
 
   if (vectors.length === 0) {

--- a/app/support/search/to-tsvector.ts
+++ b/app/support/search/to-tsvector.ts
@@ -13,21 +13,31 @@ const ftsCfg = config.postgres.textSearchConfigName;
 export function toTSVector(text: string) {
   const vectors = tokenize(normalizeText(text || '')).map((token) => {
     if (token instanceof HashTag || token instanceof Mention) {
-      // Mentions and hashtags should be found by exact @-query or by regular word query
-      const exactText =
-        token instanceof HashTag ? token.text.replace(/[_-]/g, '') : token.text;
+      // Mentions and hashtags should be found by exact @/#-query or by regular word query
+      const exactText = token instanceof HashTag
+        ? token.text.replace(/[_-]/g, '') // join parts of hashtag to ignore separators
+        : token.text;
       return pgFormat(
         `(to_tsvector(%L, %L)::text || ' ' || %L)::tsvector`,
         ftsCfg,
-        token.text.replace(/[_-]+/g, ' '),
+        token.text.substring(1).replace(/[_-]+/g, ' '), // convert separated text to phrase
         `'${exactText}':1`
       );
-    } else if (token instanceof Link) {
+    }
+
+    if (token instanceof Link) {
       return pgFormat(`to_tsvector(%L, %L)`, ftsCfg, linkToText(token));
     }
 
-    return pgFormat('to_tsvector(%L, %L)', ftsCfg, token.text);
-  });
+    const trimmedText = token.text.trim();
+    return trimmedText && pgFormat('to_tsvector(%L, %L)', ftsCfg, trimmedText);
+  }).filter(Boolean);
 
-  return vectors.length > 0 ? `(${vectors.join('||')})` : `to_tsvector('')`;
+  if (vectors.length === 0) {
+    return `''::tsvector`;
+  } else if (vectors.length === 1) {
+    return vectors[0];
+  }
+
+  return `(${vectors.join(' || ')})`;
 }

--- a/config/default.js
+++ b/config/default.js
@@ -214,7 +214,10 @@ config.registrationsLimit = {
   maxCount: 100
 };
 
-config.search = { maxQueryComplexity: 30 };
+config.search = {
+  maxQueryComplexity: 30,
+  minPrefixLength:    2,
+};
 
 config.maintenance = { messageFile: 'tmp/MAINTENANCE.txt' };
 

--- a/migrations/20200725165312_exact-search.js
+++ b/migrations/20200725165312_exact-search.js
@@ -1,0 +1,27 @@
+/**
+ * The to_tsvector_with_exact function calculates the standard (stemmed)
+ * tsvector and the vector with the exact wordforms. These vectors mixed so that
+ * the stemmed and exact words are shared the same positions:
+ *
+ * '=fox':1 '=jumps':2 '=over':3 'fox':1 'jump':2
+ */
+
+export const up = (knex) => knex.schema.raw(`do $$begin
+  create function to_tsvector_with_exact(cfg regconfig, str text)
+    returns tsvector
+    language 'sql'
+  AS $BODY$
+    select array_to_string(array_cat(
+      -- Standard to_tsvector with cfg
+      string_to_array(to_tsvector(cfg, str)::text, ' '),
+      -- Exact wordorms with 'simple' configuration and '=' prefixes
+      -- The result is like '=dog':4 '=fox':1 '=jumps':2 '=over':3
+      string_to_array(
+        regexp_replace(to_tsvector('simple', str)::text, '''([^:])', '''=\\1', 'g'), ' ')
+    ), ' ')::tsvector;
+  $BODY$;
+end$$`);
+
+export const down = (knex) => knex.schema.raw(`do $$begin
+  drop function to_tsvector_with_exact(cfg regconfig, str text);
+end$$`);

--- a/test/integration/support/DbAdapter/search.js
+++ b/test/integration/support/DbAdapter/search.js
@@ -566,8 +566,23 @@ describe('Search', () => {
         filter: (p) => /@celestials/.test(p.body)
       },
       {
-        query:  '"mention @celestials"',
-        filter: (p) => /@celestials/.test(p.body)
+        query:   '"mention @celestials"',
+        filter:  () => false,
+        comment: 'no post with exact wordforms'
+      },
+      {
+        query:   '"mentions @celestials"',
+        filter:  (p) => /@celestials/.test(p.body),
+        comment: 'one post with exact exact wordforms'
+      },
+      {
+        query:   'posts "mentions @celestials"',
+        filter:  (p) => /@celestials/.test(p.body),
+        comment: 'word + exact exact wordforms'
+      },
+      {
+        query:  '"celestials"',
+        filter: (p) => /@celestials/.test(p.body),
       },
       {
         query:   '"@celestials mention"',

--- a/test/integration/support/DbAdapter/search.js
+++ b/test/integration/support/DbAdapter/search.js
@@ -679,7 +679,37 @@ describe('Search', () => {
       {
         query:  'words',
         filter: (p) => /time/.test(p.body)
-      }
+      },
+      {
+        query:   'ment*',
+        filter:  (p) => /ment/.test(p.body),
+        comment: 'wildcard'
+      },
+      {
+        query:   '#ment*',
+        filter:  (p) => /#ment/.test(p.body),
+        comment: 'wildcard in hashtag'
+      },
+      {
+        query:   'com*',
+        filter:  (p) => /com/.test(p.body),
+        comment: 'wildcard that contains full word'
+      },
+      {
+        query:   'co*',
+        filter:  (p) => /\bco/.test(p.body),
+        comment: 'short wildcard'
+      },
+      {
+        query:   '*',
+        filter:  () => false,
+        comment: '"*" wildcard is not supported'
+      },
+      {
+        query:   'mention + luna',
+        filter:  (p) => /first/.test(p.body),
+        comment: 'plus operator'
+      },
     ]);
   });
 

--- a/test/integration/support/DbAdapter/search.js
+++ b/test/integration/support/DbAdapter/search.js
@@ -317,6 +317,16 @@ describe('Search', () => {
             filter:     (p) => p.userId === luna.id
           },
           {
+            query:      'from:luna from:luna',
+            viewerName: 'luna',
+            filter:     (p) => p.userId === luna.id
+          },
+          {
+            query:      'from:me from:luna',
+            viewerName: 'luna',
+            filter:     (p) => p.userId === luna.id
+          },
+          {
             query:  'from:unknown',
             filter: () => false
           },

--- a/test/unit/support/search/parser.ts
+++ b/test/unit/support/search/parser.ts
@@ -83,36 +83,34 @@ describe('search:parseQuery', () => {
       query:  'inbody: in-comment:"a b"',
       result: [
         new ScopeStart(IN_POSTS),
-        new InScope(IN_COMMENTS, [new AnyText([new Text(false, true, 'a b')])])
+        new InScope(IN_COMMENTS, new AnyText([new Text(false, true, 'a b')]))
       ]
     },
     {
       query:  'inbody: -in-comment:qwer',
       result: [
         new ScopeStart(IN_POSTS),
-        new InScope(IN_COMMENTS, [new AnyText([new Text(true, false, 'qwer')])])
+        new InScope(IN_COMMENTS, new AnyText([new Text(true, false, 'qwer')]))
       ]
     },
     {
       query:  'inbody: -in-comment:qwer,ty',
       result: [
         new ScopeStart(IN_POSTS),
-        new InScope(IN_COMMENTS, [
-          new AnyText([new Text(true, false, 'qwer')]),
-          new AnyText([new Text(true, false, 'ty')])
-        ])
+        new InScope(IN_COMMENTS, new AnyText([new Text(true, false, 'qwer')])),
+        new InScope(IN_COMMENTS, new AnyText([new Text(true, false, 'ty')])),
       ]
     },
     {
       query:  'inbody: in-comment:qwer,ty',
       result: [
         new ScopeStart(IN_POSTS),
-        new InScope(IN_COMMENTS, [
+        new InScope(IN_COMMENTS,
           new AnyText([
             new Text(false, false, 'qwer'),
             new Text(false, false, 'ty')
           ])
-        ])
+        )
       ]
     }
   ];

--- a/test/unit/support/search/to-tsvector.ts
+++ b/test/unit/support/search/to-tsvector.ts
@@ -18,7 +18,7 @@ describe('toTSVector', () => {
 
   it('should return vector of regular text', () => {
     const string = 'the quick brown fox jumped over the lazy dog';
-    expect(toTSVector(string), 'to be', `to_tsvector('${ftsCfg}', '${string}')`);
+    expect(toTSVector(string), 'to be', `to_tsvector_with_exact('${ftsCfg}', '${string}')`);
   });
 
   it('should return vector of text with mentions and hashtags', () => {
@@ -26,13 +26,13 @@ describe('toTSVector', () => {
     expect(
       toTSVector(string), 'to be',
       `(`
-      + `to_tsvector('${ftsCfg}', 'the quick brown') || `
+      + `to_tsvector_with_exact('${ftsCfg}', 'the quick brown') || `
       + `(`
-        + `to_tsvector('${ftsCfg}', 'fox jump')::text || ' ' || `
+        + `to_tsvector_with_exact('${ftsCfg}', 'fox jump')::text || ' ' || `
         + `'''@fox-jump'':1'`
       + `)::tsvector || `
       + `(`
-        + `to_tsvector('${ftsCfg}', 'lazy dog')::text || ' ' || `
+        + `to_tsvector_with_exact('${ftsCfg}', 'lazy dog')::text || ' ' || `
         + `'''#lazydog'':1'`
       + `)::tsvector`
       + `)`
@@ -44,8 +44,8 @@ describe('toTSVector', () => {
     expect(
       toTSVector(string), 'to be',
       `(`
-      + `to_tsvector('${ftsCfg}', 'the quick brown') || `
-      + `to_tsvector('${ftsCfg}', 'foxnews com')`
+      + `to_tsvector_with_exact('${ftsCfg}', 'the quick brown') || `
+      + `to_tsvector_with_exact('${ftsCfg}', 'foxnews com')`
       + `)`
     );
   });

--- a/test/unit/support/search/to-tsvector.ts
+++ b/test/unit/support/search/to-tsvector.ts
@@ -1,17 +1,52 @@
 /* eslint-env node, mocha */
 import expect from 'unexpected';
+import config from 'config';
 
 import { toTSVector } from '../../../../app/support/search/to-tsvector';
 
-/**
- * It is not a full test but just test of some corner cases
- */
+
+const ftsCfg = config.postgres.textSearchConfigName;
+
 describe('toTSVector', () => {
   it('should return empty vector of empty string', () => {
-    expect(toTSVector(''), 'to be', `to_tsvector('')`);
+    expect(toTSVector(''), 'to be', `''::tsvector`);
   });
 
   it('should return empty vector of string of unsupported characters', () => {
-    expect(toTSVector('\u0652'), 'to be', `to_tsvector('')`);
+    expect(toTSVector('\u0652'), 'to be', `''::tsvector`);
+  });
+
+  it('should return vector of regular text', () => {
+    const string = 'the quick brown fox jumped over the lazy dog';
+    expect(toTSVector(string), 'to be', `to_tsvector('${ftsCfg}', '${string}')`);
+  });
+
+  it('should return vector of text with mentions and hashtags', () => {
+    const string = 'the quick brown @fox-jump #lazy-dog';
+    expect(
+      toTSVector(string), 'to be',
+      `(`
+      + `to_tsvector('${ftsCfg}', 'the quick brown') || `
+      + `(`
+        + `to_tsvector('${ftsCfg}', 'fox jump')::text || ' ' || `
+        + `'''@fox-jump'':1'`
+      + `)::tsvector || `
+      + `(`
+        + `to_tsvector('${ftsCfg}', 'lazy dog')::text || ' ' || `
+        + `'''#lazydog'':1'`
+      + `)::tsvector`
+      + `)`
+    );
+  });
+
+  it('should return vector of text with links', () => {
+    const string = 'the quick brown www.foxnews.com';
+    expect(
+      toTSVector(string), 'to be',
+      `(`
+      + `to_tsvector('${ftsCfg}', 'the quick brown') || `
+      + `to_tsvector('${ftsCfg}', 'foxnews com')`
+      + `)`
+    );
   });
 });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -15,6 +15,11 @@ declare module 'config' {
     postgres: {
       textSearchConfigName: string;
     }
+
+    search: {
+      maxQueryComplexity: number;
+      minPrefixLength:    number;
+    }
   }
 
   const c: Config;


### PR DESCRIPTION
1. The double-quoted phrase now means "search these words in the specific order and in exact word forms".
2. The prefix search added: `cat*`.
3. The `+` operator added: `cat + mouse` query means these two words standing next to each other in that order (but without the exact word forms).

Operators priority: `dog cat + mouse | bird` means `dog AND (cat FOLLOWED_BY (mouse OR bird))`

⚠ These changes require re-indexing the database, otherwise queries with prefixes and double quotes will not work.