### PR TITLE
Expiration times and activation codes for app tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+ - Application tokens now have an `expiresAt` field. The expiration time can be
+   specified during token creation. Tokens are automatically invalidates after
+   the expiration time.
+
+ - The new `activationCode` field is returned when app token creted or reissued.
+   This code can be used to obtain the full token value. Activation codes are
+   short (6 alphanumeric characters) and have narrow lifetime (5 min), they are
+   useful for transfer via the non-secure communication channel.
+
  - The output of `GET /v2/server-info` has a new field
    _externalAuthProvidersInfo_ that contains an id, brand and title of each
    available external identity provider, so the client can show the proper
@@ -16,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    clients and contains only id's of these providers.
 
 ### Changed
+ - The realtime socket authorizations is now re-validates every 5 minutes to
+   handle the expired app tokens.
+ 
  - The format of _externalAuthProviders_ configuration key was changed, see the
    [separate document](config/external-auth-providers.md) for the details. The
    site administrator can now configure almost any OAuth2 external identity

--- a/app/app.js
+++ b/app/app.js
@@ -29,7 +29,7 @@ export async function getSingleton() {
 
     const _app = new FreefeedApp();
     routesInit(_app);
-    initJobProcessing();
+    initJobProcessing(_app);
 
     const server = http.createServer(_app.callback());
     _app.context.pubsub = new PubsubListener(server, _app);

--- a/app/controllers/api/v2/AppTokensController.js
+++ b/app/controllers/api/v2/AppTokensController.js
@@ -9,7 +9,11 @@ import { ValidationException, NotFoundException, BadRequestException } from '../
 import { appTokensScopes } from '../../../models/app-tokens-scopes';
 import { Address } from '../../../support/ipv6';
 
-import { appTokenCreateInputSchema, appTokenUpdateInputSchema } from './data-schemes/app-tokens';
+import {
+  appTokenCreateInputSchema,
+  appTokenUpdateInputSchema,
+  appTokenActivateInputSchema,
+} from './data-schemes/app-tokens';
 
 
 export const create = compose([
@@ -70,8 +74,10 @@ export const create = compose([
     await token.create();
 
     ctx.body = {
-      token:       serializeAppToken(token),
-      tokenString: token.tokenString(),
+      token:             serializeAppToken(token),
+      tokenString:       token.tokenString(),
+      activationCode:    token.activationCode,
+      activationCodeTTL: config.appTokens.activationCodeTTL,
     };
   },
 ]);
@@ -107,8 +113,10 @@ export const reissue = compose([
     await token.reissue();
 
     ctx.body = {
-      token:       serializeAppToken(token),
-      tokenString: token.tokenString(),
+      token:             serializeAppToken(token),
+      tokenString:       token.tokenString(),
+      activationCode:    token.activationCode,
+      activationCodeTTL: config.appTokens.activationCodeTTL,
     };
   },
 ]);
@@ -176,6 +184,38 @@ export const current = compose([
     }
 
     ctx.body = { token: serializeAppToken(token, true) };
+  },
+]);
+
+export const activate = compose([
+  inputSchemaRequired(appTokenActivateInputSchema),
+  monitored('app-tokens.activate'),
+  async (ctx) => {
+    const { activationCode: rawActivationCode } = ctx.request.body;
+    const activationCode = AppTokenV1.normalizeActivationCode(rawActivationCode);
+
+    if (activationCode === null) {
+      throw new ValidationException(`Invalid activation code, check that you entered it correctly`);
+    }
+
+    const token = await dbAdapter.getAppTokenByActivationCode(activationCode, config.appTokens.activationCodeTTL);
+
+    if (!token) {
+      throw new NotFoundException('Unknown or expired activation code');
+    }
+
+    try {
+      token.checkRestrictions(ctx);
+    } catch (err) {
+      throw new NotFoundException('Unknown or expired activation code');
+    }
+
+    await token.reissue();
+
+    ctx.body = {
+      token:       serializeAppToken(token, true),
+      tokenString: token.tokenString(),
+    };
   },
 ]);
 

--- a/app/controllers/api/v2/data-schemes/app-tokens.js
+++ b/app/controllers/api/v2/data-schemes/app-tokens.js
@@ -83,3 +83,14 @@ export const appTokenUpdateInputSchema = {
     },
   }
 };
+
+export const appTokenActivateInputSchema = {
+  '$schema': 'http://json-schema.org/schema#',
+
+  type:     'object',
+  required: [
+    'activationCode',
+  ],
+
+  properties: { activationCode: { type: 'string' } }
+}

--- a/app/controllers/api/v2/data-schemes/app-tokens.js
+++ b/app/controllers/api/v2/data-schemes/app-tokens.js
@@ -25,6 +25,20 @@ export const appTokenCreateInputSchema = {
       uniqueItems: true,
       minItems:    0,
     },
+    expiresAt: {
+      oneOf: [
+        {
+          type:        'number',
+          description: 'Token lifetime in seconds since creation',
+          minimum:     0,
+        },
+        {
+          type:        'string',
+          description: 'Token expiration date in ISO 8601 format',
+          format:      'date-time',
+        }
+      ]
+    },
     restrictions: {
       type:     'object',
       required: [

--- a/app/controllers/middlewares/with-auth-token.js
+++ b/app/controllers/middlewares/with-auth-token.js
@@ -124,22 +124,11 @@ export async function tokenFromJWT(
     }
 
     // Restrictions (IPs and origins)
-    {
-      const { netmasks = [], origins = [] } = token.restrictions;
-
-      if (netmasks.length > 0) {
-        const remoteAddr = new Address(remoteIP);
-
-        if (!netmasks.some((mask) => new Address(mask).contains(remoteAddr))) {
-          authDebug(`app token is not allowed from IP ${remoteIP}`)
-          throw new NotAuthorizedException(`token is not allowed from this IP`);
-        }
-      }
-
-      if (origins.length > 0 && !origins.includes(headers.origin)) {
-        authDebug(`app token is not allowed from origin ${headers.origin}`)
-        throw new NotAuthorizedException(`token is not allowed from this origin`);
-      }
+    try {
+      token.checkRestrictions({ remoteIP, headers });
+    } catch (e) {
+      authDebug(e.message)
+      throw new NotAuthorizedException(e.message);
     }
 
     // Route access

--- a/app/jobs/app-tokens.js
+++ b/app/jobs/app-tokens.js
@@ -1,0 +1,36 @@
+import { DateTime } from 'luxon';
+
+import { Job, dbAdapter } from '../models';
+
+
+export const APP_TOKEN_INACTIVATE = 'APP_TOKEN_INACTIVATE';
+
+// Job creators
+export function scheduleTokenInactivation(token) {
+  if (!token.expiresAt) {
+    return Promise.resolve(null);
+  }
+
+  const unlockAt = DateTime.fromJSDate(token.expiresAt)
+    .plus({ minutes: 10 })
+    .toJSDate();
+
+  return Job.create(APP_TOKEN_INACTIVATE, { tokenId: token.id }, { unlockAt });
+}
+
+/**
+ * Job handlers
+ *
+ * @param {JobManager} jobManager
+ */
+export function initHandlers(jobManager) {
+  jobManager.on(APP_TOKEN_INACTIVATE, async (job) => {
+    const token = await dbAdapter.getAppTokenById(job.payload.tokenId);
+
+    if (!token?.isActive) {
+      return;
+    }
+
+    await token.inactivate();
+  });
+}

--- a/app/jobs/app-tokens.js
+++ b/app/jobs/app-tokens.js
@@ -15,7 +15,11 @@ export function scheduleTokenInactivation(token) {
     .plus({ minutes: 10 })
     .toJSDate();
 
-  return Job.create(APP_TOKEN_INACTIVATE, { tokenId: token.id }, { unlockAt });
+  return Job.create(
+    APP_TOKEN_INACTIVATE,
+    { tokenId: token.id },
+    { unlockAt, uniqKey: token.id }
+  );
 }
 
 /**

--- a/app/jobs/index.js
+++ b/app/jobs/index.js
@@ -4,16 +4,18 @@ import config from 'config';
 
 import { JobManager } from '../models';
 
+import { initHandlers as initPeriodicHandlers } from './periodic';
 import { initHandlers as initUserGoneHandlers } from './user-gone';
 import { initHandlers as initAppTokensHandlers } from './app-tokens';
 
 
-export function initJobProcessing() {
+export function initJobProcessing(app) {
   const jobManager = new JobManager(config.jobManager);
   [
+    initPeriodicHandlers,
     initUserGoneHandlers,
     initAppTokensHandlers,
-  ].forEach((h) => h(jobManager));
+  ].forEach((h) => h(jobManager, app));
 
   // Use monitor and Sentry to collect job statistics and report errors
   jobManager.use((handler) => async (job) => {

--- a/app/jobs/index.js
+++ b/app/jobs/index.js
@@ -5,11 +5,15 @@ import config from 'config';
 import { JobManager } from '../models';
 
 import { initHandlers as initUserGoneHandlers } from './user-gone';
+import { initHandlers as initAppTokensHandlers } from './app-tokens';
 
 
 export function initJobProcessing() {
   const jobManager = new JobManager(config.jobManager);
-  initUserGoneHandlers(jobManager);
+  [
+    initUserGoneHandlers,
+    initAppTokensHandlers,
+  ].forEach((h) => h(jobManager));
 
   // Use monitor and Sentry to collect job statistics and report errors
   jobManager.use((handler) => async (job) => {

--- a/app/jobs/periodic.js
+++ b/app/jobs/periodic.js
@@ -1,0 +1,42 @@
+import createDebug from 'debug';
+import Raven from 'raven';
+import config from 'config';
+
+import { Job } from '../models';
+
+
+const debugError = createDebug('freefeed:jobs:errors');
+
+const PERIODIC_REAUTH_REALTIME = 'PERIODIC_REAUTH_REALTIME';
+
+export function initHandlers(jobManager, app) {
+  definePeriodicJob(jobManager, {
+    name:     PERIODIC_REAUTH_REALTIME,
+    handler:  () => app.context.pubsub.reAuthorizeSockets(),
+    nextTime: () => new Date(Date.now() + (5 * 60 * 1000)), // every 5 minutes
+  });
+}
+
+////////////////////////////////////
+
+export async function definePeriodicJob(jobManager, { name, payload = {}, handler, nextTime }) {
+  jobManager.on(name, async (job) => {
+    try {
+      await handler(job);
+    } catch (err) {
+      // Do not retry periodic jobs
+      debugError(`error processing periodic job '${job.name}'`, err, job);
+
+      if ('sentryDsn' in config) {
+        Raven.captureException(
+          err,
+          { extra: { err: `error processing job '${job.name}': ${err.message}` } }
+        );
+      }
+    }
+
+    await Job.clone(nextTime());
+  });
+  // Create a first job
+  await Job.create(name, payload, { uniqKey: 'periodic', unlockAt: nextTime() });
+}

--- a/app/jobs/user-gone.js
+++ b/app/jobs/user-gone.js
@@ -17,13 +17,14 @@ export function userCooldownStart(user) {
   return Job.create(USER_COOLDOWN_START, {
     id:     user.id,
     goneAt: user.goneAt.getTime(),
-  });
+  }, { uniqKey: user.id });
 }
 
 export function userDataDeletionStart(user) {
   return Job.create(
     USER_DELETE_DATA,
-    { id: user.id, email: user.hiddenEmail }
+    { id: user.id, email: user.hiddenEmail },
+    { uniqKey: user.id }
   );
 }
 
@@ -50,12 +51,12 @@ export function initHandlers(jobManager) {
         Job.create(
           USER_COOLDOWN_REMINDER,
           { id: user.id, goneAt: user.goneAt.getTime() },
-          { unlockAt: reminderDate(user) }
+          { unlockAt: reminderDate(user), uniqKey: user.id }
         ),
         Job.create(
           USER_DELETION_START,
           { id: user.id, goneAt: user.goneAt.getTime() },
-          { unlockAt: deletionDate(user) }
+          { unlockAt: deletionDate(user), uniqKey: user.id }
         ),
       ]);
     })
@@ -107,7 +108,7 @@ export function initHandlers(jobManager) {
     }
 
     // Repeat this job if we are not done
-    await Job.create(job.name, job.payload);
+    await Job.create(job.name, job.payload, { uniqKey: job.uniqKey });
   });
 }
 

--- a/app/jobs/user-gone.js
+++ b/app/jobs/user-gone.js
@@ -108,7 +108,7 @@ export function initHandlers(jobManager) {
     }
 
     // Repeat this job if we are not done
-    await Job.create(job.name, job.payload, { uniqKey: job.uniqKey });
+    await Job.clone();
   });
 }
 

--- a/app/models/app-tokens-scopes.js
+++ b/app/models/app-tokens-scopes.js
@@ -41,6 +41,7 @@ export const alwaysDisallowedRoutes = [
   'GET /v2/app-tokens/scopes',
   'GET /v2/app-tokens',
   'POST /v2/app-tokens',
+  'POST /v2/app-tokens/activate',
   'POST /v2/app-tokens/:tokenId/reissue',
   'PUT /v2/app-tokens/:tokenId',
   'DELETE /v2/app-tokens/:tokenId',

--- a/app/models/auth-tokens.js
+++ b/app/models/auth-tokens.js
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import jwt from 'jsonwebtoken'
 import config from 'config';
 
+import { scheduleTokenInactivation } from '../jobs/app-tokens';
+
 
 const appTokenUsageDebounce = '10 sec'; // PostgreSQL 'interval' type syntax
 
@@ -94,6 +96,8 @@ export function addAppTokenV1Model(dbAdapter) {
       for (const f of fieldsToUpdate) {
         this[f] = newToken[f];
       }
+
+      await scheduleTokenInactivation(this);
     }
 
     async registerUsage({ ip, userAgent = '' }) {

--- a/app/models/auth-tokens.js
+++ b/app/models/auth-tokens.js
@@ -48,6 +48,10 @@ export function addAppTokenV1Model(dbAdapter) {
     issue = 1;
     createdAt;
     updatedAt;
+    expiresAt;
+    // This field of type number is for token creation only. Use it to set the
+    // expiration time in seconds from the token's creation time.
+    expiresAtSeconds;
     scopes = [];
     restrictions = {};
     lastUsedAt = null;
@@ -57,22 +61,7 @@ export function addAppTokenV1Model(dbAdapter) {
     constructor(params) {
       super(params.userId);
 
-      const fields = [
-        'id',
-        'userId',
-        'title',
-        'isActive',
-        'issue',
-        'createdAt',
-        'updatedAt',
-        'scopes',
-        'restrictions',
-        'lastUsedAt',
-        'lastIP',
-        'lastUserAgent',
-      ];
-
-      for (const f of fields) {
+      for (const f of Object.keys(this)) {
         if (f in params) {
           this[f] = params[f];
         }
@@ -98,6 +87,8 @@ export function addAppTokenV1Model(dbAdapter) {
       const fieldsToUpdate = [
         'createdAt',
         'updatedAt',
+        'expiresAt',
+        'expiresAtSeconds', // for clean up
       ];
 
       for (const f of fieldsToUpdate) {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -15,6 +15,7 @@ export function addJobModel(dbAdapter) {
     name;
     payload;
     attempts;
+    uniqKey;
 
     constructor(params) {
       for (const f of Object.keys(this)) {
@@ -32,9 +33,9 @@ export function addJobModel(dbAdapter) {
      * @param {object} params
      * @returns {Promise<Job>}
      */
-    static create(name, payload = {}, { unlockAt = 0 } = {}) {
+    static create(name, payload = {}, { unlockAt = 0, uniqKey = null } = {}) {
       _checkUnlockAtType(unlockAt);
-      return dbAdapter.createJob(name, payload, { unlockAt });
+      return dbAdapter.createJob(name, payload, { unlockAt, uniqKey });
     }
 
     static getById(id) {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -59,6 +59,16 @@ export function addJobModel(dbAdapter) {
     delete() {
       return dbAdapter.deleteJob(this.id);
     }
+
+    /**
+     * Create a new job with the same properties as this but with a new unlockAt
+     * time.
+     *
+     * @returns {Promise<Job>}
+     */
+    clone(unlockAt = 0) {
+      return Job.create(this.name, this.payload, { uniqKey: this.uniqKey, unlockAt });
+    }
   }
 }
 

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -62,11 +62,12 @@ export default class PubsubListener {
     // authentication
     this.io.use(async (socket, next) => {
       try {
-        socket.user = await getAuthUser(socket.handshake.query.token, socket);
-        debug(`[socket.id=${socket.id}] auth user`, socket.user.id);
+        socket.userId = await getAuthUserId(socket.handshake.query.token, socket);
+        debug(`[socket.id=${socket.id}] auth user`, socket.userId);
       } catch (e) {
         // Can not properly return error to client so just treat user as anonymous
-        socket.user = { id: null };
+        socket.userId = null;
+        socket.authToken = null;
         debug(`[socket.id=${socket.id}] auth error`, e.message);
       }
 
@@ -104,8 +105,8 @@ export default class PubsubListener {
         throw new EventHandlingError('request without data');
       }
 
-      socket.user = await getAuthUser(data.authToken, socket);
-      debug(`[socket.id=${socket.id}] auth user`, socket.user.id);
+      socket.userId = await getAuthUserId(data.authToken, socket);
+      debug(`[socket.id=${socket.id}] auth user`, socket.userId);
     });
 
     onSocketEvent(socket, 'subscribe', async (data, debugPrefix) => {
@@ -127,21 +128,21 @@ export default class PubsubListener {
             if (!t) {
               throw new EventHandlingError(
                 `attempt to subscribe to nonexistent timeline`,
-                `User ${socket.user.id} attempted to subscribe to nonexistent timeline (ID=${objId})`
+                `User ${socket.userId} attempted to subscribe to nonexistent timeline (ID=${objId})`
               );
             }
 
-            if (t.isPersonal() && t.userId !== socket.user.id) {
+            if (t.isPersonal() && t.userId !== socket.userId) {
               throw new EventHandlingError(
                 `attempt to subscribe to someone else's '${t.name}' timeline`,
-                `User ${socket.user.id} attempted to subscribe to '${t.name}' timeline (ID=${objId}) belonging to user ${t.userId}`
+                `User ${socket.userId} attempted to subscribe to '${t.name}' timeline (ID=${objId}) belonging to user ${t.userId}`
               );
             }
           } else if (channelType === 'user') {
-            if (objId !== socket.user.id) {
+            if (objId !== socket.userId) {
               throw new EventHandlingError(
                 `attempt to subscribe to someone else's '${channelType}' channel`,
-                `User ${socket.user.id} attempted to subscribe to someone else's '${channelType}' channel (ID=${objId})`
+                `User ${socket.userId} attempted to subscribe to someone else's '${channelType}' channel (ID=${objId})`
               );
             }
           }
@@ -237,12 +238,10 @@ export default class PubsubListener {
       return;
     }
 
-    let users = destSockets.map((s) => s.user);
+    let userIds = destSockets.map((s) => s.userId);
 
     if (post) {
       if (type === eventNames.POST_UPDATED) {
-        let userIds = users.map((u) => u.id);
-
         if (json.newUserIds && !json.newUserIds.isEmpty()) {
           // Users who listen to post rooms but
           // could not see post before. They should
@@ -251,7 +250,7 @@ export default class PubsubListener {
           const newUserIds = List.intersection(json.newUserIds, userIds).items;
           const newUserRooms = flatten(
             destSockets
-              .filter((s) => newUserIds.includes((s.user.id)))
+              .filter((s) => newUserIds.includes((s.userId)))
               .map((s) => Object.keys(s.rooms))
           );
 
@@ -274,7 +273,7 @@ export default class PubsubListener {
           const removedUserIds = List.intersection(json.removedUserIds, userIds).items;
           const removedUserRooms = flatten(
             destSockets
-              .filter((s) => removedUserIds.includes((s.user.id)))
+              .filter((s) => removedUserIds.includes((s.userId)))
               .map((s) => Object.keys(s.rooms))
           );
 
@@ -286,29 +285,22 @@ export default class PubsubListener {
 
           userIds = List.difference(userIds, removedUserIds).items;
         }
-
-        users = users.filter((u) => userIds.includes(u.id));
       } else {
-        users = await post.onlyUsersCanSeePost(users);
+        const allPostReaders = await post.usersCanSeePostIds();
+        userIds = List.intersection(allPostReaders, userIds).items;
       }
 
-      destSockets = destSockets.filter((s) => users.includes(s.user));
+      destSockets = destSockets.filter((s) => userIds.includes(s.userId));
     }
 
-    const bansMap = await dbAdapter.getUsersBansIdsMap(users.map((u) => u.id).filter((id) => !!id));
+    const bansMap = await dbAdapter.getUsersBansIdsMap(userIds);
 
     await Promise.all(destSockets.map(async (socket) => {
-      const { user } = socket;
-
-      if (!user) {
-        // is it actually possible now?
-        debug(`broadcastMessage: socket ${socket.id} doesn't have user associated with it`);
-        return;
-      }
+      const { userId } = socket;
 
       // Bans
-      if (post && user.id) {
-        const banIds = bansMap.get(user.id) || [];
+      if (post && userId) {
+        const banIds = bansMap.get(userId) || [];
 
         if (
           ((type === eventNames.COMMENT_CREATED || type === eventNames.COMMENT_UPDATED) && banIds.includes(json.comments.createdBy))
@@ -482,7 +474,7 @@ export default class PubsubListener {
   onGlobalUserUpdate = (userId) => this.broadcastMessage(
     ['global:users'], eventNames.GLOBAL_USER_UPDATED, null, null,
     async (socket, type, json) => {
-      const [user] = await serializeUsersByIds([userId], true, socket.user.id);
+      const [user] = await serializeUsersByIds([userId], true, socket.userId);
       await socket.emit(type, { ...json, user });
     }
   );
@@ -505,7 +497,7 @@ export default class PubsubListener {
     await this.broadcastMessage(
       rooms, 'user:update', null, null,
       async (socket, type, json) => {
-        if (!socket.user.id) {
+        if (!socket.userId) {
           return;
         }
 
@@ -513,7 +505,7 @@ export default class PubsubListener {
 
         if (groupIds.length > 1) {
           // User probably not subscribed to all of these groups
-          isSubscribed = await Promise.all(feedIds.map((id) => dbAdapter.isUserSubscribedToTimeline(socket.user.id, id)));
+          isSubscribed = await Promise.all(feedIds.map((id) => dbAdapter.isUserSubscribedToTimeline(socket.userId, id)));
         }
 
         const subscribedGroupIds = groupIds.filter((_, i) => isSubscribed[i]);
@@ -521,13 +513,13 @@ export default class PubsubListener {
         const updatedGroups = await serializeUsersByIds(
           subscribedGroupIds,
           true,
-          socket.user.id,
+          socket.userId,
         );
 
         await socket.emit(type, {
           ...json,
           updatedGroups: updatedGroups.slice(0, subscribedGroupIds.length),
-          id:            socket.user.id,
+          id:            socket.userId,
         });
       }
     );
@@ -557,8 +549,8 @@ export default class PubsubListener {
 
   async _commentLikeEventEmitter(socket, type, json) {
     const commentUUID = json.comments.id;
-    const viewer = socket.user;
-    const [commentLikesData] = await dbAdapter.getLikesInfoForComments([commentUUID], viewer.id);
+    const viewerId = socket.userId;
+    const [commentLikesData] = await dbAdapter.getLikesInfoForComments([commentUUID], viewerId);
     json.comments.likes = parseInt(commentLikesData.c_likes);
     json.comments.hasOwnLike = commentLikesData.has_own_like;
 
@@ -566,7 +558,7 @@ export default class PubsubListener {
   }
 
   _postEventEmitter = async (socket, type, { postId }) => {
-    const json = await serializeSinglePost(postId, socket.user.id);
+    const json = await serializeSinglePost(postId, socket.userId);
     defaultEmitter(socket, type, json);
   };
 
@@ -574,11 +566,11 @@ export default class PubsubListener {
   /**
    * Emits message only to the specified user
    */
-  _singleUserEmitter = (userId) => (socket, type, json) => {
-    if (socket.user.id === userId) {
-      defaultEmitter(socket, type, json);
-    }
-  };
+  _singleUserEmitter = (userId) => (socket, type, json) =>
+    (socket.userId === userId) && defaultEmitter(socket, type, json);
+
+  _withUserIdEmitter = (socket, type, json) =>
+    socket.userId && defaultEmitter(socket, type, { ...json, id: socket.userId });
 
   async _insertCommentLikesInfo(postPayload, viewerUUID) {
     postPayload.posts = { ...postPayload.posts, commentLikes: 0, ownCommentLikes: 0, omittedCommentLikes: 0, omittedOwnCommentLikes: 0 };
@@ -741,9 +733,9 @@ const onSocketEvent = (socket, event, handler) => socket.on(event, async (data, 
   }
 });
 
-async function getAuthUser(jwtToken, socket) {
+async function getAuthUserId(jwtToken, socket) {
   if (!jwtToken) {
-    return { id: null };
+    return null;
   }
 
   const authData = await tokenFromJWT(
@@ -763,5 +755,5 @@ async function getAuthUser(jwtToken, socket) {
     });
   }
 
-  return authData.user;
+  return authData.user.id;
 }

--- a/app/routes/api/v2/AppTokens.js
+++ b/app/routes/api/v2/AppTokens.js
@@ -7,6 +7,7 @@ import {
   list,
   current,
   reissueCurrent,
+  activate,
 } from '../../../controllers/api/v2/AppTokensController';
 
 
@@ -14,6 +15,7 @@ export default function addRoutes(app) {
   app.get('/v2/app-tokens/scopes', scopes);
   app.get('/v2/app-tokens', list);
   app.post('/v2/app-tokens', create);
+  app.post('/v2/app-tokens/activate', activate);
   app.get('/v2/app-tokens/current', current);
   app.post('/v2/app-tokens/current/reissue', reissueCurrent);
   app.post('/v2/app-tokens/:tokenId/reissue', reissue);

--- a/app/support/DbAdapter/app-tokens.js
+++ b/app/support/DbAdapter/app-tokens.js
@@ -91,11 +91,7 @@ const APP_TOKEN_FIELDS = {
   last_user_agent: 'lastUserAgent',
 };
 
-const APP_TOKEN_FIELDS_MAPPING = {
-  created_at:   (time) =>  time ? time.toISOString() : undefined,
-  updated_at:   (time) =>  time ? time.toISOString() : undefined,
-  last_used_at: (time) =>  time ? time.toISOString() : null,
-};
+const APP_TOKEN_FIELDS_MAPPING = {};
 
 const APP_TOKEN_COLUMNS = {
   id:            'uid',
@@ -112,8 +108,4 @@ const APP_TOKEN_COLUMNS = {
   lastUserAgent: 'last_user_agent',
 };
 
-const APP_TOKEN_COLUMNS_MAPPING = {
-  createdAt:  (ts) => ts ? new Date(ts) : undefined,
-  updatedAt:  (ts) => ts ? new Date(ts) : undefined,
-  lastUsedAt: (ts) => ts ? new Date(ts) : null,
-};
+const APP_TOKEN_COLUMNS_MAPPING = {};

--- a/app/support/DbAdapter/jobs.js
+++ b/app/support/DbAdapter/jobs.js
@@ -54,8 +54,18 @@ export default function jobsTrait(superClass) {
     }
 
     // For testing purposes only
-    async getAllJobs() {
-      const rows = await this.database.getAll(`select * from jobs order by created_at`);
+    async getAllJobs(names = null) {
+      let rows;
+
+      if (names) {
+        rows = await this.database.getAll(
+          `select * from jobs where name = any(:names) order by created_at`,
+          { names }
+        );
+      } else {
+        rows = await this.database.getAll(`select * from jobs order by created_at`);
+      }
+
       return rows.map(initJobObject);
     }
 

--- a/app/support/DbAdapter/jobs.js
+++ b/app/support/DbAdapter/jobs.js
@@ -5,12 +5,15 @@ import { prepareModelPayload, initObject } from './utils';
 
 export default function jobsTrait(superClass) {
   return class extends superClass {
-    async createJob(name, payload = {}, { unlockAt } = {}) {
+    async createJob(name, payload = {}, { unlockAt, uniqKey } = {}) {
       const row = await this.database.getRow(
         `insert into jobs 
-          (name, payload, unlock_at) values (:name, :payload, :unlockAt)
+          (name, payload, unlock_at, uniq_key) 
+          values (:name, :payload, :unlockAt, :uniqKey)
+          on conflict (name, uniq_key) do 
+            update set (payload, unlock_at) = (:payload, :unlockAt)
           returning *`,
-        { name, payload, unlockAt: this._jobUnlockAt(unlockAt) }
+        { name, payload, uniqKey, unlockAt: this._jobUnlockAt(unlockAt) }
       );
 
       return initJobObject(row);
@@ -84,6 +87,7 @@ const JOB_FIELDS = {
   name:       'name',
   payload:    'payload',
   attempts:   'attempts',
+  uniq_key:   'uniqKey',
 };
 
 const JOB_FIELDS_MAPPING = {};

--- a/config/default.js
+++ b/config/default.js
@@ -302,4 +302,9 @@ config.userDeletion = {
 
 config.ianaTimeZone = 'Europe/Tallinn';
 
+config.appTokens = {
+  //
+  activationCodeTTL: 300, // in seconds
+};
+
 module.exports = config;

--- a/migrations/20202707142636_app_tokens_exp.js
+++ b/migrations/20202707142636_app_tokens_exp.js
@@ -10,8 +10,15 @@ export const up = (knex) => knex.schema.raw(`do $$begin
   create index app_tokens_is_active_idx on app_tokens using btree (is_active);
   create index app_tokens_expires_at_idx on app_tokens using btree (expires_at);
   create index app_tokens_activation_code_idx on app_tokens using btree (activation_code);
+
+  alter table jobs add column uniq_key text;
+  -- If uniq_key is not null then the (name, uniq_key) must be unique
+  alter table jobs add constraint job_uniq_key unique (name, uniq_key);
 end$$`);
 
 export const down = (knex) => knex.schema.raw(`do $$begin
   alter table app_tokens drop column expires_at;
+
+  alter table jobs drop constraint job_uniq_key;
+  alter table jobs drop column uniq_key;
 end$$`);

--- a/migrations/20202707142636_app_tokens_exp.js
+++ b/migrations/20202707142636_app_tokens_exp.js
@@ -1,0 +1,12 @@
+export const up = (knex) => knex.schema.raw(`do $$begin
+  -- expires_at is null for persistent tokens. We don't use 'infinity' here
+  -- for better JS interoperability.
+  alter table app_tokens add column expires_at timestamptz;
+
+  create index app_tokens_is_active_idx on app_tokens using btree (is_active);
+  create index app_tokens_expires_at_idx on app_tokens using btree (expires_at);
+end$$`);
+
+export const down = (knex) => knex.schema.raw(`do $$begin
+  alter table app_tokens drop column expires_at;
+end$$`);

--- a/migrations/20202707142636_app_tokens_exp.js
+++ b/migrations/20202707142636_app_tokens_exp.js
@@ -3,8 +3,13 @@ export const up = (knex) => knex.schema.raw(`do $$begin
   -- for better JS interoperability.
   alter table app_tokens add column expires_at timestamptz;
 
+  -- activation_code can be null for the earlier generated tokens. Codes are
+  -- not necessary unique.
+  alter table app_tokens add column activation_code text;
+
   create index app_tokens_is_active_idx on app_tokens using btree (is_active);
   create index app_tokens_expires_at_idx on app_tokens using btree (expires_at);
+  create index app_tokens_activation_code_idx on app_tokens using btree (activation_code);
 end$$`);
 
 export const down = (knex) => knex.schema.raw(`do $$begin

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -232,6 +232,7 @@ export const appTokenInfoRestricted = {
   issue:        expect.it('to be a number'),
   createdAt:    expect.it('to satisfy', iso8601TimeString),
   updatedAt:    expect.it('to satisfy', iso8601TimeString),
+  expiresAt:    expect.it('to be null').or('to satisfy', iso8601TimeString),
   scopes:       expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),
   restrictions: expect.it('to exhaustively satisfy', {
     netmasks: expect.it('to be an array').and('to be empty').or('to have items satisfying', 'to be a string'),

--- a/test/integration/models/auth-tokens.js
+++ b/test/integration/models/auth-tokens.js
@@ -356,7 +356,7 @@ describe('Auth Tokens', () => {
       });
 
       it(`should create job that should inactivate token`, async () => {
-        const jobs = await dbAdapter.getAllJobs();
+        const jobs = await dbAdapter.getAllJobs([APP_TOKEN_INACTIVATE]);
         expect(jobs, 'to satisfy', [{ name: APP_TOKEN_INACTIVATE, payload: { tokenId: token.id } }]);
         jobId = jobs[0].id;
       });

--- a/test/integration/models/auth-tokens.js
+++ b/test/integration/models/auth-tokens.js
@@ -3,7 +3,8 @@
 import _ from 'lodash';
 import unexpected from 'unexpected';
 import unexpectedDate from 'unexpected-date';
-import jwt from 'jsonwebtoken'
+import jwt from 'jsonwebtoken';
+import { DateTime } from 'luxon';
 import config from 'config';
 
 import cleanDB from '../../dbCleaner';
@@ -140,7 +141,7 @@ describe('Auth Tokens', () => {
           dbAdapter.getAppTokenById(token.id),
           dbAdapter.now(),
         ]);
-        expect(new Date(t2.lastUsedAt), 'to be close to', now);
+        expect(t2.lastUsedAt, 'to be close to', now);
         expect(t2.lastIP, 'to be', ip);
         expect(t2.lastUserAgent, 'to be', userAgent);
       });
@@ -154,7 +155,7 @@ describe('Auth Tokens', () => {
           dbAdapter.getAppTokenById(token.id),
           dbAdapter.now(),
         ]);
-        expect(new Date(t2.lastUsedAt), 'to be close to', now);
+        expect(t2.lastUsedAt, 'to be close to', now);
         expect(t2.lastIP, 'to be', ip);
         expect(t2.lastUserAgent, 'to be', '');
       });
@@ -252,6 +253,83 @@ describe('Auth Tokens', () => {
 
           const { rows: logRows } = await $pg_database.raw('select * from app_tokens_log where token_id = :id limit 1', { id: token.id });
           expect(logRows, 'to be empty');
+        });
+      });
+    });
+
+    describe(`Token expiration`, () => {
+      before(() => cleanDB($pg_database));
+
+      let token;
+
+      before(async () => {
+        luna = new User({ username: 'luna', password: 'pw' });
+        await luna.create();
+
+        token = new AppTokenV1({
+          userId: luna.id,
+          title:  'My app',
+        });
+        await token.create();
+      });
+
+      it(`should have nullish expiresAt field on regular token`, () => {
+        expect(token.expiresAt, 'to be null');
+      });
+
+      it(`should create token with expiresAt field`, async () => {
+        const expiresAt = DateTime.local().plus({ hours: 1 }).toJSDate();
+
+        const t = new AppTokenV1({
+          userId: luna.id,
+          title:  'My app',
+          expiresAt,
+        });
+        await t.create();
+        expect(t.expiresAt, 'to be close to', expiresAt);
+
+        await dbAdapter.deleteAppToken(t.id);
+      });
+
+      it(`should create token with expiresAtSeconds field`, async () => {
+        const t = new AppTokenV1({
+          userId:           luna.id,
+          title:            'My app',
+          expiresAtSeconds: 1000,
+        });
+        const [, now] = await Promise.all([t.create(), dbAdapter.now()]);
+        expect(t, 'to satisfy', {
+          expiresAt:        expect.it('to be close to', DateTime.fromJSDate(now).plus({ seconds: 1000 }).toJSDate()),
+          expiresAtSeconds: undefined,
+        });
+
+        await dbAdapter.deleteAppToken(t.id);
+      });
+
+      it(`should return token in list of active tokens`, async () => {
+        const tokens = await dbAdapter.listActiveAppTokens(luna.id);
+        expect(tokens, 'to satisfy', [{ id: token.id }]);
+      });
+
+      describe('token is expired', () => {
+        before(async () => {
+          await dbAdapter.updateAppToken(token.id, { expiresAt: DateTime.local().plus({ days: -1 }).toJSDate() });
+          token = await dbAdapter.getAppTokenById(token.id);
+        });
+
+        after(async () => {
+          await dbAdapter.updateAppToken(token.id, { expiresAt: DateTime.local().plus({ hours: 1 }).toJSDate() });
+          token = await dbAdapter.getAppTokenById(token.id);
+        });
+
+        it(`should not return expired token in list of active tokens`, async () => {
+          const tokens = await dbAdapter.listActiveAppTokens(luna.id);
+          expect(tokens, 'to satisfy', []);
+        });
+
+        it(`should not return expired token by id and issue`, async () => {
+          const t = await dbAdapter.getActiveAppTokenByIdAndIssue(token.id, token.issue);
+          expect(t, 'to be null');
         });
       });
     });


### PR DESCRIPTION
This PR introduces the expiration times and activation codes for app tokens according to this [RFC](https://paper.dropbox.com/doc/FreeFeed-1.1-HKLU1GsPmrxAJdfr4fvCA). These changes is fully backward-compatible, so it is possible to update server without waiting for the client changes.

This PR also fixes the realtime authorization problem described [here](https://paper.dropbox.com/doc/FreeFeed-B9tm4h0s5LWKPXd05zW5B#:uid=389704377046453884613466&h2=Realtime). Every 5 minutes the special periodic job re-authorizes all active realtime connections. If some token appears to be expired or inactivated by owner, this connection becames unauthorized.