### PR TITLE
Apply hide list to posts authored by friends in wide home feed mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [Unreleased]
+
+### Changed
+- The main homefeed hide list is now applied to posts authored by friends (in
+  _friends-all-activity_ mode). It affects the following situation: you are
+  subscribed to the user U in main homefeed and to the group G in secondary
+  homefeed, and U created a post in G. Now you will not see this post in main
+  homefeed in _friends-all-activity_ mode.

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -232,18 +232,23 @@ const timelinesPostsTrait = (superClass) => class extends superClass {
 
     const sourceConditionSQL = timelineIntIds
       ? orJoin([
-      // Show posts from destination feeds
+        // Show posts from destination feeds
         sqlIntarrayIn('p.feed_ids', timelineIntIds),
+        // Extra sources with hide list applied
         andJoin([
-        // Show posts from activities
-          sqlIntarrayIn('p.feed_ids', params.activityFeedIds),
+          orJoin([
+            andJoin([
+              // Show posts from activities
+              sqlIntarrayIn('p.feed_ids', params.activityFeedIds),
+              // Probably only propagable posts (classic mode)
+              params.activityOnPropagable && 'p.is_propagable',
+            ]),
+            // Also show posts from these authors (wide mode)
+            sqlIn('p.user_id', params.authorsIds),
+          ]),
           // Except of hide list
           sqlIntarrayIn('p.feed_ids', List.inverse(params.activityHideIds)),
-          // Probably only propagable posts (classic mode)
-          params.activityOnPropagable && 'p.is_propagable',
         ]),
-        // Also show posts from these authors (wide mode)
-        sqlIn('p.user_id', params.authorsIds),
       ])
       : 'true'; /* Just select everything */
 


### PR DESCRIPTION
1. User A have two home feeds: main (M) and secondary (S). 
2. A subscribed to user B in M and to group G in S. 
3. B write post to G.

Before this commit A could see this post in M in wide (HOMEFEED_MODE_FRIENDS_ALL_ACTIVITY) mode even though G is in hide list of M. This commit hides post from M.

Bug report https://freefeed.net/support/197127d7-1d1b-46b7-80dc-0eb8a6cca000
