### PR TITLE
Serialize groups in RT updates according to the current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+
+### Fixed
+- Groups in realtime events (such as `user:update` or `global:user:update`) now serializes according to the current user. This affects the visibility of the group's administrators list.

--- a/app/pubsub.js
+++ b/app/pubsub.js
@@ -1,6 +1,5 @@
 import { dbAdapter } from './models'
 import { serializeTimeline } from './serializers/v2/timeline';
-import { serializeUsersByIds } from './serializers/v2/user';
 
 
 export class DummyPublisher {
@@ -123,8 +122,7 @@ export default class pubSub {
   }
 
   async globalUserUpdate(userId) {
-    const [user] = await serializeUsersByIds([userId], false);
-    await this.publisher.globalUserUpdated(JSON.stringify(user));
+    await this.publisher.globalUserUpdated(JSON.stringify(userId));
   }
 
   async updateGroupTimes(groupIds) {

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -406,7 +406,7 @@ export async function performJSONRequest(method, relativePath, body = undefined,
 }
 
 export function authHeaders(userCtx) {
-  return { 'Authorization': `Bearer ${userCtx.authToken}` };
+  return userCtx ? { 'Authorization': `Bearer ${userCtx.authToken}` } : {};
 }
 
 export async function sessionRequest(username, password) {


### PR DESCRIPTION
Depending on the current user group can show/hide its administrators list.

Should fix this bug: https://freefeed.net/support/d56da91d-8245-40d8-9f99-f71f0ac93ecb