### PR TITLE
Support the Server-Timing response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- The Server-Timing response header (for now, it contains a single metric, 'total' - the total request processing time)
 - Improve search: search by exact word form, by prefix and with word order operator
 
 ## [1.85.0] - 2020-09-01

--- a/app/freefeed-app.ts
+++ b/app/freefeed-app.ts
@@ -11,6 +11,7 @@ import passport from 'koa-passport';
 import conditional from 'koa-conditional-get';
 import etag from 'koa-etag';
 import koaStatic from 'koa-static';
+import serverTiming from 'koa-server-timing';
 
 import { version as serverVersion } from '../package.json';
 
@@ -76,6 +77,7 @@ class FreefeedApp extends Application {
     }
 
     this.use(responseTime());
+    this.use(serverTiming({ total: true }));
 
     this.use(koaStatic(`${__dirname}/../${config.attachments.storage.rootDir}`));
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "koa-morgan": "1.0.1",
     "koa-passport": "~4.1.3",
     "koa-response-time": "~2.1.0",
+    "koa-server-timing": "~0.2.2",
     "koa-static": "~5.0.0",
     "lodash": "~4.17.20",
     "luxon": "~1.24.1",

--- a/test/functional/common-routing.js
+++ b/test/functional/common-routing.js
@@ -29,6 +29,11 @@ describe('Common API routing', () => {
     expect(resp.headers.get('Access-Control-Expose-Headers'), 'to contain', 'Date');
   });
 
+  it(`should publish the Server-Timing response header`, async () => {
+    const resp = await fetch(`${app.context.config.host}/v2/server-info`);
+    expect(resp.headers.get('Server-Timing'), 'to satisfy', /total=\d/);
+  });
+
   it(`should return error if API method is not exists`, async () => {
     const resp = await fetch(`${app.context.config.host}/v1/unexisting/method`);
     expect(resp.status, 'to be', 404);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4364,6 +4364,11 @@ koa-send@^5.0.0:
     http-errors "^1.7.3"
     resolve-path "^1.4.0"
 
+koa-server-timing@~0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/koa-server-timing/-/koa-server-timing-0.2.2.tgz#d975ea0739cc1a11c2fd7934d18d73e334ce04ba"
+  integrity sha1-2XXqBznMGhHC/Xk00Y1z4zTOBLo=
+
 koa-static@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/koa-static/-/koa-static-5.0.0.tgz#5e92fc96b537ad5219f425319c95b64772776943"


### PR DESCRIPTION
For now, the Server-Timing contains a single metric, 'total' - the total request processing time. Other metrics can be easily added, see https://www.npmjs.com/package/koa-server-timing