### PR TITLE
Add new fields to config: siteTitle, company.title and company.address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+ - The new fields in the config: _siteTitle_, _company.title_ and
+   _company.address_. These fields can be used to customize site (FreeFeed
+   instance) branding in emails, RSS feeds and service messages.
+
 ## [1.87.0] - 2020-10-13
 ### Added
  - The Server-Timing response header (for now, it contains a single metric,

--- a/app/controllers/api/v2/ExtAuthController.js
+++ b/app/controllers/api/v2/ExtAuthController.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import { pick } from 'lodash';
 import compose from 'koa-compose';
 
@@ -94,7 +95,7 @@ export const authFinish = compose([
         if (profileUser && profileUser.id !== currentUser.id) {
           throw new ForbiddenException(
             `The '${state.profile.fullName}' profile on ${authProvider.title} is already ` +
-          `associated with another FreeFeed account: @${profileUser.username}`
+          `associated with another ${config.siteTitle} account: @${profileUser.username}`
           );
         }
 

--- a/app/controllers/api/v2/PostsController.js
+++ b/app/controllers/api/v2/PostsController.js
@@ -1,3 +1,4 @@
+import config from 'config';
 import _ from 'lodash';
 import compose from 'koa-compose';
 
@@ -72,7 +73,7 @@ export const opengraph = compose([
 
     const body = _.escape(post.body);
 
-    let og = `<meta property="og:title" content="FreeFeed.net/${author.username}" />
+    let og = `<meta property="og:title" content="${author.username} at ${config.siteTitle}" />
       <meta property="og:description" content="${body}" />
       <meta property="og:type" content="article" />`;
 

--- a/app/controllers/api/v2/TimelinesRSS.js
+++ b/app/controllers/api/v2/TimelinesRSS.js
@@ -1,9 +1,9 @@
 import { escape as urlEscape } from 'querystring';
 
+import config from 'config';
 import { escape as htmlEscape } from 'lodash';
 import compose from 'koa-compose';
 import builder from 'xmlbuilder';
-import config from 'config'
 
 import { dbAdapter } from '../../../models';
 import { extractTitle, textToHTML } from '../../../support/rss-text-parser';
@@ -13,7 +13,6 @@ import { serializeComment } from '../../../serializers/v2/post';
 import { userTimeline, ORD_CREATED } from './TimelinesController';
 
 
-const SERVICE_NAME = 'FreeFeed.net';
 const TITILE_MAX_LEN = 60;
 const ommitBubblesThreshold = 600 * 1000; // 10 min in ms
 
@@ -41,14 +40,14 @@ async function timelineToRSS(data, ctx) {
     .att('version', '2.0')
   const channel = rss
     .ele('channel')
-    .ele('title', {}, `${feedTitle} @ ${SERVICE_NAME}`).up()
+    .ele('title', {}, `${feedTitle} @ ${config.siteTitle}`).up()
     .ele('link', {}, `${config.host}/${urlEscape(owner.username)}`).up()
     .ele('description', {}, owner.description).up();
 
   const userpic = owner.profilePictureLargeUrl || config.profilePictures.defaultProfilePictureMediumUrl;
   channel.ele('image')
     .ele('url', {}, userpic).up()
-    .ele('title', {}, `${feedTitle} @ ${SERVICE_NAME}`).up()
+    .ele('title', {}, `${feedTitle} @ ${config.siteTitle}`).up()
     .ele('link', {}, `${config.host}/${urlEscape(owner.username)}`).up();
 
   const postMakers = await Promise.all(data.timelines.posts.map((postId) => postItemMaker(postId, data, ctx)));

--- a/app/mailers/BestOfDigestMailer.js
+++ b/app/mailers/BestOfDigestMailer.js
@@ -22,7 +22,7 @@ export async function sendDailyBestOfEmail(user, data, digestDate) {
 
   const attachments = [fa['fa-heart'], fa['fa-lock'], fa['fa-comment-o'], fa['post-protected'], fa['fa-chevron-right']];
 
-  return Mailer.sendMail(user, `The best of your FreeFeed for ${digestDate}`, {
+  return Mailer.sendMail(user, `The best of your ${config.siteTitle} for ${digestDate}`, {
     digest: {
       body: emailBodyWithInlineStyles,
       date: digestDate
@@ -44,7 +44,7 @@ export async function sendWeeklyBestOfEmail(user, data, digestDate) {
 
   const attachments = [fa['fa-heart'], fa['fa-lock'], fa['fa-comment-o'], fa['post-protected'], fa['fa-chevron-right']];
 
-  return Mailer.sendMail(user, `The best of your FreeFeed for the week of ${digestDate}`, {
+  return Mailer.sendMail(user, `The best of your ${config.siteTitle} for the week of ${digestDate}`, {
     digest: {
       body: emailBodyWithInlineStyles,
       date: digestDate

--- a/app/scripts/views/mailer/dailyBestOfDigest.ejs
+++ b/app/scripts/views/mailer/dailyBestOfDigest.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>The best of your FreeFeed for <%= digest.date %></title>
+    <title>The best of your <% =config.siteTitle %> for <%= digest.date %></title>
 
 
     <style type="text/css">
@@ -80,12 +80,12 @@
                             <td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
                                 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                     <tr style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                        <td class="content-block" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top"><a href="<%= baseUrl %>" style="font-weight: bold;color:#333;text-decoration: none; font-size:21px;">FreeFeed</a> <span style="color:#333;text-decoration: none; font-size:21px;">| Best of day</span>
+                                        <td class="content-block" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top"><a href="<%= baseUrl %>" style="font-weight: bold;color:#333;text-decoration: none; font-size:21px;"><% =config.siteTitle %></a> <span style="color:#333;text-decoration: none; font-size:21px;">| Best of day</span>
                                         </td>
                                     </tr>
                                     <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                         <td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-                                            Hello <%- recipient.username %>, the entries below were popular among your friends. You are receiving this FreeFeed digest daily. You can unsubscribe in your <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; text-decoration: underline; margin: 0;">email preferences</a>.
+                                            Hello <%- recipient.username %>, the entries below were popular among your friends. You are receiving this <% =config.siteTitle %> digest daily. You can unsubscribe in your <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; text-decoration: underline; margin: 0;">email preferences</a>.
                                         </td>
                                     </tr>
                                     <tr>
@@ -100,9 +100,9 @@
                     <div class="footer" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
                         <table width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                             <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                <td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; line-height: 1.5em; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">FreeFeed MTÜ<br />Muti 30-25<br />13424 Tallinn, Estonia<br /><br />
+                                <td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; line-height: 1.5em; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top"><%= config.company.title %><br /><%= config.company.address %><br /><br />
 
-                                If you don't want to receive FreeFeed notification emails, you can <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">unsubscribe</a></td>
+                                If you don't want to receive <% =config.siteTitle %> notification emails, you can <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">unsubscribe</a></td>
                             </tr>
                         </table>
                     </div>

--- a/app/scripts/views/mailer/notificationsDigest.ejs
+++ b/app/scripts/views/mailer/notificationsDigest.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Your FreeFeed notifications for <%= digest.interval %></title>
+    <title>Your <% =config.siteTitle %> notifications for <%= digest.interval %></title>
 
 
     <style type="text/css">
@@ -80,12 +80,12 @@
                             <td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
                                 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                     <tr style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                        <td class="content-block" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top"><a href="<%= baseUrl %>" style="font-weight: bold;color:#333;text-decoration: none; font-size:21px;">FreeFeed</a> <span style="color:#333;text-decoration: none; font-size:21px;">| Notifications</span>
+                                        <td class="content-block" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top"><a href="<%= baseUrl %>" style="font-weight: bold;color:#333;text-decoration: none; font-size:21px;"><% =config.siteTitle %></a> <span style="color:#333;text-decoration: none; font-size:21px;">| Notifications</span>
                                         </td>
                                     </tr>
                                     <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                         <td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-                                            Hello <%= recipient.username %>, here are the notifications for <strong><%= digest.interval %></strong> that you might have missed since your last visit to FreeFeed:
+                                            Hello <%= recipient.username %>, here are the notifications for <strong><%= digest.interval %></strong> that you might have missed since your last visit to <% =config.siteTitle %>:
                                         </td>
                                     </tr>
                                     <%- digest.body %>
@@ -96,9 +96,9 @@
                     <div class="footer" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
                         <table width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                             <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                <td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; line-height: 1.5em; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">FreeFeed MTÜ<br />Muti 30-25<br />13424 Tallinn, Estonia<br /><br />
+                                <td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; line-height: 1.5em; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top"><%= config.company.title %><br /><%= config.company.address %><br /><br />
 
-                                If you don't want to receive FreeFeed notification emails, you can <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">unsubscribe</a></td>
+                                If you don't want to receive <% =config.siteTitle %> notification emails, you can <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">unsubscribe</a></td>
                             </tr>
                         </table>
                     </div>

--- a/app/scripts/views/mailer/resetPassword.ejs
+++ b/app/scripts/views/mailer/resetPassword.ejs
@@ -1,7 +1,7 @@
-FreeFeed password reset
+<%= config.siteTitle %> password reset
 ------------------------
 
-Thank you for using FreeFeed. We received a password reset request
+Thank you for using <%= config.siteTitle %>. We received a password reset request
 for this email address (<%= user.email %>) on
 <%= config.mailer.host %>. To reset your password, click the link below:
 
@@ -14,4 +14,4 @@ apologize for the inconvenience.
 If you have any problems resetting your password, you can get help
 from us at <%= config.mailer.fromEmail %>.
 
-FreeFeed.net Team
+<%= config.siteTitle %> Team

--- a/app/scripts/views/mailer/user-cooldown-finish.ejs
+++ b/app/scripts/views/mailer/user-cooldown-finish.ejs
@@ -1,6 +1,6 @@
 Your account has been deleted
 ----------------------------------
 
-Your FreeFeed account @<%= user.username %> has been deleted.
+Your <%= config.siteTitle %> account @<%= user.username %> has been deleted.
 
-FreeFeed.net Team
+<%= config.siteTitle %> Team

--- a/app/scripts/views/mailer/user-cooldown-reminder.ejs
+++ b/app/scripts/views/mailer/user-cooldown-reminder.ejs
@@ -9,4 +9,4 @@ on <%= deletionDate.toDateString() %>.
 To restore your account, enter your username/email and password
 in <%= config.mailer.host %>/signin and follow the instructions.
 
-FreeFeed.net Team
+<%= config.siteTitle %> Team

--- a/app/scripts/views/mailer/user-cooldown-start.ejs
+++ b/app/scripts/views/mailer/user-cooldown-start.ejs
@@ -10,4 +10,4 @@ will be deleted permanently.
 To restore your account, enter your username/email and password
 in <%= config.mailer.host %>/signin and follow the instructions.
 
-FreeFeed.net Team
+<%= config.siteTitle %> Team

--- a/app/scripts/views/mailer/weeklyBestOfDigest.ejs
+++ b/app/scripts/views/mailer/weeklyBestOfDigest.ejs
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>The best of your FreeFeed for the week of  <%= digest.date %></title>
+    <title>The best of your <% =config.siteTitle %> for the week of  <%= digest.date %></title>
 
 
     <style type="text/css">
@@ -80,12 +80,12 @@
                             <td class="content-wrap" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 20px;" valign="top">
                                 <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                     <tr style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                        <td class="content-block" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top"><a href="<%= baseUrl %>" style="font-weight: bold;color:#333;text-decoration: none; font-size:21px;">FreeFeed</a> <span style="color:#333;text-decoration: none; font-size:21px;">| Best of week</span>
+                                        <td class="content-block" style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top"><a href="<%= baseUrl %>" style="font-weight: bold;color:#333;text-decoration: none; font-size:21px;"><% =config.siteTitle %></a> <span style="color:#333;text-decoration: none; font-size:21px;">| Best of week</span>
                                         </td>
                                     </tr>
                                     <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                         <td class="content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
-                                            Hello <%- recipient.username %>, the entries below were popular among your friends this week. You are receiving this FreeFeed digest weekly. You can receive it more frequently or unsubscribe in your <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; text-decoration: underline; margin: 0;">email preferences</a>.
+                                            Hello <%- recipient.username %>, the entries below were popular among your friends this week. You are receiving this <% =config.siteTitle %> digest weekly. You can receive it more frequently or unsubscribe in your <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; text-decoration: underline; margin: 0;">email preferences</a>.
                                         </td>
                                     </tr>
                                     <tr>
@@ -100,9 +100,9 @@
                     <div class="footer" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
                         <table width="100%" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                             <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
-                                <td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; line-height: 1.5em; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top">FreeFeed MTÜ<br />Muti 30-25<br />13424 Tallinn, Estonia<br /><br />
+                                <td class="aligncenter content-block" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; line-height: 1.5em; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;" align="center" valign="top"><%= config.company.title %><br /><%= config.company.address %><br /><br />
 
-                                If you don't want to receive FreeFeed notification emails, you can <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">unsubscribe</a></td>
+                                If you don't want to receive <% =config.siteTitle %> notification emails, you can <a href="<%= baseUrl %>/settings#notifications" style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">unsubscribe</a></td>
                             </tr>
                         </table>
                     </div>

--- a/app/views/emails/best-of-digest/Feed.jsx
+++ b/app/views/emails/best-of-digest/Feed.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import Post from './Post.jsx';
+
 
 export default (props) => {
   const getEntryComponent = () => (post) => {

--- a/app/views/emails/best-of-digest/Post.jsx
+++ b/app/views/emails/best-of-digest/Post.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classnames from 'classnames';
-import _ from 'lodash';
 import config from 'config';
 
 import PostAttachments from './post-attachments.jsx';
@@ -100,7 +99,7 @@ export default class Post extends React.Component {
     }
 
     // "Like" / "Un-like"
-    const didILikePost = _.find(props.usersLikedPost, { id: props.user.id });
+    const didILikePost = props.usersLikedPost.some((u) => u.id === props.user.id);
     const likeLink = (
       <span>
         {' - '}
@@ -140,11 +139,15 @@ export default class Post extends React.Component {
           />
 
           <div className="post-footer">
-            {isPrivate ? (
-              <img src="cid:falock@2x" className="post-lock-icon fa fa-lock" width="16px" height="16px" title="This entry is private"/>
-            ) : isProtected ? (
-              <img src="cid:postprotected@2x" className="post-lock-icon post-protected-icon fa fa-lock" width="16px" height="16px" title="This entry is only visible to FreeFeed users"/>
-            ) : false}
+            {isPrivate && (
+              isProtected ? (
+                <img src="cid:postprotected@2x" className="post-lock-icon post-protected-icon fa fa-lock"
+                  width="16px" height="16px" title={`This entry is only visible to ${config.siteTitle} users`}/>
+              ) : (
+                <img src="cid:falock@2x" className="post-lock-icon fa fa-lock"
+                  width="16px" height="16px" title="This entry is private"/>
+              )
+            )}
             <Link to={canonicalPostURI} className="post-timestamp">
               <TimeDisplay timeStamp={+props.createdAt} />
             </Link>

--- a/config/default.js
+++ b/config/default.js
@@ -19,6 +19,8 @@ const stubTransport = function () {
 };
 
 const config = {
+  siteTitle: 'FreeFeed',
+
   port:     3000,
   database: 2,
 
@@ -42,6 +44,12 @@ const config = {
   frontendPreferencesLimit: 65536,
 
   monitorPrefix: 'development',
+};
+
+// Site instance owner's requisites for use in the digest email footers
+config.company = {
+  title:   'Our Company',
+  address: 'Our Company Address, City, Country',
 };
 
 config.host = defer((cfg) => `http://localhost:${cfg.port}`);

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -18,7 +18,7 @@ export default class Mailer {
 
   static async sendMail(recipient, subject, locals, file, sendAsHtml = false, attachments = []) {
     locals.config = config;
-    const plainText = await ejs.renderFile(file, locals, { async: true });
+    const plainText = await ejs.renderFile(file, { config, ...locals }, { async: true });
     const subjectTransformFn = _.get(locals, 'mailerConfig.subjectTransformation', defaultSubjectTransformation);
     const transformedSubject = subjectTransformFn(subject);
 

--- a/test/functional/timelines-rss.js
+++ b/test/functional/timelines-rss.js
@@ -44,14 +44,14 @@ describe('TimelinesAsRSS', () => {
       });
       const channel = findNode(resp.root, 'channel');
       expect(channel.children, 'to satisfy', [
-        { name: 'title', content: `Posts of ${luna.username} @ FreeFeed.net` },
+        { name: 'title', content: `Posts of ${luna.username} @ ${config.siteTitle}` },
         { name: 'link', content: `${config.host}/${luna.username}` },
         { name: 'description' },
         {
           name:     'image',
           children: [
             { name: 'url', content: config.profilePictures.defaultProfilePictureMediumUrl },
-            { name: 'title', content: `Posts of ${luna.username} @ FreeFeed.net` },
+            { name: 'title', content: `Posts of ${luna.username} @ ${config.siteTitle}` },
             { name: 'link', content: `${config.host}/${luna.username}` },
           ],
         },
@@ -223,14 +223,14 @@ describe('TimelinesAsRSS', () => {
       });
       const channel = findNode(resp.root, 'channel');
       expect(channel.children, 'to satisfy', [
-        { name: 'title', content: `Posts in group ${celestials.username} @ FreeFeed.net` },
+        { name: 'title', content: `Posts in group ${celestials.username} @ ${config.siteTitle}` },
         { name: 'link', content: `${config.host}/${celestials.username}` },
         { name: 'description' },
         {
           name:     'image',
           children: [
             { name: 'url', content: config.profilePictures.defaultProfilePictureMediumUrl },
-            { name: 'title', content: `Posts in group ${celestials.username} @ FreeFeed.net` },
+            { name: 'title', content: `Posts in group ${celestials.username} @ ${config.siteTitle}` },
             { name: 'link', content: `${config.host}/${celestials.username}` },
           ],
         },

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -4,6 +4,7 @@
  */
 declare module 'config' {
   type Config = {
+    siteTitle: string,
     host: string;
     attachments: {
       fileSizeLimit: number;
@@ -18,7 +19,12 @@ declare module 'config' {
 
     search: {
       maxQueryComplexity: number;
-      minPrefixLength:    number;
+      minPrefixLength: number;
+    }
+
+    company: {
+      title: string;
+      address: string;
     }
   }
 


### PR DESCRIPTION
These fields can be used to customize the site (FreeFeed instance) branding in emails, RSS feeds, and service messages. Closes #485.