### PR TITLE
Make tests compatible with Node 14

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Start Redis v${{ matrix.redis-version }}
-      uses: superchargejs/redis-github-action@1.1.0
+      uses: supercharge/redis-github-action@1.1.0
       with:
         redis-version: ${{ matrix.redis-version }}
 

--- a/test/functional/app-tokens.js
+++ b/test/functional/app-tokens.js
@@ -406,7 +406,7 @@ describe('Realtime', () => {
   it('sould not deliver post event to anonymous session', async () => {
     const test = session.notReceiveWhile(
       'comment:new',
-      createCommentAsync(luna, post.id, 'Hello'),
+      () => createCommentAsync(luna, post.id, 'Hello'),
     );
     await expect(test, 'to be fulfilled');
   });
@@ -415,7 +415,7 @@ describe('Realtime', () => {
     await session.sendAsync('auth', { authToken: luna.authToken });
     const test = session.receiveWhile(
       'comment:new',
-      createCommentAsync(luna, post.id, 'Hello'),
+      () => createCommentAsync(luna, post.id, 'Hello'),
     );
     await expect(test, 'to be fulfilled');
   });
@@ -424,7 +424,7 @@ describe('Realtime', () => {
     await session.sendAsync('auth', { authToken: token.tokenString() });
     const test = session.receiveWhile(
       'comment:new',
-      createCommentAsync(luna, post.id, 'Hello'),
+      () => createCommentAsync(luna, post.id, 'Hello'),
     );
     await expect(test, 'to be fulfilled');
   });

--- a/test/functional/bookmarklet.js
+++ b/test/functional/bookmarklet.js
@@ -81,7 +81,7 @@ describe('BookmarkletController', () => {
       it(`should deliver 'post:new' event when post created`, async () => {
         const test = lunaSession.receiveWhile(
           'post:new',
-          callBookmarklet(luna, { title: 'Post' }),
+          () => callBookmarklet(luna, { title: 'Post' }),
         );
         await expect(test, 'to be fulfilled');
       });
@@ -89,7 +89,7 @@ describe('BookmarkletController', () => {
       it(`should deliver 'post:new' and 'comment:new' events when post created with comment`, async () => {
         const test = lunaSession.receiveWhileSeq(
           ['post:new', 'comment:new'],
-          callBookmarklet(luna, { title: 'Post', comment: 'Comment' }),
+          () => callBookmarklet(luna, { title: 'Post', comment: 'Comment' }),
         );
         await expect(test, 'to be fulfilled');
       });

--- a/test/functional/gone-users.js
+++ b/test/functional/gone-users.js
@@ -192,12 +192,12 @@ describe('Gone users', () => {
         await rtSession.sendAsync('subscribe', { global: ['users'] });
 
         {
-          const test = rtSession.receiveWhile('global:user:update', setGoneStatus(luna, null));
+          const test = rtSession.receiveWhile('global:user:update', () => setGoneStatus(luna, null));
           await expect(test, 'when fulfilled', 'to satisfy', { user: { id: luna.user.id, isGone: undefined } });
         }
 
         {
-          const test = rtSession.receiveWhile('global:user:update', setGoneStatus(luna, GONE_SUSPENDED));
+          const test = rtSession.receiveWhile('global:user:update', () => setGoneStatus(luna, GONE_SUSPENDED));
           await expect(test, 'when fulfilled', 'to satisfy', { user: { id: luna.user.id, isGone: true } });
         }
       });
@@ -214,7 +214,7 @@ describe('Gone users', () => {
 
           const test = rtSession.receiveWhileSeq(
             ['global:user:update', 'global:user:update'],
-            setGoneStatus(luna, GONE_SUSPENDED)
+            () => setGoneStatus(luna, GONE_SUSPENDED)
           );
           await expect(
             test, 'when fulfilled', 'to satisfy',

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -451,7 +451,7 @@ describe('Group Moderation', () => {
               it(`should deliver 'post:update' event when Mars removes post`, async () => {
                 const test = rtSession.receiveWhile(
                   'post:update',
-                  deletePostAsync(mars, post.id),
+                  () => deletePostAsync(mars, post.id),
                 );
                 await expect(test, 'when fulfilled', 'to satisfy', { posts: { id: post.id } });
               });
@@ -466,7 +466,7 @@ describe('Group Moderation', () => {
               it(`should deliver 'post:update' event when Mars removes post`, async () => {
                 const test = rtSession.receiveWhile(
                   'post:update',
-                  deletePostAsync(mars, post.id),
+                  () => deletePostAsync(mars, post.id),
                 );
                 await expect(test, 'when fulfilled', 'to satisfy', { posts: { id: post.id } });
               });
@@ -481,7 +481,7 @@ describe('Group Moderation', () => {
               it(`should deliver 'post:update' event when Mars removes post`, async () => {
                 const test = rtSession.receiveWhile(
                   'post:update',
-                  deletePostAsync(mars, post.id),
+                  () => deletePostAsync(mars, post.id),
                 );
                 await expect(test, 'when fulfilled', 'to satisfy', { posts: { id: post.id } });
               });
@@ -520,7 +520,7 @@ describe('Group Moderation', () => {
                 it(`should deliver 'post:destroy' event to anonymous when Mars removes post`, async () => {
                   const test = rtSession.receiveWhile(
                     'post:destroy',
-                    deletePostAsync(mars, post.id),
+                    () =>  deletePostAsync(mars, post.id),
                   );
                   await expect(test, 'when fulfilled', 'to satisfy', { meta: { postId: post.id } });
                 });
@@ -528,7 +528,7 @@ describe('Group Moderation', () => {
                 it(`should deliver 'post:destroy' event to Jupiter when Mars removes post`, async () => {
                   const test = jupiterSession.receiveWhile(
                     'post:destroy',
-                    deletePostAsync(mars, post.id),
+                    () => deletePostAsync(mars, post.id),
                   );
                   await expect(test, 'when fulfilled', 'to satisfy', { meta: { postId: post.id } });
                 });
@@ -536,7 +536,7 @@ describe('Group Moderation', () => {
                 it(`should deliver 'post:update' event to Luna when Mars removes post`, async () => {
                   const test = lunaSession.receiveWhile(
                     'post:update',
-                    deletePostAsync(mars, post.id),
+                    () => deletePostAsync(mars, post.id),
                   );
                   await expect(test, 'when fulfilled', 'to satisfy', { posts: { id: post.id } });
                 });
@@ -544,7 +544,7 @@ describe('Group Moderation', () => {
                 it(`should deliver 'post:update' event to Mars when Mars removes post`, async () => {
                   const test = marsSession.receiveWhile(
                     'post:update',
-                    deletePostAsync(mars, post.id),
+                    () => deletePostAsync(mars, post.id),
                   );
                   await expect(test, 'when fulfilled', 'to satisfy', { posts: { id: post.id } });
                 });

--- a/test/functional/realtime-session.js
+++ b/test/functional/realtime-session.js
@@ -11,6 +11,7 @@ const silenceTimeout = 500;
 export default class Session {
   socket = null;
   name = '';
+  listeners = new Set();
 
   static create(port, name = '') {
     const options = {
@@ -28,6 +29,16 @@ export default class Session {
   constructor(socket, name = '') {
     this.socket = socket;
     this.name = name;
+
+    // To catch all events (https://stackoverflow.com/a/33960032)
+    const { onevent } = socket;
+    socket.onevent = function (packet) {
+      const args = packet.data || [];
+      onevent.call(this, packet); // original call
+      packet.data = ['*'].concat(args);
+      onevent.call(this, packet); // additional call to catch-all
+    };
+    socket.on('*', (event, data) => [...this.listeners].forEach((l) => l({ event, data })));
   }
 
   send(event, data) {
@@ -48,29 +59,59 @@ export default class Session {
 
   disconnect() {
     this.socket.disconnect();
+    this.listeners.clear();
   }
 
   receive(event) {
     return new Promise((resolve, reject) => {
-      const success = (data) => {
-        this.socket.off(event, success);
-        clearTimeout(timer);
-        resolve(data);
+      const timer = setTimeout(
+        () => reject(new Error(`${this.name ? `${this.name}: ` : ''}Expecting '${event}' event, got timeout`)),
+        eventTimeout,
+      );
+      const handler = ({ event: receivedEvent, data }) => {
+        if (receivedEvent === event) {
+          this.listeners.delete(handler);
+          clearTimeout(timer);
+          resolve(data);
+        }
       };
-      this.socket.on(event, success);
-      const timer = setTimeout(() => reject(new Error(`${this.name ? `${this.name}: ` : ''}Expecting '${event}' event, got timeout`)), eventTimeout);
+      this.listeners.add(handler);
     });
   }
 
   notReceive(event) {
     return new Promise((resolve, reject) => {
-      const fail = () => {
-        this.socket.off(event, fail);
-        clearTimeout(timer);
-        reject(new Error(`${this.name ? `${this.name}: ` : ''}Expecting silence, got '${event}' event`));
-      };
-      this.socket.on(event, fail);
       const timer = setTimeout(() => resolve(null), silenceTimeout);
+      const handler = ({ event: receivedEvent }) => {
+        if (receivedEvent === event) {
+          this.listeners.delete(handler);
+          clearTimeout(timer);
+          reject(new Error(`${this.name ? `${this.name}: ` : ''}Got unexpected '${event}' event`));
+        }
+      };
+      this.listeners.add(handler);
+    });
+  }
+
+  receiveSeq(events) {
+    return new Promise((resolve, reject) => {
+      const collectedData = [];
+      const timer = setTimeout(
+        () => reject(new Error(`${this.name ? `${this.name}: ` : ''}Expecting ${JSON.stringify(events)} events, got ${JSON.stringify(events.slice(0, collectedData.length))}`)),
+        eventTimeout,
+      );
+      const handler = ({ event: receivedEvent, data }) => {
+        if (receivedEvent === events[collectedData.length]) {
+          collectedData.push(data);
+
+          if (collectedData.length === events.length) {
+            this.listeners.delete(handler);
+            clearTimeout(timer);
+            resolve(collectedData);
+          }
+        }
+      };
+      this.listeners.add(handler);
     });
   }
 
@@ -83,14 +124,6 @@ export default class Session {
   async notReceiveWhile(event, ...tasks) {
     const listen = this.notReceive(event);
     await Promise.all([listen, ...tasks.map((t) => t())]);
-  }
-
-  async receiveSeq1(events) {
-    return await events.reduce(async (acc, event) => {
-      const arr = await acc;
-      const resp = await this.receive(event);
-      return [...arr, resp];
-    }, []);
   }
 
   async receiveWhileSeq(events, ...tasks) {

--- a/test/functional/realtime-session.js
+++ b/test/functional/realtime-session.js
@@ -74,16 +74,18 @@ export default class Session {
     });
   }
 
-  async receiveWhile(event, ...promises) {
-    const [result] = await Promise.all([this.receive(event), ...promises]);
+  async receiveWhile(event, ...tasks) {
+    const listen = this.receive(event);
+    const [result] = await Promise.all([listen, ...tasks.map((t) => t())]);
     return result;
   }
 
-  async notReceiveWhile(event, ...promises) {
-    await Promise.all([this.notReceive(event), ...promises]);
+  async notReceiveWhile(event, ...tasks) {
+    const listen = this.notReceive(event);
+    await Promise.all([listen, ...tasks.map((t) => t())]);
   }
 
-  async receiveSeq(events) {
+  async receiveSeq1(events) {
     return await events.reduce(async (acc, event) => {
       const arr = await acc;
       const resp = await this.receive(event);
@@ -91,8 +93,9 @@ export default class Session {
     }, []);
   }
 
-  async receiveWhileSeq(events, ...promises) {
-    const [result] = await Promise.all([this.receiveSeq(events), ...promises]);
+  async receiveWhileSeq(events, ...tasks) {
+    const listen = this.receiveSeq(events);
+    const [result] = await Promise.all([listen, ...tasks.map((t) => t())]);
     return result;
   }
 }

--- a/test/functional/realtime2.js
+++ b/test/functional/realtime2.js
@@ -299,7 +299,7 @@ describe('Realtime #2', () => {
         const screenName = 'Sailor Moon';
         const test = anonSession.receiveWhile(
           'global:user:update',
-          funcTestHelper.updateUserAsync(luna, { screenName })
+          () => funcTestHelper.updateUserAsync(luna, { screenName })
         );
         await expect(test, 'when fulfilled', 'to satisfy', {
           user: {
@@ -313,7 +313,7 @@ describe('Realtime #2', () => {
       it(`should deliver 'global:user:update' event when Luna goes private`, async () => {
         const test = anonSession.receiveWhile(
           'global:user:update',
-          funcTestHelper.goPrivate(luna)
+          () => funcTestHelper.goPrivate(luna)
         );
         await expect(test, 'when fulfilled', 'to satisfy', {
           user: {
@@ -327,7 +327,7 @@ describe('Realtime #2', () => {
       it(`should deliver 'global:user:update' event when Luna updates profile picture`, async () => {
         const test = anonSession.receiveWhile(
           'global:user:update',
-          funcTestHelper.updateProfilePicture(luna, 'test/fixtures/default-userpic-75.gif')
+          () => funcTestHelper.updateProfilePicture(luna, 'test/fixtures/default-userpic-75.gif')
         );
         await expect(test, 'when fulfilled', 'to satisfy', {
           user: {
@@ -343,7 +343,7 @@ describe('Realtime #2', () => {
         const lunaUser = await dbAdapter.getUserById(luna.user.id);
         const test = anonSession.receiveWhile(
           'global:user:update',
-          lunaUser.updateUsername('jupiter')
+          () => lunaUser.updateUsername('jupiter')
         );
         await expect(test, 'when fulfilled', 'to satisfy', {
           user: {
@@ -386,28 +386,28 @@ describe('Realtime #2', () => {
         describe(`${watcher.name} is watching`, () => {
           it(`should deliver 'global:user:update' event when group changes screenName`,
             () => shouldMatchActualInfo(
-              funcTestHelper.updateGroupAsync(selenites, luna, { screenName: 'The First Men in the Moon' }),
+              () => funcTestHelper.updateGroupAsync(selenites, luna, { screenName: 'The First Men in the Moon' }),
               watcher.session, watcher.userCtx,
             )
           );
 
           it(`should deliver 'global:user:update' event when group becomes restricted`,
             () => shouldMatchActualInfo(
-              funcTestHelper.updateGroupAsync(selenites, luna, { isRestricted: '1' }),
+              () => funcTestHelper.updateGroupAsync(selenites, luna, { isRestricted: '1' }),
               watcher.session, watcher.userCtx,
             )
           );
 
           it(`should deliver 'global:user:update' event when group becomes private`,
             () => shouldMatchActualInfo(
-              funcTestHelper.updateGroupAsync(selenites, luna, { isPrivate: '1' }),
+              () => funcTestHelper.updateGroupAsync(selenites, luna, { isPrivate: '1' }),
               watcher.session, watcher.userCtx,
             )
           );
 
           it(`should deliver 'global:user:update' event when group updates profile picture`,
             () => shouldMatchActualInfo(
-              funcTestHelper.updateGroupProfilePicture(luna, selenites.username, 'test/fixtures/default-userpic-75.gif'),
+              () => funcTestHelper.updateGroupProfilePicture(luna, selenites.username, 'test/fixtures/default-userpic-75.gif'),
               watcher.session, watcher.userCtx,
             )
           );
@@ -436,7 +436,7 @@ describe('Realtime #2', () => {
     it(`should deliver 'post:new' to Luna when Luna writes direct post to Mars`, async () => {
       const test = lunaSession.receiveWhile(
         'post:new',
-        funcTestHelper.createAndReturnPostToFeed([mars.user], luna, 'Hello'),
+        () => funcTestHelper.createAndReturnPostToFeed([mars.user], luna, 'Hello'),
       );
       await expect(test, 'to be fulfilled');
     });
@@ -444,7 +444,7 @@ describe('Realtime #2', () => {
     it(`should deliver 'post:new' to Mars when Luna writes direct post to Mars`, async () => {
       const test = marsSession.receiveWhile(
         'post:new',
-        funcTestHelper.createAndReturnPostToFeed([mars.user], luna, 'Hello'),
+        () => funcTestHelper.createAndReturnPostToFeed([mars.user], luna, 'Hello'),
       );
       await expect(test, 'to be fulfilled');
     });
@@ -458,7 +458,7 @@ describe('Realtime #2', () => {
       it(`should deliver 'comment:new' to Luna when Luna comments direct post`, async () => {
         const test = lunaSession.receiveWhile(
           'comment:new',
-          funcTestHelper.createCommentAsync(luna, post.id, 'Hello'),
+          () => funcTestHelper.createCommentAsync(luna, post.id, 'Hello'),
         );
         await expect(test, 'to be fulfilled');
       });
@@ -466,7 +466,7 @@ describe('Realtime #2', () => {
       it(`should deliver 'comment:new' to Mars when Luna comments direct post`, async () => {
         const test = marsSession.receiveWhile(
           'comment:new',
-          funcTestHelper.createCommentAsync(luna, post.id, 'Hello'),
+          () => funcTestHelper.createCommentAsync(luna, post.id, 'Hello'),
         );
         await expect(test, 'to be fulfilled');
       });
@@ -474,7 +474,7 @@ describe('Realtime #2', () => {
       it(`should deliver 'post:destroy' to Luna when Luna deletes direct post`, async () => {
         const test = lunaSession.receiveWhile(
           'post:destroy',
-          funcTestHelper.deletePostAsync(luna, post.id),
+          () => funcTestHelper.deletePostAsync(luna, post.id),
         );
         await expect(test, 'to be fulfilled');
       });
@@ -482,7 +482,7 @@ describe('Realtime #2', () => {
       it(`should deliver 'post:destroy' to Mars when Luna deletes direct post`, async () => {
         const test = marsSession.receiveWhile(
           'post:destroy',
-          funcTestHelper.deletePostAsync(luna, post.id),
+          () => funcTestHelper.deletePostAsync(luna, post.id),
         );
         await expect(test, 'to be fulfilled');
       });
@@ -567,7 +567,7 @@ describe('Realtime #2', () => {
           luna.post = await funcTestHelper.createAndReturnPostToFeed([luna], luna, 'Post');
           const test = marsSession.receiveWhile(
             'post:new',
-            funcTestHelper.updatePostAsync(luna, { feeds: [luna.username, celestials.username] }),
+            () => funcTestHelper.updatePostAsync(luna, { feeds: [luna.username, celestials.username] }),
           );
           await expect(test, 'to be fulfilled');
         });
@@ -576,7 +576,7 @@ describe('Realtime #2', () => {
           luna.post = await funcTestHelper.createAndReturnPostToFeed([luna], luna, 'Post');
           const test = anonSession.receiveWhile(
             'post:new',
-            funcTestHelper.updatePostAsync(luna, { feeds: [luna.username, celestials.username] }),
+            () => funcTestHelper.updatePostAsync(luna, { feeds: [luna.username, celestials.username] }),
           );
           await expect(test, 'to be fulfilled');
         });
@@ -585,7 +585,7 @@ describe('Realtime #2', () => {
           luna.post = await funcTestHelper.createAndReturnPostToFeed([luna, celestials], luna, 'Post');
           const test = marsSession.receiveWhile(
             'post:destroy',
-            funcTestHelper.updatePostAsync(luna, { feeds: [luna.username] }),
+            () => funcTestHelper.updatePostAsync(luna, { feeds: [luna.username] }),
           );
           await expect(test, 'to be fulfilled');
         });
@@ -594,7 +594,7 @@ describe('Realtime #2', () => {
           luna.post = await funcTestHelper.createAndReturnPostToFeed([luna, celestials], luna, 'Post');
           const test = anonSession.receiveWhile(
             'post:destroy',
-            funcTestHelper.updatePostAsync(luna, { feeds: [luna.username] }),
+            () => funcTestHelper.updatePostAsync(luna, { feeds: [luna.username] }),
           );
           await expect(test, 'to be fulfilled');
         });
@@ -617,7 +617,7 @@ describe('Realtime #2', () => {
             luna.post = await funcTestHelper.createAndReturnPostToFeed([luna], luna, 'Post');
             const test = secondMarsSession.notReceiveWhile(
               'post:new',
-              funcTestHelper.updatePostAsync(luna, { feeds: [luna.username, celestials.username] }),
+              () => funcTestHelper.updatePostAsync(luna, { feeds: [luna.username, celestials.username] }),
             );
             await expect(test, 'to be fulfilled');
           });
@@ -633,7 +633,7 @@ describe('Realtime #2', () => {
           luna.post = await funcTestHelper.createAndReturnPostToFeed([mars], luna, 'Direct');
           const test = jupiterSession.receiveWhile(
             'post:new',
-            funcTestHelper.updatePostAsync(luna, { feeds: [mars.username, jupiter.username] }),
+            () => funcTestHelper.updatePostAsync(luna, { feeds: [mars.username, jupiter.username] }),
           );
           await expect(test, 'to be fulfilled');
         });
@@ -710,7 +710,7 @@ describe('Realtime: Homefeed modes', () => {
   const testPostActivity = async (commenter, post, should = true) => {
     const test = lunaSession[should ? 'receiveWhile' : 'notReceiveWhile'](
       'comment:new',
-      funcTestHelper.createCommentAsync(commenter, post.id, 'Hello'),
+      () => funcTestHelper.createCommentAsync(commenter, post.id, 'Hello'),
     );
     await expect(test, 'to be fulfilled');
   };
@@ -886,7 +886,7 @@ describe('Realtime: Group time updates', () => {
   it(`should deliver 'user:update' to Luna when Luna writes a post to Selenites`, async () => {
     const test = lunaSession.receiveWhile(
       'user:update',
-      funcTestHelper.createAndReturnPostToFeed([selenites], luna, 'Hello'),
+      () => funcTestHelper.createAndReturnPostToFeed([selenites], luna, 'Hello'),
     );
     await expect(test, 'to be fulfilled with', { updatedGroups: [{ id: selenites.group.id }] });
   });
@@ -895,7 +895,7 @@ describe('Realtime: Group time updates', () => {
     const post = await funcTestHelper.createAndReturnPostToFeed([selenites], luna, 'Hello');
     const test = lunaSession.receiveWhile(
       'user:update',
-      funcTestHelper.createCommentAsync(luna, post.id, 'Hello'),
+      () => funcTestHelper.createCommentAsync(luna, post.id, 'Hello'),
     );
     await expect(test, 'to be fulfilled with', { updatedGroups: [{ id: selenites.group.id }] });
   });
@@ -903,7 +903,7 @@ describe('Realtime: Group time updates', () => {
   it(`should deliver 'user:update' to Mars when Luna writes a post to Selenites`, async () => {
     const test = marsSession.receiveWhile(
       'user:update',
-      funcTestHelper.createAndReturnPostToFeed([selenites], luna, 'Hello'),
+      () => funcTestHelper.createAndReturnPostToFeed([selenites], luna, 'Hello'),
     );
     await expect(test, 'to be fulfilled with', { updatedGroups: [{ id: selenites.group.id }] });
   });
@@ -911,7 +911,7 @@ describe('Realtime: Group time updates', () => {
   it(`should deliver 'user:update' with two groups to Luna when Luna writes a post to Selenites and Celestials`, async () => {
     const test = lunaSession.receiveWhile(
       'user:update',
-      funcTestHelper.createAndReturnPostToFeed([selenites, celestials], luna, 'Hello'),
+      () => funcTestHelper.createAndReturnPostToFeed([selenites, celestials], luna, 'Hello'),
     );
     await expect(test, 'to be fulfilled with', {
       updatedGroups: expect
@@ -924,7 +924,7 @@ describe('Realtime: Group time updates', () => {
   it(`should deliver 'user:update' with two groups to Mars when Luna writes a post to Selenites and Celestials`, async () => {
     const test = marsSession.receiveWhile(
       'user:update',
-      funcTestHelper.createAndReturnPostToFeed([selenites, celestials], luna, 'Hello'),
+      () => funcTestHelper.createAndReturnPostToFeed([selenites, celestials], luna, 'Hello'),
     );
     await expect(test, 'to be fulfilled with', {
       updatedGroups: expect
@@ -937,7 +937,7 @@ describe('Realtime: Group time updates', () => {
   it(`should not deliver 'user:update' to Venus when Luna writes a post to Selenites`, async () => {
     const test = venusSession.notReceiveWhile(
       'user:update',
-      funcTestHelper.createAndReturnPostToFeed([selenites], luna, 'Hello'),
+      () => funcTestHelper.createAndReturnPostToFeed([selenites], luna, 'Hello'),
     );
     await expect(test, 'to be fulfilled');
   });
@@ -945,7 +945,7 @@ describe('Realtime: Group time updates', () => {
   it(`should deliver 'user:update' with Selenites only group to Jupiter when Luna writes a post to Selenites and Celestials`, async () => {
     const test = jupiterSession.receiveWhile(
       'user:update',
-      funcTestHelper.createAndReturnPostToFeed([selenites, celestials], luna, 'Hello'),
+      () => funcTestHelper.createAndReturnPostToFeed([selenites, celestials], luna, 'Hello'),
     );
     await expect(test, 'to be fulfilled with', { updatedGroups: [{ id: selenites.group.id }] });
   });


### PR DESCRIPTION
Realtime test sessions now handles events sequences in one sub/unsub cycle. The previous approach, with resubscription after the each event, was somehow incompatible with Node 14.