### PR TITLE
Add a `realtimeChannels` field to 'post:new' realtime events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.89.0] - Not Released
+### Fixed
+- The 'post:new' realtime event was emitted without the `realtimeChannels`
+  field. As a result, the client had no information on which channels the
+  message was sent to. This led to new posts appearing in unrelated feeds.
+
 ### Added
 - Initial Typescript definitions for DbAdapter and models
 

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -582,9 +582,9 @@ export default class PubsubListener {
     defaultEmitter(socket, type, json);
   }
 
-  _postEventEmitter = async (socket, type, { postId }) => {
+  _postEventEmitter = async (socket, type, { postId, realtimeChannels }) => {
     const json = await serializeSinglePost(postId, socket.userId);
-    defaultEmitter(socket, type, json);
+    defaultEmitter(socket, type, { ...json, realtimeChannels });
   };
 
 

--- a/test/functional/realtime2.js
+++ b/test/functional/realtime2.js
@@ -438,7 +438,7 @@ describe('Realtime #2', () => {
         'post:new',
         () => funcTestHelper.createAndReturnPostToFeed([mars.user], luna, 'Hello'),
       );
-      await expect(test, 'to be fulfilled');
+      await expect(test, 'to be fulfilled with', { realtimeChannels: expect.it('to be an array') });
     });
 
     it(`should deliver 'post:new' to Mars when Luna writes direct post to Mars`, async () => {


### PR DESCRIPTION
The 'post:new' realtime event was emitted without the `realtimeChannels` field. As a result, the client had no information on which channels the message was sent to. This led to new posts appearing in unrelated feeds.