### PR TITLE
Use X-Forwarded-For header in realtime connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   created, reissued, closed (at sign out); user can view list of their session
   with the information of last usage and close one or more of them. The old
   session tokens (SessionTokenV0) are still supported but deprecated.
+- The 'proxyIpHeader' config option (default value is 'X-Forwarded-For') for the
+  instances behind the proxy. Active when the 'trustProxyHeaders' option is
+  true.
 
 ## [1.90.0] - 2020-12-29
 ### Fixed

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -65,8 +65,7 @@ export default class UsersController {
       };
 
       if (config.recaptcha.enabled) {
-        const ip = ctx.request.get('x-forwarded-for') || ctx.request.ip;
-        await recaptchaVerify(ctx.request.body.captcha, ip);
+        await recaptchaVerify(ctx.request.body.captcha, ctx.request.ip);
       }
 
       let extProfileData = null;

--- a/app/freefeed-app.ts
+++ b/app/freefeed-app.ts
@@ -30,6 +30,7 @@ class FreefeedApp extends Application {
 
     if (config.trustProxyHeaders) {
       this.proxy = true;
+      this.proxyIpHeader = config.proxyIpHeader;
     }
 
     this.context.config = config;

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -798,9 +798,13 @@ async function getAuthUserId(jwtToken, socket) {
     return null;
   }
 
+  // Parse the 'X-Forwarded-For' header ("client, proxy1, proxy2")
+  const proxyHeader = socket.handshake.headers[config.proxyIpHeader.toLowerCase()];
+  const ips = config.trustProxyHeaders && proxyHeader ? proxyHeader.split(/\s*,\s*/) : [];
+
   // Fake context
   const ctx = {
-    ip: socket.handshake.address,
+    ip: ips[0] || socket.handshake.address,
     headers: {
       ...socket.handshake.headers,
       authorization: `Bearer ${jwtToken}`,

--- a/app/scripts/views/mailer/auth-session-blocked.ejs
+++ b/app/scripts/views/mailer/auth-session-blocked.ejs
@@ -5,13 +5,13 @@ One of your authorization sessions has been blocked due to suspicious
 activity. The session was accessed from:
 
   IP: <%= access.ip %>
-  Time: <%= access.date.toDateString() %>
+  Time: <%= access.date.toUTCString() %>
   Browser: <%= access.userAgent %>
 
 The last usage of this session was from:
 
   IP: <%= session.lastIP || 'undefined' %>
-  Time: <%= session.lastUsedAt ? session.lastUsedAt.toDateString() : 'undefined' %>
+  Time: <%= session.lastUsedAt ? session.lastUsedAt.toUTCString() : 'undefined' %>
   Browser: <%= session.lastUserAgent || 'undefined' %>
 
 If you don't recognize any of these IP addresses or browsers, we recommend you

--- a/config/default.js
+++ b/config/default.js
@@ -33,6 +33,7 @@ const config = {
   // Configure koa app to trust proxy headers:
   // X-Forwarded-Host, X-Forwarded-Proto and X-Forwarded-For
   trustProxyHeaders: false,
+  proxyIpHeader: 'X-Forwarded-For',
 
   logResponseTime: true,
   // disableRealtime: true,

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -10,6 +10,7 @@ declare module 'config' {
     secret: string;
     appRoot: string;
     trustProxyHeaders: boolean;
+    proxyIpHeader: string;
     logResponseTime: boolean;
     attachments: {
       fileSizeLimit: number;


### PR DESCRIPTION
We need the real client IP for logging and access control purposes. Unfortunately, it is hard to properly test it, because the websocket connection doesn't allow to specify additional HTTP headers.