### PR TITLE
Properly index texts with HTML-like tags (like spoiler tags)

### DIFF
--- a/app/support/search/to-tsvector.ts
+++ b/app/support/search/to-tsvector.ts
@@ -2,7 +2,7 @@ import pgFormat from 'pg-format';
 import { HashTag, Mention, Link } from 'social-text-tokenizer';
 import config from 'config';
 
-import { tokenize } from '../tokenize-text';
+import { HTMLTag, tokenize } from '../tokenize-text';
 
 import { normalizeText, linkToText } from './norm';
 
@@ -28,6 +28,10 @@ export function toTSVector(text: string) {
 
       if (token instanceof Link) {
         return pgFormat(`to_tsvector_with_exact(%L, %L)`, ftsCfg, linkToText(token));
+      }
+
+      if (token instanceof HTMLTag) {
+        return token.content && pgFormat('to_tsvector_with_exact(%L, %L)', ftsCfg, token.content);
       }
 
       const trimmedText = token.text.trim();

--- a/app/support/tokenize-text.ts
+++ b/app/support/tokenize-text.ts
@@ -6,7 +6,23 @@ import {
   mentions,
   links,
   arrows,
+  Token,
 } from 'social-text-tokenizer';
+// The CJS version of social-text-tokenizer has not .d.ts yet, so expecting error
+// @ts-expect-error
+import byRegexp from 'social-text-tokenizer/build/cjs/lib/byRegexp';
+
+export class HTMLTag extends Token {
+  public closing = false;
+  public content = '';
+}
+
+const htmlTags = byRegexp(/<(\/)?(.+?)>/g, (offset: number, text: string, m: RegExpExecArray) => {
+  const t = new HTMLTag(offset, text);
+  t.closing = !!m[1];
+  t.content = m[2].trim();
+  return t;
+});
 
 export const tokenize = withText(
   combine(
@@ -15,5 +31,6 @@ export const tokenize = withText(
     mentions(),
     links({ tldList: ['рф', 'com', 'net', 'org', 'edu', 'place'] }),
     arrows(),
+    htmlTags,
   ),
 );

--- a/test/unit/support/search/to-tsvector.ts
+++ b/test/unit/support/search/to-tsvector.ts
@@ -50,4 +50,19 @@ describe('toTSVector', () => {
         `)`,
     );
   });
+
+  it('should return vector of text with SPOILERS', () => {
+    const string = 'the quick <spoiler>brown</spoiler> fox';
+    expect(
+      toTSVector(string),
+      'to be',
+      `(` +
+        `to_tsvector_with_exact('${ftsCfg}', 'the quick') || ` +
+        `to_tsvector_with_exact('${ftsCfg}', 'spoiler') || ` +
+        `to_tsvector_with_exact('${ftsCfg}', 'brown') || ` +
+        `to_tsvector_with_exact('${ftsCfg}', 'spoiler') || ` +
+        `to_tsvector_with_exact('${ftsCfg}', 'fox')` +
+        `)`,
+    );
+  });
 });


### PR DESCRIPTION
Indexing tags content as a plain text, so the "spoiler" query will now return all texts with the &lt;spoiler> tag.

Ideally, we should reindex the database after this change.