### PR TITLE
Add list of 'inline' attachments' MIME-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The 'proxyIpHeader' config option (default value is 'X-Forwarded-For') for the
   instances behind the proxy. Active when the 'trustProxyHeaders' option is
   true.
+- Explicit list of the attachments' MIME types that should be served with
+  'Content-Disposition: inline'. All other attachments should be served with
+  'Content-Disposition: attachment' to prevent in-browser execution of active
+  content.
 
 ## [1.90.1] - 2021-01-12
 ### Fixed

--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -444,8 +444,12 @@ export function addModel(dbAdapter) {
       // Modern browsers support UTF-8 filenames
       const fileNameUtf8 = encodeURIComponent(this.fileName);
 
+      const disposition = config.media.inlineMimeTypes.includes(this.mimeType)
+        ? 'inline'
+        : 'attachment';
+
       // Inline version of 'attfnboth' method (http://greenbytes.de/tech/tc2231/#attfnboth)
-      return `inline; filename="${fileNameAscii}"; filename*=utf-8''${fileNameUtf8}`;
+      return `${disposition}; filename="${fileNameAscii}"; filename*=utf-8''${fileNameUtf8}`;
     }
 
     async destroy() {

--- a/config/default.js
+++ b/config/default.js
@@ -116,6 +116,21 @@ config.media = {
     bucket: 'bucket-name',
     // endpoint:        'nyc3.digitaloceanspaces.com',
   },
+  // Files of these types are uplodes to S3 with 'Content-Disposition: inline'.
+  // All other types will have 'Content-Disposition: attachment' to prevent
+  // in-browser execution.
+  inlineMimeTypes: [
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'audio/mpeg',
+    'audio/mp4',
+    'audio/ogg',
+    'video/mp4',
+    'application/pdf',
+    'text/plain',
+  ],
 };
 config.attachments = {
   url: defer((cfg) => cfg.media.url),

--- a/test/integration/models/attachment.js
+++ b/test/integration/models/attachment.js
@@ -407,5 +407,19 @@ describe('Attachment', () => {
       const deleted = await dbAdapter.getAttachmentById(attachment.id);
       expect(deleted).to.be.null;
     });
+
+    it(`should produce 'inline' Content-Disposition for image/jpeg file`, () => {
+      const attachment = new Attachment({ fileName: 'sample', mimeType: 'image/jpeg' });
+      expect(attachment.getContentDisposition()).to.be.equal(
+        `inline; filename="sample"; filename*=utf-8''sample`,
+      );
+    });
+
+    it(`should produce 'attachment' Content-Disposition for application/zip file`, () => {
+      const attachment = new Attachment({ fileName: 'sample', mimeType: 'application/zip' });
+      expect(attachment.getContentDisposition()).to.be.equal(
+        `attachment; filename="sample"; filename*=utf-8''sample`,
+      );
+    });
   });
 });


### PR DESCRIPTION
Add explicit list of the attachments' MIME types that should be served with 'Content-Disposition: inline'. All other attachments should be served with 'Content-Disposition: attachment' to prevent in-browser execution of active content.