### PR TITLE
Do not block sessions on invalid token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   channel with the 'event:new' message type. The message format is the same as
   in `GET /v2/notifications` response.
 
+### Changed
+- Do not block authorization sessions if token with the invalid issue is comes.
+  We probably should add another blocking criteria in the future.
+
 ## [1.92.1] - 2021-01-24
 ### Added
 - Count blocked auth sessions in StatsD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Do not block authorization sessions if token with the invalid issue is comes.
   We probably should add another blocking criteria in the future.
+- Remove old authorization sessions by last use (instead of last update) time.
 
 ## [1.92.1] - 2021-01-24
 ### Added

--- a/app/support/DbAdapter/auth-sessions.js
+++ b/app/support/DbAdapter/auth-sessions.js
@@ -97,8 +97,8 @@ const authSessionsTrait = (superClass) =>
     async cleanOldAuthSessions(activeTTLDays, inactiveTTLDays) {
       await this.database.raw(
         `delete from auth_sessions where
-        status = :activeStatus and updated_at < now() - :activeTTLDays * '1 day'::interval
-        or status <> :activeStatus and updated_at < now() - :inactiveTTLDays * '1 day'::interval`,
+        status = :activeStatus and last_used_at < now() - :activeTTLDays * '1 day'::interval
+        or status <> :activeStatus and last_used_at < now() - :inactiveTTLDays * '1 day'::interval`,
         { activeTTLDays, inactiveTTLDays, activeStatus: ACTIVE },
       );
     }

--- a/app/support/ExtAuth/Cache.ts
+++ b/app/support/ExtAuth/Cache.ts
@@ -35,7 +35,7 @@ export class Cache {
     await this.cache.set(this.keyPrefix + key, data, this.ttl);
   }
 
-  get<T>(key: string): Promise<T> {
+  get<T>(key: string): Promise<T | undefined> {
     return this.cache.get(this.keyPrefix + key);
   }
 

--- a/test/functional/session.js
+++ b/test/functional/session.js
@@ -278,13 +278,6 @@ describe('SessionController', () => {
         'to be fulfilled with',
         { __httpCode: 401 },
       );
-
-      // ...and the entire session is now blocked
-      await expect(
-        performJSONRequest('GET', '/v1/users/me', null, authHeaders(newToken)),
-        'to be fulfilled with',
-        { __httpCode: 401 },
-      );
     });
 
     it(`should allow to reauthorize realtime session`, async () => {

--- a/test/integration/models/auth-tokens.js
+++ b/test/integration/models/auth-tokens.js
@@ -529,7 +529,7 @@ describe('Auth Tokens', () => {
         session2 = await sessionTokenV1Store.create(luna.id);
 
         await dbAdapter.database.raw(
-          `update auth_sessions set updated_at = now() - :time * '1 day'::interval where uid = :uid`,
+          `update auth_sessions set last_used_at = now() - :time * '1 day'::interval where uid = :uid`,
           { uid: session2.id, time: config.authSessions.activeSessionTTLDays + 1 },
         );
 


### PR DESCRIPTION
Do not block sessions on invalid token, remove old sessions by last use time.

It still required a client-side changes.