### PR TITLE
Add  `GET /v2/notifications/:notifId` API method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.95.0] - Not Released
+### Added
+- New API method `GET /v2/notifications/:notifId` allows to fetch single
+  notification by its id.
 
 ## [1.94.2] - 2021-03-09
 ### Fixed

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -115,6 +115,7 @@ export const appTokensScopes = [
     title: 'Manage notifications',
     routes: [
       'GET /v2/notifications',
+      'GET /v2/notifications/:notifId',
       'POST /v2/users/markAllNotificationsAsRead',
       'GET /v2/users/getUnreadNotificationsNumber',
     ],

--- a/app/routes/api/v2/NotificationsRoute.js
+++ b/app/routes/api/v2/NotificationsRoute.js
@@ -2,4 +2,5 @@ import { EventsController } from '../../../controllers';
 
 export default function addRoutes(app) {
   app.get('/v2/notifications', EventsController.myEvents);
+  app.get('/v2/notifications/:notifId', EventsController.eventById);
 }


### PR DESCRIPTION
New API method `GET /v2/notifications/:notifId` allows to fetch single notification by its id. It will be useful for notification-related services, specifically for Telegram client.