### PR TITLE
Add a "to:" search operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ specs).
       This method accepts `maxComments=all` and `maxLikes=all` get parameters.
 - WebP attachments support. The uploaded WebP originals are kept unchanged, but
   have JPEG thumbnails for better compatibility with older browsers.
+- The "to:" search operator. "to:user1,group2" limits search to posts published
+  in group2 feed or written _to_ user1 as a direct message. This operator acts
+  like "in:" for the groups but also allows to search in direct messages with
+  the specific addressee.
 
 ## [1.94.2] - 2021-03-09
 ### Fixed

--- a/app/support/search/query-syntax.md
+++ b/app/support/search/query-syntax.md
@@ -32,6 +32,7 @@ Some operators takes user name as an arguments. In such operators you can use a 
 * in-my:
 * commented-by:
 * liked-by:
+* to:
 
 
 ### Global search scope
@@ -87,6 +88,8 @@ The "in:" operator has the "group:" alias, it left for compatibility.
 **liked-by:user1,user2** limits search to posts liked by user1 or user2.
 
 `cat liked-by:alice` will find all posts liked by Alice with the "cat" word.
+
+**to:user1,group2** limits search to posts published in group2 feed or written _to_ user1 as a direct message. This operator acts like **in:** for the groups but also allows to search in direct messages with the specific addressee.
 
 ### Content authorship
 

--- a/app/support/search/query-tokens.ts
+++ b/app/support/search/query-tokens.ts
@@ -179,6 +179,7 @@ export const listConditions: [RegExp, string][] = [
   [/^in-?my$/, 'in-my'],
   [/^commented-?by$/, 'commented-by'],
   [/^liked-?by$/, 'liked-by'],
+  [/^to$/, 'to'],
   // Comments
   // [/^cliked-?by$/, 'cliked-by'],
   // Authorship

--- a/test/integration/support/DbAdapter/search.js
+++ b/test/integration/support/DbAdapter/search.js
@@ -396,7 +396,7 @@ describe('Search', () => {
         });
       });
 
-      describe('in-my:', () => {
+      describe('in-my:, to: (for directs)', () => {
         describe('Luna subscribed to Mars, saves and likes some posts', () => {
           let postsToLike, postsToSave;
           before(async () => {
@@ -467,7 +467,7 @@ describe('Search', () => {
             posts.push(directPost);
           });
           after(async () => {
-            posts.pop(directPost);
+            posts.pop();
             await directPost.destroy();
             await mars.unsubscribeFrom(luna);
             await luna.unsubscribeFrom(mars);
@@ -488,6 +488,16 @@ describe('Search', () => {
               query: 'in-my:directs -from:me',
               viewerName: 'luna',
               filter: () => false,
+            },
+            {
+              query: 'to:mars',
+              viewerName: 'luna',
+              filter: (p) => p.id === directPost.id,
+            },
+            {
+              query: 'to:me',
+              viewerName: 'mars',
+              filter: (p) => p.id === directPost.id,
             },
           ]);
         });


### PR DESCRIPTION
**to:user1,group2** limits search to posts published in group2 feed or written _to_ user1 as a direct message. This operator acts like **in:** for the groups but also allows to search in direct messages with the specific addressee.