### PR TITLE
Add 'fromFeed' parameter(s) to the post deletion API method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.100.0] - Not released
+### Added
+- The `DELETE /v1/posts/:postId` API method now can have one or more 'fromFeed'
+   GET-parameters. These parameter defines the 'Posts' feeds (by username) from
+   which this post should be deleted. If there are no 'fromFeed' parameters, the
+   post will be deleted completely (by author) or from all managed groups (by
+   groups admin).
 
 ## [1.99.0] - 2021-06-08
 ### Fixed

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -58,6 +58,7 @@ export class Post {
   onlyUsersCanSeePost(fromUsers: User[]): Promise<User[]>;
   getGroupsPostedTo(): Promise<Group[]>;
   getCreatedBy(): Promise<User>;
+  isAuthorOrGroupAdmin(user: User): Promise<boolean>;
 }
 
 export class Timeline {

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -90,6 +90,7 @@ export class DbAdapter {
       subscriptions: number;
     };
   }>;
+  isUserAdminOfGroup(userId: UUID, groupId: UUID): Promise<boolean>;
 
   getUsersIdsByIntIds(intIds: number[]): Promise<{ id: number; uid: UUID }[]>;
   getPostsIdsByIntIds(intIds: number[]): Promise<{ id: number; uid: UUID }[]>;
@@ -117,6 +118,7 @@ export class DbAdapter {
   // Timelines
   getTimelinesByIds(ids: UUID[]): Promise<Timeline[]>;
   getAllUserNamedFeed(userId: UUID, feedName: string): Promise<Timeline[]>;
+  getUserNamedFeed(userId: UUID, feedName: string): Promise<Nullable<Timeline>>;
 
   // App tokens
   createAppToken(token: AppTokenCreateParams): Promise<AppTokenV1>;


### PR DESCRIPTION
The `DELETE /v1/posts/:postId` API method now can have one or more 'fromFeed' GET-parameters. These parameter defines the 'Posts' feeds (by username) from which this post should be deleted. If there are no 'fromFeed' parameters, the post will be deleted completely (by author) or from all managed groups (by groups admin).

Closes #532