### PR TITLE
Disable the 'global:user:update' event for non-members of private groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    post will be deleted completely (by author) or from all managed groups (by
    groups admin).
 
+### Changed
+- When the private group info is changed, the 'global:user:update' realtime
+  event is delivered only to the group subscribers (earlier it was sent to
+  everyone).
+
 ## [1.99.1] - 2021-07-03
 ### Fixed
 - GDPR script works again

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -534,7 +534,7 @@ export default class PubsubListener {
 
     let receivers = List.everything();
 
-    if (account.isGroup && account.isPrivate === '1') {
+    if (account.isGroup() && account.isPrivate === '1') {
       const postsFeed = await account.getPostsTimeline();
       receivers = List.from(await dbAdapter.getTimelineSubscribersIds(postsFeed.id));
     }

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -525,18 +525,35 @@ export default class PubsubListener {
     await this._sendCommentLikeMsg(data, eventNames.COMMENT_LIKE_REMOVED);
   };
 
-  onGlobalUserUpdate = (userId) =>
-    this.broadcastMessage(
+  onGlobalUserUpdate = async (userId) => {
+    const account = await dbAdapter.getFeedOwnerById(userId);
+
+    if (!account) {
+      return;
+    }
+
+    let receivers = List.everything();
+
+    if (account.isGroup && account.isPrivate === '1') {
+      const postsFeed = await account.getPostsTimeline();
+      receivers = List.from(await dbAdapter.getTimelineSubscribersIds(postsFeed.id));
+    }
+
+    await this.broadcastMessage(
       ['global:users'],
       eventNames.GLOBAL_USER_UPDATED,
       null,
       null,
       async (socket, type, json) => {
+        if (!receivers.includes(socket.userId)) {
+          return;
+        }
+
         const [user] = await serializeUsersByIds([userId], true, socket.userId);
         await socket.emit(type, { ...json, user });
       },
     );
-
+  };
   onGroupTimesUpdate = async ({ groupIds }) => {
     const groups = (await dbAdapter.getFeedOwnersByIds(groupIds)).filter((g) => g.isGroup());
 

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -75,6 +75,7 @@ export class DbAdapter {
     userIds: UUID[],
     timelineIds: UUID[],
   ): Promise<{ uid: UUID; is_subscribed: boolean }[]>;
+  getTimelineSubscribersIds(timelineId: UUID): Promise<UUID[]>;
   getGroupAdministratorsIds(id: UUID): Promise<UUID[]>;
   getGroupsAdministratorsIds(
     groupIds: UUID[],


### PR DESCRIPTION
When the private group info is changed, the 'global:user:update' realtime event is delivered only to the group subscribers (earlier it was sent to everyone).