### PR TITLE
Backlinks server-side support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    which this post should be deleted. If there are no 'fromFeed' parameters, the
    post will be deleted completely (by author) or from all managed groups (by
    groups admin).
+- All serialized posts now have a new numeric 'backlinksCount' field. This field
+  is the count of texts (posts or comments) that mentioned the post's UUID and
+  visible to the current user. The client should display this count as a link to
+  the search by post's UUID.
+  
+  When the post hase new or removed mention in somewhere, the 'post:update'
+  realtime message is delivered with the updated backlinksCount.
+
+  It is also recommended to re-run the search indexer (`yarn babel
+  bin/reindex_search.js`) after this changes applied. The indexing of UUIDs in
+  the plain texts (not in URLs) is slightly changed, so in rare cases the search
+  may work incorrectly. These changes are not affects the backlinks
+  functionality though.
 
 ### Changed
 - When the private group info is changed, the 'global:user:update' realtime

--- a/app/pubsub.ts
+++ b/app/pubsub.ts
@@ -1,7 +1,8 @@
 import { Comment, dbAdapter, Post } from './models';
 import { serializeTimeline } from './serializers/v2/timeline';
+import { List } from './support/open-lists';
 import { PubSubAdapter } from './support/PubSubAdapter';
-import { UUID } from './support/types';
+import { Nullable, UUID } from './support/types';
 
 export class DummyPublisher extends PubSubAdapter {
   constructor() {
@@ -10,6 +11,12 @@ export class DummyPublisher extends PubSubAdapter {
     });
   }
 }
+
+type UpdatePostOptions = {
+  rooms?: Nullable<string[]>;
+  usersBeforeIds?: Nullable<UUID[]>;
+  onlyForUsers?: List<UUID>;
+};
 
 export default class pubSub {
   constructor(private publisher: PubSubAdapter) {}
@@ -54,10 +61,13 @@ export default class pubSub {
 
   async updatePost(
     postId: UUID,
-    rooms: string[] | null = null,
-    usersBeforeIds: UUID[] | null = null,
+    {
+      rooms = null,
+      usersBeforeIds = null,
+      onlyForUsers = List.everything(),
+    }: UpdatePostOptions = {},
   ) {
-    const payload = JSON.stringify({ postId, rooms, usersBeforeIds });
+    const payload = JSON.stringify({ postId, rooms, usersBeforeIds, onlyForUsers });
     await this.publisher.postUpdated(payload);
   }
 

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -93,6 +93,7 @@ export async function serializeFeed(
     likes,
     omittedComments,
     omittedLikes,
+    backlinksCount,
   } of postsWithStuff.filter(Boolean)) {
     const sPost = {
       ...serializePostData(post),
@@ -102,6 +103,7 @@ export async function serializeFeed(
       likes,
       omittedComments,
       omittedLikes,
+      backlinksCount,
     };
 
     if (post.feedIntIds.includes(hidesFeedId)) {

--- a/app/support/DbAdapter/backlinks.js
+++ b/app/support/DbAdapter/backlinks.js
@@ -1,0 +1,94 @@
+import pgFormat from 'pg-format';
+import config from 'config';
+
+import { Comment } from '../../models';
+
+///////////////////////////////////////////////////
+// Backlinks
+///////////////////////////////////////////////////
+
+import { andJoin, sqlNotIn } from './utils';
+
+const ftsCfg = config.postgres.textSearchConfigName;
+
+const backlinksTrait = (superClass) =>
+  class extends superClass {
+    /**
+     * @param {string[]} uids
+     * @param {string|null} [viewerId]
+     */
+    async getBacklinksCounts(uids, viewerId = null) {
+      const result = new Map();
+
+      if (uids.length === 0) {
+        return result;
+      }
+
+      const [
+        // Private feeds viewer can read
+        visiblePrivateFeedIntIds,
+        // Users who banned viewer or banned by viewer (viewer should not see their posts)
+        bannedUsersIds,
+        // Users banned by viewer (for comments)
+        bannedByViewer,
+      ] = await Promise.all([
+        viewerId ? this.getVisiblePrivateFeedIntIds(viewerId) : [],
+        viewerId ? this.getUsersBansOrWasBannedBy(viewerId) : [],
+        viewerId ? await this.getUserBansIds(viewerId) : [],
+      ]);
+
+      // Additional restrictions for comments
+      const commentsRestrictionSQL = andJoin([
+        pgFormat('c.hide_type=%L', Comment.VISIBLE),
+        sqlNotIn('c.user_id', bannedByViewer),
+      ]);
+
+      const postsRestrictionsSQL = andJoin([
+        // Privacy
+        viewerId
+          ? pgFormat(
+              `(not p.is_private or p.destination_feed_ids && %L)`,
+              `{${visiblePrivateFeedIntIds.join(',')}}`,
+            )
+          : 'not p.is_protected',
+        // Bans
+        sqlNotIn('p.user_id', bannedUsersIds),
+        // Gone post's authors
+        'u.gone_status is null',
+      ]);
+
+      const withSQL = `with posts as (
+          select p.* from posts p join users u on p.user_id = u.uid 
+          where ${postsRestrictionsSQL}
+        ), uids as (select * from unnest(:uids::uuid[]) as uids (uid))`;
+
+      const [foundPosts, foundComments] = await Promise.all([
+        this.database.getAll(
+          `${withSQL}
+          select uids.uid, count(*)::int 
+          from uids, posts p
+          where p.body_tsvector @@ phraseto_tsquery(:ftsCfg, replace(uids.uid::text, '-', ' '))
+          group by uids.uid`,
+          { ftsCfg, uids },
+        ),
+        this.database.getAll(
+          `${withSQL}
+          select uids.uid, count(*)::int
+          from uids, comments c, posts p
+          where c.post_id = p.uid and
+            ${commentsRestrictionSQL} and
+            c.body_tsvector @@ phraseto_tsquery(:ftsCfg, replace(uids.uid::text, '-', ' '))
+          group by uids.uid`,
+          { ftsCfg, uids },
+        ),
+      ]);
+
+      for (const row of [...foundPosts, ...foundComments]) {
+        result.set(row.uid, (result.get(row.uid) || 0) + row.count);
+      }
+
+      return result;
+    }
+  };
+
+export default backlinksTrait;

--- a/app/support/DbAdapter/backlinks.js
+++ b/app/support/DbAdapter/backlinks.js
@@ -67,7 +67,9 @@ const backlinksTrait = (superClass) =>
           `${withSQL}
           select uids.uid, count(*)::int 
           from uids, posts p
-          where p.body_tsvector @@ phraseto_tsquery(:ftsCfg, replace(uids.uid::text, '-', ' '))
+          where
+            p.body_tsvector @@ phraseto_tsquery(:ftsCfg, replace(uids.uid::text, '-', ' ')) 
+            and p.uid <> uids.uid
           group by uids.uid`,
           { ftsCfg, uids },
         ),
@@ -75,9 +77,11 @@ const backlinksTrait = (superClass) =>
           `${withSQL}
           select uids.uid, count(*)::int
           from uids, comments c, posts p
-          where c.post_id = p.uid and
-            ${commentsRestrictionSQL} and
-            c.body_tsvector @@ phraseto_tsquery(:ftsCfg, replace(uids.uid::text, '-', ' '))
+          where
+            c.post_id = p.uid
+            and p.uid <> uids.uid
+            and ${commentsRestrictionSQL}
+            and c.body_tsvector @@ phraseto_tsquery(:ftsCfg, replace(uids.uid::text, '-', ' '))
           group by uids.uid`,
           { ftsCfg, uids },
         ),

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -164,4 +164,7 @@ export class DbAdapter {
 
   getUnreadDirectsNumber(userId: UUID): Promise<number>;
   getUnreadEventsNumber(userId: UUID): Promise<number>;
+
+  // Backlinks
+  getBacklinksCounts(uuids: UUID[], viewerId?: Nullable<UUID>): Promise<Map<UUID, number>>;
 }

--- a/app/support/DbAdapter/index.js
+++ b/app/support/DbAdapter/index.js
@@ -34,6 +34,7 @@ import { withDbHelpers } from './utils';
 import nowTrait from './now';
 import jobsTrait from './jobs';
 import authSessionsTrait from './auth-sessions';
+import backlinksTrait from './backlinks';
 
 class DbAdapterBase {
   constructor(database) {
@@ -98,4 +99,5 @@ export const DbAdapter = _.flow([
   nowTrait,
   jobsTrait,
   authSessionsTrait,
+  backlinksTrait,
 ])(DbAdapterBase);

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -448,14 +448,14 @@ const timelinesPostsTrait = (superClass) =>
       order by created_at, id
     `;
 
-      const [{ rows: likesData }, { rows: commentsData }] = await Promise.all([
-        this.database.raw(likesSQL),
-        this.database.raw(commentsSQL),
+      const [likesData, commentsData, postsCommentLikes, backlinks] = await Promise.all([
+        this.database.getAll(likesSQL),
+        this.database.getAll(commentsSQL),
+        this.getLikesInfoForPosts(uniqPostsIds, viewerId),
+        this.getBacklinksCounts(uniqPostsIds, viewerId),
       ]);
 
       const results = {};
-
-      const postsCommentLikes = await this.getLikesInfoForPosts(uniqPostsIds, viewerId);
 
       for (const post of postsData) {
         results[post.uid] = {
@@ -466,6 +466,7 @@ const timelinesPostsTrait = (superClass) =>
           omittedComments: 0,
           likes: [],
           omittedLikes: 0,
+          backlinksCount: backlinks.get(post.uid) || 0,
         };
         results[post.uid].post.commentLikes = 0;
         results[post.uid].post.ownCommentLikes = 0;

--- a/app/support/backlinks.ts
+++ b/app/support/backlinks.ts
@@ -1,0 +1,52 @@
+import { xor } from 'lodash';
+
+import { List } from './open-lists';
+import { UUID } from './types';
+
+export function getUpdatedUUIDs(text1: string, text2: string = '') {
+  if (text1 === text2) {
+    return [];
+  }
+
+  return xor(extractUUIDs(text1), extractUUIDs(text2));
+}
+
+export const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+export function extractUUIDs(text: string): UUID[] {
+  return [...text.matchAll(uuidRe)].map((m) => m[0]).filter(onlyUnique);
+}
+
+function onlyUnique<T>(value: T, index: number, arr: T[]) {
+  return arr.indexOf(value) === index;
+}
+
+interface Visible {
+  usersCanSee(): Promise<List<UUID>>;
+}
+
+interface PubSub {
+  updatePost(id: UUID, options?: { onlyForUsers: List<UUID> }): Promise<void>;
+}
+
+export async function notifyBacklinkedLater(entity: Visible, pubSub: PubSub, uuids: UUID[]) {
+  if (uuids.length === 0) {
+    return () => Promise.resolve();
+  }
+
+  const prevViewers = await entity.usersCanSee();
+  return () => notifyBacklinkedNow(entity, pubSub, uuids, prevViewers);
+}
+
+export async function notifyBacklinkedNow(
+  entity: Visible,
+  pubSub: PubSub,
+  uuids: UUID[],
+  prevViewers = List.empty() as List<UUID>,
+) {
+  const viewers = await entity.usersCanSee();
+  const onlyForUsers = List.union(prevViewers, viewers);
+  await Promise.all(
+    // Notify mentioned posts
+    uuids.map((id) => pubSub.updatePost(id, { onlyForUsers })),
+  );
+}

--- a/app/support/open-lists.ts
+++ b/app/support/open-lists.ts
@@ -99,7 +99,7 @@ export class List<T> {
     }
 
     // unreachable
-    return new List();
+    return new List<X>();
   }
 
   static intersection<X>(list1: ListLike<X>, list2: ListLike<X>) {

--- a/app/support/search/parser.ts
+++ b/app/support/search/parser.ts
@@ -1,6 +1,7 @@
 import XRegExp from 'xregexp';
 import { flow } from 'lodash';
 import config from 'config';
+import { validate as uuidValidate } from 'uuid';
 
 import { normalizeText } from './norm';
 import {
@@ -64,6 +65,15 @@ export function parseQuery(query: string, { minPrefixLength }: ParseQueryOptions
     if (groups.plus) {
       tokens.push(new Plus());
       return;
+    }
+
+    // Handle UUIDs
+    // UUID-like texts should become a space-separated phrase
+    if (!groups.qstring && uuidValidate(groups.word)) {
+      groups.qstring = JSON.stringify(groups.word.replace(/-/g, ' '));
+      delete groups.word;
+    } else if (groups.qstring && uuidValidate(groups.qstring.replace(/^"|"$/g, ''))) {
+      groups.qstring = groups.qstring.replace(/-/g, ' ');
     }
 
     // in-body: (start of scope)

--- a/app/support/search/to-tsvector.ts
+++ b/app/support/search/to-tsvector.ts
@@ -2,7 +2,7 @@ import pgFormat from 'pg-format';
 import { HashTag, Mention, Link } from 'social-text-tokenizer';
 import config from 'config';
 
-import { HTMLTag, tokenize } from '../tokenize-text';
+import { HTMLTag, tokenize, UUIDString } from '../tokenize-text';
 
 import { normalizeText, linkToText } from './norm';
 
@@ -32,6 +32,10 @@ export function toTSVector(text: string) {
 
       if (token instanceof HTMLTag) {
         return token.content && pgFormat('to_tsvector_with_exact(%L, %L)', ftsCfg, token.content);
+      }
+
+      if (token instanceof UUIDString) {
+        return pgFormat('to_tsvector_with_exact(%L, %L)', ftsCfg, token.text.replace(/-/g, ' '));
       }
 
       const trimmedText = token.text.trim();

--- a/app/support/tokenize-text.ts
+++ b/app/support/tokenize-text.ts
@@ -10,7 +10,9 @@ import {
 } from 'social-text-tokenizer';
 // The CJS version of social-text-tokenizer has not .d.ts yet, so expecting error
 // @ts-expect-error
-import byRegexp from 'social-text-tokenizer/build/cjs/lib/byRegexp';
+import byRegexp, { makeToken } from 'social-text-tokenizer/build/cjs/lib/byRegexp';
+
+import { uuidRe } from './backlinks';
 
 export class HTMLTag extends Token {
   public closing = false;
@@ -24,6 +26,10 @@ const htmlTags = byRegexp(/<(\/)?(.+?)>/g, (offset: number, text: string, m: Reg
   return t;
 });
 
+export class UUIDString extends Token {}
+
+const uuidStrings = byRegexp(uuidRe, makeToken(UUIDString));
+
 export const tokenize = withText(
   combine(
     hashTags(),
@@ -32,5 +38,6 @@ export const tokenize = withText(
     links({ tldList: ['рф', 'com', 'net', 'org', 'edu', 'place'] }),
     arrows(),
     htmlTags,
+    uuidStrings,
   ),
 );

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "typescript": "~4.3.5",
     "unexpected": "~12.0.3",
     "unexpected-date": "~2.0.0",
+    "unexpected-map": "~3.1.0",
     "unexpected-moment": "~3.3.0",
     "unexpected-sinon": "~11.0.1",
     "xml-parser": "~1.2.1"

--- a/test/functional/backlinks.js
+++ b/test/functional/backlinks.js
@@ -1,0 +1,67 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../dbCleaner';
+
+import {
+  authHeaders,
+  // authHeaders,
+  createAndReturnPost,
+  createTestUsers,
+  goPrivate,
+  goPublic,
+  // goPrivate,
+  // goPublic,
+  performJSONRequest,
+} from './functional_test_helper';
+
+describe('Backlinks', () => {
+  let luna, mars;
+  let lunaPostId;
+
+  before(async () => {});
+
+  before(async () => {
+    await cleanDB($pg_database);
+    [luna, mars] = await createTestUsers(['luna', 'mars']);
+
+    ({ id: lunaPostId } = await createAndReturnPost(luna, 'Luna post'));
+    await createAndReturnPost(mars, `As Luna said, ${lunaPostId}`);
+  });
+
+  it(`should return Luna post with 1 backlink`, async () => {
+    const resp = await performJSONRequest('GET', `/v2/posts/${lunaPostId}`);
+    expect(resp, 'to satisfy', { posts: { backlinksCount: 1 } });
+  });
+
+  describe('Mars becomes private', () => {
+    before(() => goPrivate(mars));
+    after(() => goPublic(mars));
+
+    it(`should return Luna post with 0 backlinks to anonymous`, async () => {
+      const resp = await performJSONRequest('GET', `/v2/posts/${lunaPostId}`);
+      expect(resp, 'to satisfy', { posts: { backlinksCount: 0 } });
+    });
+
+    it(`should return Luna post with 0 backlinks to Luna`, async () => {
+      const resp = await performJSONRequest(
+        'GET',
+        `/v2/posts/${lunaPostId}`,
+        null,
+        authHeaders(luna),
+      );
+      expect(resp, 'to satisfy', { posts: { backlinksCount: 0 } });
+    });
+
+    it(`should return Luna post with 1 backlink to Mars`, async () => {
+      const resp = await performJSONRequest(
+        'GET',
+        `/v2/posts/${lunaPostId}`,
+        null,
+        authHeaders(mars),
+      );
+      expect(resp, 'to satisfy', { posts: { backlinksCount: 1 } });
+    });
+  });
+});

--- a/test/functional/backlinks.js
+++ b/test/functional/backlinks.js
@@ -1,33 +1,37 @@
 /* eslint-env node, mocha */
-/* global $pg_database */
+/* global $database, $pg_database */
 import expect from 'unexpected';
 
 import cleanDB from '../dbCleaner';
+import { getSingleton } from '../../app/app';
+import { PubSub } from '../../app/models';
+import { PubSubAdapter } from '../../app/support/PubSubAdapter';
 
 import {
   authHeaders,
-  // authHeaders,
   createAndReturnPost,
+  createCommentAsync,
   createTestUsers,
+  deletePostAsync,
   goPrivate,
   goPublic,
-  // goPrivate,
-  // goPublic,
   performJSONRequest,
+  removeCommentAsync,
+  updateCommentAsync,
+  updatePostAsync,
 } from './functional_test_helper';
+import Session from './realtime-session';
 
-describe('Backlinks', () => {
+describe('Backlinks in API output', () => {
   let luna, mars;
   let lunaPostId;
-
-  before(async () => {});
 
   before(async () => {
     await cleanDB($pg_database);
     [luna, mars] = await createTestUsers(['luna', 'mars']);
 
     ({ id: lunaPostId } = await createAndReturnPost(luna, 'Luna post'));
-    await createAndReturnPost(mars, `As Luna said, ${lunaPostId}`);
+    await createAndReturnPost(mars, `As Luna said, example.com/${lunaPostId}`);
   });
 
   it(`should return Luna post with 1 backlink`, async () => {
@@ -62,6 +66,243 @@ describe('Backlinks', () => {
         authHeaders(mars),
       );
       expect(resp, 'to satisfy', { posts: { backlinksCount: 1 } });
+    });
+  });
+});
+
+describe('Backlinks in realtime', () => {
+  let luna, mars;
+  let lunaSession;
+
+  before(async () => {
+    await cleanDB($pg_database);
+    const app = await getSingleton();
+    const port = process.env.PEPYATKA_SERVER_PORT || app.context.config.port;
+    const pubsubAdapter = new PubSubAdapter($database);
+    PubSub.setPublisher(pubsubAdapter);
+
+    [luna, mars] = await createTestUsers(['luna', 'mars']);
+    lunaSession = await Session.create(port, 'Luna session');
+    await lunaSession.sendAsync('auth', { authToken: luna.authToken });
+
+    // Luna subscribed to her timeline
+    const lunaTimeline = await luna.user.getPostsTimeline();
+    await lunaSession.sendAsync('subscribe', { timeline: [lunaTimeline.id] });
+
+    // Luna created post
+    luna.post = await createAndReturnPost(luna, 'Luna post');
+  });
+
+  describe('Mars is public', () => {
+    it(`should deliver 'post:update' to the Luna when Mars creates post with her post ID`, async () => {
+      const test = lunaSession.receiveWhile(
+        'post:update',
+        async () =>
+          (mars.post = await createAndReturnPost(
+            mars,
+            `As Luna said, example.com/${luna.post.id}`,
+          )),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 1 },
+      });
+    });
+
+    it(`should not deliver 'post:update' to the Luna when Mars updates post keeping her post ID`, async () => {
+      const test = lunaSession.notReceiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
+      );
+      await expect(test, 'to be fulfilled');
+    });
+
+    it(`should deliver 'post:update' to the Luna when Mars updates post and removes her post ID`, async () => {
+      const test = lunaSession.receiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, hmm...` }),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 0 },
+      });
+    });
+
+    it(`should deliver 'post:update' to the Luna when Mars updates post and returns her post ID`, async () => {
+      const test = lunaSession.receiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 1 },
+      });
+    });
+
+    it(`should deliver 'post:update' to the Luna when Mars removes post with her post ID`, async () => {
+      const test = lunaSession.receiveWhile('post:update', () =>
+        deletePostAsync(mars, mars.post.id),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 0 },
+      });
+    });
+  });
+
+  describe('Mars is private', () => {
+    before(() => goPrivate(mars));
+    after(() => goPublic(mars));
+
+    it(`should not deliver 'post:update' to the Luna when Mars creates post with her post ID`, async () => {
+      const test = lunaSession.notReceiveWhile(
+        'post:update',
+        async () =>
+          (mars.post = await createAndReturnPost(
+            mars,
+            `As Luna said, example.com/${luna.post.id}`,
+          )),
+      );
+      await expect(test, 'to be fulfilled');
+    });
+
+    it(`should not deliver 'post:update' to the Luna when Mars updates post keeping her post ID`, async () => {
+      const test = lunaSession.notReceiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
+      );
+      await expect(test, 'to be fulfilled');
+    });
+
+    it(`should not deliver 'post:update' to the Luna when Mars updates post and removes her post ID`, async () => {
+      const test = lunaSession.notReceiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, hmm...` }),
+      );
+      await expect(test, 'to be fulfilled');
+    });
+
+    it(`should not deliver 'post:update' to the Luna when Mars updates post and returns her post ID`, async () => {
+      const test = lunaSession.notReceiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
+      );
+      await expect(test, 'to be fulfilled');
+    });
+
+    it(`should not deliver 'post:update' to the Luna when Mars removes post with her post ID`, async () => {
+      const test = lunaSession.notReceiveWhile('post:update', () =>
+        deletePostAsync(mars, mars.post.id),
+      );
+      await expect(test, 'to be fulfilled');
+    });
+  });
+
+  describe('Backlinks in comments', () => {
+    before(async () => (mars.post = await createAndReturnPost(mars, `Just a post`)));
+    after(() => deletePostAsync(mars, mars.post.id));
+
+    describe('Mars is public', () => {
+      it(`should deliver 'post:update' to the Luna when Mars creates comment with her post ID`, async () => {
+        const test = lunaSession.receiveWhile(
+          'post:update',
+          async () =>
+            ({ comments: mars.comment } = await createCommentAsync(
+              mars,
+              mars.post.id,
+              `As Luna said, example.com/${luna.post.id}`,
+            ).then((r) => r.json())),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 1 },
+        });
+      });
+
+      it(`should not deliver 'post:update' to the Luna when Mars updates comment keeping her post ID`, async () => {
+        const test = lunaSession.notReceiveWhile('post:update', () =>
+          updateCommentAsync(
+            mars,
+            mars.comment.id,
+            `As Luna said, again, example.com/${luna.post.id}`,
+          ),
+        );
+        await expect(test, 'to be fulfilled');
+      });
+
+      it(`should deliver 'post:update' to the Luna when Mars updates comment and removes her post ID`, async () => {
+        const test = lunaSession.receiveWhile('post:update', () =>
+          updateCommentAsync(mars, mars.comment.id, `As Luna said, hmm...`),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 0 },
+        });
+      });
+
+      it(`should deliver 'post:update' to the Luna when Mars updates comment and returns her post ID`, async () => {
+        const test = lunaSession.receiveWhile('post:update', () =>
+          updateCommentAsync(
+            mars,
+            mars.comment.id,
+            `As Luna said, again, example.com/${luna.post.id}`,
+          ),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 1 },
+        });
+      });
+
+      it(`should deliver 'post:update' to the Luna when Mars removes comment with her post ID`, async () => {
+        const test = lunaSession.receiveWhile('post:update', () =>
+          removeCommentAsync(mars, mars.comment.id),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 0 },
+        });
+      });
+    });
+
+    describe('Mars is private', () => {
+      before(() => goPrivate(mars));
+      after(() => goPublic(mars));
+
+      it(`should not deliver 'post:update' to the Luna when Mars creates comment with her post ID`, async () => {
+        const test = lunaSession.notReceiveWhile(
+          'post:update',
+          async () =>
+            ({ comments: mars.comment } = await createCommentAsync(
+              mars,
+              mars.post.id,
+              `As Luna said, example.com/${luna.post.id}`,
+            ).then((r) => r.json())),
+        );
+        await expect(test, 'to be fulfilled');
+      });
+
+      it(`should not deliver 'post:update' to the Luna when Mars updates comment keeping her post ID`, async () => {
+        const test = lunaSession.notReceiveWhile('post:update', () =>
+          updateCommentAsync(
+            mars,
+            mars.comment.id,
+            `As Luna said, again, example.com/${luna.post.id}`,
+          ),
+        );
+        await expect(test, 'to be fulfilled');
+      });
+
+      it(`should not deliver 'post:update' to the Luna when Mars updates comment and removes her post ID`, async () => {
+        const test = lunaSession.notReceiveWhile('post:update', () =>
+          updateCommentAsync(mars, mars.comment.id, `As Luna said, hmm...`),
+        );
+        await expect(test, 'to be fulfilled');
+      });
+
+      it(`should not deliver 'post:update' to the Luna when Mars updates comment and returns her post ID`, async () => {
+        const test = lunaSession.notReceiveWhile('post:update', () =>
+          updateCommentAsync(
+            mars,
+            mars.comment.id,
+            `As Luna said, again, example.com/${luna.post.id}`,
+          ),
+        );
+        await expect(test, 'to be fulfilled');
+      });
+
+      it(`should not deliver 'post:update' to the Luna when Mars removes comment with her post ID`, async () => {
+        const test = lunaSession.notReceiveWhile('post:update', () =>
+          removeCommentAsync(mars, mars.comment.id),
+        );
+        await expect(test, 'to be fulfilled');
+      });
     });
   });
 });

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -206,6 +206,7 @@ const postBasic = {
   ownCommentLikes: expect.it('to be a number'),
   omittedCommentLikes: expect.it('to be a number'),
   omittedOwnCommentLikes: expect.it('to be a number'),
+  backlinksCount: expect.it('to be a number'),
 };
 
 const commentBasic = {

--- a/test/integration/support/DbAdapter/backlinks.js
+++ b/test/integration/support/DbAdapter/backlinks.js
@@ -216,7 +216,7 @@ describe('Backlinks DB trait', () => {
     });
   });
 
-  describe('Mars suspends theirself', () => {
+  describe('Mars suspends themselves', () => {
     before(() => mars.setGoneStatus(GONE_SUSPENDED));
     after(() => mars.setGoneStatus(null));
 

--- a/test/integration/support/DbAdapter/backlinks.js
+++ b/test/integration/support/DbAdapter/backlinks.js
@@ -232,4 +232,14 @@ describe('Backlinks DB trait', () => {
       );
     });
   });
+
+  describe('Link to the post itself', () => {
+    before(() => lunaPost.update({ body: `this post has address example.com/${lunaPost.id}` }));
+    after(() => lunaPost.update({ body: 'just a post' }));
+
+    it(`should not count self-link to the Luna post`, async () => {
+      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
+      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+    });
+  });
 });

--- a/test/integration/support/DbAdapter/backlinks.js
+++ b/test/integration/support/DbAdapter/backlinks.js
@@ -1,0 +1,235 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import unexpected from 'unexpected';
+import unexpectedMap from 'unexpected-map';
+
+import { dbAdapter, Post, User } from '../../../../app/models';
+import { GONE_SUSPENDED } from '../../../../app/models/user';
+import cleanDB from '../../../dbCleaner';
+
+const expect = unexpected.clone().use(unexpectedMap);
+
+describe('Backlinks DB trait', () => {
+  let luna, mars, venus, jupiter;
+  let lunaFeed, marsFeed, venusFeed;
+  let lunaPost, marsPost, venusPost;
+  before(async () => {
+    await cleanDB($pg_database);
+
+    luna = new User({ username: 'luna', password: 'pw' });
+    mars = new User({ username: 'mars', password: 'pw' });
+    venus = new User({ username: 'venus', password: 'pw' });
+    jupiter = new User({ username: 'jupiter', password: 'pw' });
+    await Promise.all([luna.create(), mars.create(), venus.create(), jupiter.create()]);
+
+    [lunaFeed, marsFeed, venusFeed] = await Promise.all([
+      luna.getPostsTimeline(),
+      mars.getPostsTimeline(),
+      venus.getPostsTimeline(),
+    ]);
+
+    // Luna post has 2 backlinks: from the Mars and Venus posts
+    // Mars post has 1 backlinks: from the Venus post
+    // Venus post has 1 backlinks: from the Jupiter comment to the Mars post
+
+    lunaPost = new Post({
+      body: `just a post`,
+      userId: luna.id,
+      timelineIds: [lunaFeed.id],
+    });
+    await lunaPost.create();
+
+    marsPost = new Post({
+      body: `luna post: example.com/${lunaPost.id}`,
+      userId: mars.id,
+      timelineIds: [marsFeed.id],
+    });
+    await marsPost.create();
+
+    venusPost = new Post({
+      body: `luna post: example.com/${lunaPost.id}, mars post: example.com/${marsPost.id}`,
+      userId: venus.id,
+      timelineIds: [venusFeed.id],
+    });
+    await venusPost.create();
+
+    await jupiter
+      .newComment({ postId: marsPost.id, body: `venus post: example.com/${venusPost.id}` })
+      .create();
+  });
+
+  it(`should calculate backlink counts for Luna, Mars and Venus posts`, async () => {
+    const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+    expect(
+      result,
+      'to equal',
+      new Map([
+        [lunaPost.id, 2],
+        [marsPost.id, 1],
+        [venusPost.id, 1],
+      ]),
+    );
+  });
+
+  describe('Venus becomes protected', () => {
+    before(() => venus.update({ isProtected: '1', isPrivate: '0' }));
+    after(() => venus.update({ isProtected: '0', isPrivate: '0' }));
+
+    it(`should not count Venus post for anonymous`, async () => {
+      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 1],
+          [venusPost.id, 1],
+        ]),
+      );
+    });
+
+    it(`should count Venus post for Luna`, async () => {
+      const result = await dbAdapter.getBacklinksCounts(
+        [lunaPost.id, marsPost.id, venusPost.id],
+        luna.id,
+      );
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 2],
+          [marsPost.id, 1],
+          [venusPost.id, 1],
+        ]),
+      );
+    });
+  });
+
+  describe('Venus becomes private', () => {
+    before(() => venus.update({ isProtected: '1', isPrivate: '1' }));
+    after(() => venus.update({ isProtected: '0', isPrivate: '0' }));
+
+    it(`should not count Venus post for anonymous`, async () => {
+      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 1],
+          [venusPost.id, 1],
+        ]),
+      );
+    });
+
+    it(`should not count Venus post for Luna`, async () => {
+      const result = await dbAdapter.getBacklinksCounts(
+        [lunaPost.id, marsPost.id, venusPost.id],
+        luna.id,
+      );
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 1],
+          [venusPost.id, 1],
+        ]),
+      );
+    });
+
+    it(`should count Venus post for Venus`, async () => {
+      const result = await dbAdapter.getBacklinksCounts(
+        [lunaPost.id, marsPost.id, venusPost.id],
+        venus.id,
+      );
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 2],
+          [marsPost.id, 1],
+          [venusPost.id, 1],
+        ]),
+      );
+    });
+  });
+
+  describe('Mars bans Jupiter', () => {
+    before(() => mars.ban(jupiter.username));
+    after(() => mars.unban(jupiter.username));
+
+    it(`should count Jupiter comment for anonymous`, async () => {
+      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 2],
+          [marsPost.id, 1],
+          [venusPost.id, 1],
+        ]),
+      );
+    });
+
+    it(`should count Jupiter comment for Venus`, async () => {
+      const result = await dbAdapter.getBacklinksCounts(
+        [lunaPost.id, marsPost.id, venusPost.id],
+        venus.id,
+      );
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 2],
+          [marsPost.id, 1],
+          [venusPost.id, 1],
+        ]),
+      );
+    });
+
+    it(`should not count Jupiter comment for Mars`, async () => {
+      const result = await dbAdapter.getBacklinksCounts(
+        [lunaPost.id, marsPost.id, venusPost.id],
+        mars.id,
+      );
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 2],
+          [marsPost.id, 1],
+        ]),
+      );
+    });
+
+    it(`should not count Mars post for Jupiter`, async () => {
+      const result = await dbAdapter.getBacklinksCounts(
+        [lunaPost.id, marsPost.id, venusPost.id],
+        jupiter.id,
+      );
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 1],
+          [marsPost.id, 1],
+        ]),
+      );
+    });
+  });
+
+  describe('Mars suspends theirself', () => {
+    before(() => mars.setGoneStatus(GONE_SUSPENDED));
+    after(() => mars.setGoneStatus(null));
+
+    it(`should not count Mars post for anonymous`, async () => {
+      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      expect(
+        result,
+        'to equal',
+        new Map([
+          [lunaPost.id, 1],
+          [marsPost.id, 1],
+        ]),
+      );
+    });
+  });
+});

--- a/test/unit/support/backlinks.ts
+++ b/test/unit/support/backlinks.ts
@@ -1,0 +1,97 @@
+/* eslint-env node, mocha */
+import expect from 'unexpected';
+
+import {
+  extractUUIDs,
+  notifyBacklinkedLater,
+  notifyBacklinkedNow,
+} from '../../../app/support/backlinks';
+import { List } from '../../../app/support/open-lists';
+import { UUID } from '../../../app/support/types';
+
+describe('Backlinks parser', () => {
+  describe('extractUUIDs', () => {
+    const cases = [
+      { text: 'abc', result: [] },
+      {
+        text: 'abc 21612a6d-dbfc-4ff1-9c0b-d41502ad3e62',
+        result: ['21612a6d-dbfc-4ff1-9c0b-d41502ad3e62'],
+      },
+      {
+        text: 'abc 21612a6d-dbfc-4ff1-9c0b-d41502ad3e62 21612a6d-dbfc-4ff1-9c0b-d41502ad3e62',
+        result: ['21612a6d-dbfc-4ff1-9c0b-d41502ad3e62'],
+      },
+      {
+        text: 'abc 21612a6d-dbfc-4ff1-9c0b-d41502ad3e62 21612a6d-dbfc-4ff1-9c0b-d41502ad3e63',
+        // ________________________________________________________________________________^
+        result: ['21612a6d-dbfc-4ff1-9c0b-d41502ad3e62', '21612a6d-dbfc-4ff1-9c0b-d41502ad3e63'],
+      },
+      {
+        text: 'abc 21612a6d-dbfc-4ff1-9c0b-d41502ad3e62 21612a6d-dbfc-0ff1-9c0b-d41502ad3e63',
+        // ___________________________________________________________^ (invalid UUID)
+        result: ['21612a6d-dbfc-4ff1-9c0b-d41502ad3e62'],
+      },
+    ];
+
+    cases.forEach(({ text, result }) => {
+      it(`should extract ${result.length} UUID(s) from "${text}"`, () => {
+        expect(extractUUIDs(text), 'to equal', result);
+      });
+    });
+  });
+});
+
+describe('Backlinks notifier', () => {
+  const pubSubCalls = [] as { id: UUID; options?: { onlyForUsers: List<UUID> } }[];
+  const pubSub = {
+    updatePost(id: UUID, options?: { onlyForUsers: List<UUID> }) {
+      pubSubCalls.push({ id, options });
+      return Promise.resolve();
+    },
+  };
+
+  const visible = (...byWhoms: List<UUID>[]) => {
+    let idx = 0;
+    return {
+      usersCanSee: () => Promise.resolve(byWhoms[idx++ % byWhoms.length]),
+    };
+  };
+
+  beforeEach(() => (pubSubCalls.length = 0));
+
+  it(`should notify posts now`, async () => {
+    const ids = ['a', 'b', 'c'];
+    const scope = List.from(['d', 'e', 'f']);
+    await notifyBacklinkedNow(visible(scope), pubSub, ids);
+    expect(pubSubCalls, 'to have length', 3);
+
+    for (const id of ids) {
+      expect(pubSubCalls, 'to have an item satisfying', {
+        id,
+        options: { onlyForUsers: scope },
+      });
+    }
+  });
+
+  it(`should notify posts later`, async () => {
+    const ids = ['a', 'b', 'c'];
+    const scopeBefore = List.from(['d', 'e', 'f']);
+    const scopeAfter = List.from(['e', 'f', 'g']);
+    const scopeTotal = List.union(scopeBefore, scopeAfter);
+
+    const notifyBacklinked = await notifyBacklinkedLater(
+      visible(scopeBefore, scopeAfter),
+      pubSub,
+      ids,
+    );
+    await notifyBacklinked();
+    expect(pubSubCalls, 'to have length', 3);
+
+    for (const id of ids) {
+      expect(pubSubCalls, 'to have an item satisfying', {
+        id,
+        options: { onlyForUsers: scopeTotal },
+      });
+    }
+  });
+});

--- a/test/unit/support/search/parser.ts
+++ b/test/unit/support/search/parser.ts
@@ -116,6 +116,35 @@ describe('search:parseQuery', () => {
         ),
       ],
     },
+    // UUIDs
+    {
+      query: 'a b 123e4567-e89b-12d3-a456-426614174000',
+      comment: 'UUID should become exact phrase',
+      result: [
+        seqTexts(new Text(false, false, 'a')),
+        seqTexts(new Text(false, false, 'b')),
+        seqTexts(new Text(false, true, '123e4567 e89b 12d3 a456 426614174000')),
+      ],
+    },
+    {
+      query: 'a b "123e4567-e89b-12d3-a456-426614174000"',
+      comment: 'UUID should become exact phrase',
+      result: [
+        seqTexts(new Text(false, false, 'a')),
+        seqTexts(new Text(false, false, 'b')),
+        seqTexts(new Text(false, true, '123e4567 e89b 12d3 a456 426614174000')),
+      ],
+    },
+    {
+      query: 'inbody:123e4567-e89b-12d3-a456-426614174000',
+      comment: 'UUID should become exact phrase',
+      result: [
+        new InScope(
+          IN_POSTS,
+          anyText(new Text(false, true, '123e4567 e89b 12d3 a456 426614174000')),
+        ),
+      ],
+    },
   ];
 
   for (const { query, comment, result } of testData) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,6 +4737,7 @@ __metadata:
     typescript: ~4.3.5
     unexpected: ~12.0.3
     unexpected-date: ~2.0.0
+    unexpected-map: ~3.1.0
     unexpected-moment: ~3.3.0
     unexpected-sinon: ~11.0.1
     url: 0.11.0
@@ -10891,6 +10892,15 @@ typescript@~4.3.5:
   peerDependencies:
     unexpected: ">=10.32.0"
   checksum: e32b9395c1d759d6c9be9d5d864f58579f7f725d1dae05f07ecfb8af54808b241e8f9648dae3a20b6c17f58946a565bbd07d5ad092ee142f89dce24e642328b6
+  languageName: node
+  linkType: hard
+
+"unexpected-map@npm:~3.1.0":
+  version: 3.1.0
+  resolution: "unexpected-map@npm:3.1.0"
+  peerDependencies:
+    unexpected: ^10.40.2 || ^11.0.0 || ^12.0.0
+  checksum: deb264a0953fc5c44b70a1def905000fd25cd119169cd8b287df43ad1a0b720ec683c77418b7151553f06ea94694df9047f5e6eea51d15dc5c81f30067bdc40d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
All serialized posts now have a new numeric 'backlinksCount' field. This field is the count of texts (posts or comments) that mentioned the post's UUID and visible to the current user. The client should display this count as a link to the search by post's UUID.

When the post has new or removed mention in somewhere, the 'post:update' realtime message is delivered with the updated backlinksCount.

It is also recommended to re-run the search indexer (`yarn babel bin/reindex_search.js`) after this changes applied. The indexing of UUIDs in the plain texts (not in URLs) is slightly changed, so in rare cases the search may work incorrectly. These changes are not affects the backlinks functionality, though.