### PR TITLE
Short links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.14.0] - Not released
+### Added
+- Short Links for posts and comments in FreeFeed texts: e.g. `/user/4a39b8`
+  (a linked post) or `/groupname/f482e5#ad2b` (a linked comment).
+
+  A short link consists of `/` followed by username/groupname, and another `/`
+  followed by `post_short_id`. There's also an optional part in the end 
+  consisting of `#` and `comment_short_id`. Short IDs are hexadecimal strings, 
+  6 to 10 chars long (post_short_id), or 4 to 6 chars long (comment_short_id).
+
+  FreeFeed clients will be expected to parse these in texts and make them 
+  clickable hyperlinks where it makes sense. Server-side support includes:
+
+  - Generating short IDs for posts and comments, storing them in the DB
+  - Exposing new property `shortId` for post and comment objects in all
+    relevant API responses
+  - Allowing using post's short ID in the "get single post" API request
+    (`GET /v2/posts/:postId`)
+  - Necessary changes in Backlinks and Notifications to enable the short links
+    support
+  - An admin script for backfilling short IDs for existing FreeFeed instances
 
 ## [2.13.2] - 2023-08-03
 ### Fixed

--- a/app/controllers/api/v2/PostsController.js
+++ b/app/controllers/api/v2/PostsController.js
@@ -15,7 +15,7 @@ import { ForbiddenException } from '../../../support/exceptions';
 import { getPostsByIdsInputSchema } from './data-schemes/posts';
 
 export const show = compose([
-  postAccessRequired(),
+  postAccessRequired(true),
   monitored('posts.show-v2'),
   async (ctx) => {
     const { user: viewer, post } = ctx.state;

--- a/app/controllers/middlewares/post-access-required.js
+++ b/app/controllers/middlewares/post-access-required.js
@@ -5,41 +5,38 @@ import {
 } from '../../support/exceptions';
 import { dbAdapter } from '../../models';
 
-export function postAccessRequired(map = { postId: 'post' }) {
+export function postAccessRequired() {
   return async (ctx, next) => {
     const forbidden = (reason = 'You can not see this post') => new ForbiddenException(reason);
     const notFound = (reason = 'Post not found') => new NotFoundException(reason);
+
     const { user: viewer } = ctx.state;
+    const { postId } = ctx.params;
 
-    await Promise.all(
-      Object.keys(map).map(async (key) => {
-        if (!ctx.params[key]) {
-          throw new ServerErrorException(
-            `Server misconfiguration: the required parameter '${key}' is missing`,
-          );
-        }
+    if (!postId) {
+      throw new ServerErrorException(
+        `Server misconfiguration: the required parameter 'postId' is missing`,
+      );
+    }
 
-        const { [key]: postId } = ctx.params;
-        const post = await dbAdapter.getPostById(postId);
-        const author = post ? await dbAdapter.getUserById(post.userId) : null;
+    const post = await dbAdapter.getPostById(postId);
+    const author = post ? await dbAdapter.getUserById(post.userId) : null;
 
-        if (!post || !author.isActive) {
-          throw notFound();
-        }
+    if (!post || !author.isActive) {
+      throw notFound();
+    }
 
-        const isVisible = await post.isVisibleFor(viewer);
+    const isVisible = await post.isVisibleFor(viewer);
 
-        if (!isVisible) {
-          if (!viewer && post.isProtected === '1' && post.isPrivate === '0') {
-            throw forbidden('Please sign in to view this post');
-          }
+    if (!isVisible) {
+      if (!viewer && post.isProtected === '1' && post.isPrivate === '0') {
+        throw forbidden('Please sign in to view this post');
+      }
 
-          throw forbidden();
-        }
+      throw forbidden();
+    }
 
-        ctx.state[map[key]] = post;
-      }),
-    );
+    ctx.state.post = post;
 
     await next();
   };

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -66,6 +66,11 @@ export function addModel(dbAdapter) {
       }
     }
 
+    get shortId() {
+      // Two chars of UUID + hex-encoded seqNumber
+      return this.id.slice(0, 2) + this.seqNumber.toString(16);
+    }
+
     get body() {
       return this.body_;
     }

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -25,6 +25,7 @@ export function addModel(dbAdapter) {
 
     id;
     intId;
+    shortId;
     body_;
     userId;
     postId;
@@ -51,6 +52,7 @@ export function addModel(dbAdapter) {
     constructor(params) {
       this.id = params.id;
       this.intId = params.intId;
+      this.shortId = params.shortId;
       this.body = params.body;
       this.userId = params.userId;
       this.postId = params.postId;
@@ -64,11 +66,6 @@ export function addModel(dbAdapter) {
       if (parseInt(params.updatedAt, 10)) {
         this.updatedAt = params.updatedAt;
       }
-    }
-
-    get shortId() {
-      // Two chars of UUID + hex-encoded seqNumber
-      return this.id.slice(0, 2) + this.seqNumber.toString(16);
     }
 
     get body() {
@@ -116,7 +113,7 @@ export function addModel(dbAdapter) {
 
       this.id = await dbAdapter.createComment(payload);
       const newComment = await dbAdapter.getCommentById(this.id);
-      const fieldsToUpdate = ['intId', 'createdAt', 'updatedAt', 'seqNumber'];
+      const fieldsToUpdate = ['intId', 'shortId', 'createdAt', 'updatedAt', 'seqNumber'];
 
       for (const f of fieldsToUpdate) {
         this[f] = newComment[f];

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -29,6 +29,7 @@ export function addModel(dbAdapter) {
   class Post {
     id;
     intId;
+    shortId;
     attachments;
     userId;
     timelineIds;
@@ -46,6 +47,7 @@ export function addModel(dbAdapter) {
     constructor(params) {
       this.id = params.id;
       this.intId = params.intId;
+      this.shortId = params.shortId;
       this.body = params.body;
       this.attachments = params.attachments || [];
       this.userId = params.userId;
@@ -59,10 +61,6 @@ export function addModel(dbAdapter) {
       this.isPrivate = params.isPrivate || '0';
       this.isProtected = params.isProtected || '0';
       this.isPropagable = params.isPropagable || '0';
-
-      if (params.shortId) {
-        this.shortId = params.shortId;
-      }
 
       if (params.friendfeedUrl) {
         this.friendfeedUrl = params.friendfeedUrl;

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -325,6 +325,10 @@ export function addModel(dbAdapter) {
       ]);
     }
 
+    getShortId() {
+      return dbAdapter.getPostShortId(this.id);
+    }
+
     getCreatedBy() {
       return dbAdapter.getUserById(this.userId);
     }

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -60,6 +60,10 @@ export function addModel(dbAdapter) {
       this.isProtected = params.isProtected || '0';
       this.isPropagable = params.isPropagable || '0';
 
+      if (params.shortId) {
+        this.shortId = params.shortId;
+      }
+
       if (params.friendfeedUrl) {
         this.friendfeedUrl = params.friendfeedUrl;
       }

--- a/app/serializers/v2/comment.js
+++ b/app/serializers/v2/comment.js
@@ -31,7 +31,16 @@ export async function serializeCommentsFull(comments, viewerId) {
 
   const sComments = comments.map((comment) => {
     const ser = {
-      ...pick(comment, ['id', 'body', 'createdAt', 'updatedAt', 'seqNumber', 'postId', 'hideType']),
+      ...pick(comment, [
+        'id',
+        'shortId',
+        'body',
+        'createdAt',
+        'updatedAt',
+        'seqNumber',
+        'postId',
+        'hideType',
+      ]),
       createdBy: comment.userId,
     };
 

--- a/app/serializers/v2/comment.js
+++ b/app/serializers/v2/comment.js
@@ -6,7 +6,7 @@ import { serializeUsersByIds } from './user';
 
 export async function serializeComment(comment, viewerId) {
   const comments = {
-    ...pick(comment, ['id', 'body', 'createdAt', 'seqNumber']),
+    ...pick(comment, ['id', 'shortId', 'body', 'createdAt', 'seqNumber']),
     createdBy: comment.userId,
   };
 

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -9,6 +9,7 @@ export function serializeComment(comment) {
   return {
     ...pick(comment, [
       'id',
+      'shortId',
       'body',
       'createdAt',
       'updatedAt',

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -216,6 +216,7 @@ function serializePostData(post) {
   return {
     ...pick(post, [
       'id',
+      'shortId',
       'body',
       'commentsDisabled',
       'createdAt',

--- a/app/support/DbAdapter/backlinks.js
+++ b/app/support/DbAdapter/backlinks.js
@@ -54,7 +54,7 @@ const backlinksTrait = (superClass) =>
 
     async updateBacklinks(text, refPostUID, refCommentUID = null, db = this.database) {
       const uuids = await db.getCol(
-        `select long_id from post_short_ids where long_id = any(?) or short_id = any(?)`,
+        `SELECT long_id FROM post_short_ids WHERE long_id = ANY(?) OR (short_id = ANY(?) AND long_id IS NOT NULL)`,
         [extractUUIDs(text), extractShortIds(text)],
       );
 

--- a/app/support/DbAdapter/backlinks.js
+++ b/app/support/DbAdapter/backlinks.js
@@ -1,5 +1,5 @@
 import { Comment } from '../../models';
-import { extractUUIDs } from '../backlinks';
+import { extractShortIds, extractUUIDs } from '../backlinks';
 
 ///////////////////////////////////////////////////
 // Backlinks
@@ -53,9 +53,10 @@ const backlinksTrait = (superClass) =>
     }
 
     async updateBacklinks(text, refPostUID, refCommentUID = null, db = this.database) {
-      const uuids = await db.getCol(`select uid from posts where uid = any(?)`, [
-        extractUUIDs(text),
-      ]);
+      const uuids = await db.getCol(
+        `select long_id from post_short_ids where long_id = any(?) or short_id = any(?)`,
+        [extractUUIDs(text), extractShortIds(text)],
+      );
 
       // Remove the old backlinks
       if (refCommentUID) {

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -183,6 +183,7 @@ export class DbAdapter {
   disableBansInGroup(userId: UUID, groupId: UUID, doDisable: boolean): Promise<boolean>;
 
   // Posts
+  getPostShortId(longId: UUID): string | null;
   getPostLongId(shortId: string): UUID | null;
   getPostById(id: UUID): Promise<Post | null>;
   getAdminsOfPostGroups(postId: UUID): Promise<User[]>;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -197,6 +197,7 @@ export class DbAdapter {
   unlikePost(postId: UUID, userId: UUID): Promise<boolean>;
 
   // Comments
+  getCommentLongIds(shortIds: string[]): Promise<UUID[]>;
   getCommentById(id: UUID): Promise<Comment | null>;
   getCommentsByIds(ids: UUID[]): Promise<Comment[]>;
   getCommentsByIntIds(ids: number[]): Promise<Comment[]>;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -183,6 +183,7 @@ export class DbAdapter {
   disableBansInGroup(userId: UUID, groupId: UUID, doDisable: boolean): Promise<boolean>;
 
   // Posts
+  getPostLongId(shortId: string): UUID | null;
   getPostById(id: UUID): Promise<Post | null>;
   getAdminsOfPostGroups(postId: UUID): Promise<User[]>;
   getPostsByIds(ids: UUID[]): Promise<Post[]>;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -183,8 +183,9 @@ export class DbAdapter {
   disableBansInGroup(userId: UUID, groupId: UUID, doDisable: boolean): Promise<boolean>;
 
   // Posts
-  getPostShortId(longId: UUID): string | null;
-  getPostLongId(shortId: string): UUID | null;
+  getPostShortId(longId: UUID): Promise<string | null>;
+  getPostLongId(shortId: string): Promise<UUID | null>;
+  getPostLongIds(shortIds: string[]): Promise<UUID[]>;
   getPostById(id: UUID): Promise<Post | null>;
   getAdminsOfPostGroups(postId: UUID): Promise<User[]>;
   getPostsByIds(ids: UUID[]): Promise<Post[]>;

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -486,6 +486,7 @@ const POST_COLUMNS_MAPPING = {
 export const POST_FIELDS = {
   uid: 'id',
   id: 'intId',
+  short_id: 'shortId',
   created_at: 'createdAt',
   updated_at: 'updatedAt',
   bumped_at: 'bumpedAt',

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -96,6 +96,13 @@ const postsTrait = (superClass) =>
       return res.long_id;
     }
 
+    async getPostLongIds(shortIds) {
+      const res = await this.database('post_short_ids')
+        .select('long_id')
+        .whereIn('short_id', shortIds);
+      return res.map((r) => r.long_id);
+    }
+
     async getPostById(id, params) {
       if (!validator.isUUID(id)) {
         return null;

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -422,9 +422,9 @@ const postsTrait = (superClass) =>
     }
 
     async createPostShortId(trx, longId) {
-      let length = config.postShortIds.initialLength;
+      let length = config.shortLinks.initialLength.post;
 
-      for (; ; length++) {
+      for (; length <= 10; length++) {
         // eslint-disable-next-line no-await-in-loop
         if (await this.createPostShortIdForLength(trx, longId, length)) {
           return;
@@ -433,7 +433,7 @@ const postsTrait = (superClass) =>
     }
 
     async createPostShortIdForLength(trx, longId, length) {
-      for (let i = 0; i < config.postShortIds.maxAttempts; i++) {
+      for (let i = 0; i < config.shortLinks.maxAttempts; i++) {
         const shortId = this.getDecentRandomString(length);
 
         // eslint-disable-next-line no-await-in-loop
@@ -459,7 +459,7 @@ const postsTrait = (superClass) =>
       }
     }
 
-    isStringDecent = (str) => !config.postShortIds.stopWords.some((word) => str.includes(word));
+    isStringDecent = (str) => !config.shortLinks.stopWords.some((word) => str.includes(word));
 
     getRandomString = (length) =>
       randomBytes(Math.ceil(length / 2)) // divide by 2 since bytes are twice longer than hex

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -62,6 +62,23 @@ const postsTrait = (superClass) =>
       return await this.database('posts').where('uid', postId).update(preparedPayload);
     }
 
+    async getPostLongId(shortId) {
+      if (!validator.isHexadecimal(shortId)) {
+        return null;
+      }
+
+      const res = await this.database('post_short_ids')
+        .select('long_id')
+        .where('short_id', shortId)
+        .first();
+
+      if (!res) {
+        return null;
+      }
+
+      return res.long_id;
+    }
+
     async getPostById(id, params) {
       if (!validator.isUUID(id)) {
         return null;

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -62,6 +62,23 @@ const postsTrait = (superClass) =>
       return await this.database('posts').where('uid', postId).update(preparedPayload);
     }
 
+    async getPostShortId(longId) {
+      if (!validator.isUUID(longId)) {
+        return null;
+      }
+
+      const res = await this.database('post_short_ids')
+        .select('short_id')
+        .where('long_id', longId)
+        .first();
+
+      if (!res) {
+        return null;
+      }
+
+      return res.short_id;
+    }
+
     async getPostLongId(shortId) {
       if (!validator.isHexadecimal(shortId)) {
         return null;

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -300,6 +300,7 @@ const timelinesPostsTrait = (superClass) =>
         'comments_count',
         'likes_count',
         'friendfeed_url',
+        'short_id',
       ).map((k) => pgFormat('p.%I', k));
       const attFields = Object.keys(ATTACHMENT_FIELDS).map((k) => pgFormat('%I', k));
       const commentFields = Object.keys(COMMENT_FIELDS).map((k) => pgFormat('%I', k));
@@ -327,9 +328,10 @@ const timelinesPostsTrait = (superClass) =>
       const [friendsIds, postsData, attData, destData] = await Promise.all([
         viewerId ? this.getUserFriendIds(viewerId) : [],
         this.database
-          .select('a.old_url as friendfeed_url', ...postFields)
+          .select('a.old_url as friendfeed_url', 's.short_id', ...postFields)
           .from('posts as p')
           .leftJoin('archive_post_names as a', 'p.uid', 'a.post_id')
+          .leftJoin('post_short_ids as s', 'p.uid', 's.long_id')
           .whereIn('p.uid', uniqPostsIds),
         this.database
           .select(...attFields)

--- a/app/support/EventService.ts
+++ b/app/support/EventService.ts
@@ -10,7 +10,7 @@ import {
   T_EVENT_TYPE,
 } from './EventTypes';
 import { Nullable, UUID } from './types';
-import { extractUUIDs } from './backlinks';
+import { extractShortIds, extractUUIDs } from './backlinks';
 
 type OnPostFeedsChangedParams = {
   addedFeeds?: Timeline[];
@@ -718,6 +718,13 @@ async function processBacklinks(srcEntity: Post | Comment, prevBody = '') {
   const prevUUIDs = extractUUIDs(prevBody);
   const newUUIDs = extractUUIDs(srcEntity.body);
   const uuids = difference(newUUIDs, prevUUIDs);
+
+  const prevShortIds = extractShortIds(prevBody);
+  const newShortIds = extractShortIds(srcEntity.body);
+  const shortIds = difference(newShortIds, prevShortIds);
+  const moreUUIDs = await dbAdapter.getPostLongIds(shortIds);
+  uuids.push(...moreUUIDs);
+
   const [mentionedPosts, mentionedComments] = await Promise.all([
     dbAdapter.getPostsByIds(uuids),
     dbAdapter.getCommentsByIds(uuids),

--- a/app/support/backlinks.ts
+++ b/app/support/backlinks.ts
@@ -11,6 +11,14 @@ export function getUpdatedUUIDs(text1: string, text2: string = '') {
   return xor(extractUUIDs(text1), extractUUIDs(text2));
 }
 
+export function getUpdatedShortIds(text1: string, text2: string = '') {
+  if (text1 === text2) {
+    return [];
+  }
+
+  return xor(extractShortIds(text1), extractShortIds(text2));
+}
+
 export const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
 export function extractUUIDs(text: string | null): UUID[] {
   return text ? [...text.matchAll(uuidRe)].map((m) => m[0]).filter(onlyUnique) : [];

--- a/app/support/backlinks.ts
+++ b/app/support/backlinks.ts
@@ -29,7 +29,7 @@ export function extractShortIds(text: string | null): string[] {
   return text ? [...text.matchAll(shortLinkRe)].map((m) => m[1]).filter(onlyUnique) : [];
 }
 
-export const hashedShortLinkRe = /\/[A-Za-z0-9-]{3,35}\/([0-9a-f]{6,10}#[0-9a-f]{3,6})/gi;
+export const hashedShortLinkRe = /\/[A-Za-z0-9-]{3,35}\/([0-9a-f]{6,10}#[0-9a-f]{4,6})/gi;
 export function extractHashedShortIds(text: string | null): string[] {
   return text ? [...text.matchAll(hashedShortLinkRe)].map((m) => m[1]).filter(onlyUnique) : [];
 }

--- a/app/support/backlinks.ts
+++ b/app/support/backlinks.ts
@@ -29,6 +29,11 @@ export function extractShortIds(text: string | null): string[] {
   return text ? [...text.matchAll(shortLinkRe)].map((m) => m[1]).filter(onlyUnique) : [];
 }
 
+export const hashedShortLinkRe = /\/[A-Za-z0-9-]{3,35}\/([0-9a-f]{6,10}#[0-9a-f]{3,6})/gi;
+export function extractHashedShortIds(text: string | null): string[] {
+  return text ? [...text.matchAll(hashedShortLinkRe)].map((m) => m[1]).filter(onlyUnique) : [];
+}
+
 function onlyUnique<T>(value: T, index: number, arr: T[]) {
   return arr.indexOf(value) === index;
 }

--- a/app/support/backlinks.ts
+++ b/app/support/backlinks.ts
@@ -16,6 +16,11 @@ export function extractUUIDs(text: string | null): UUID[] {
   return text ? [...text.matchAll(uuidRe)].map((m) => m[0]).filter(onlyUnique) : [];
 }
 
+export const shortLinkRe = /\/[A-Za-z0-9-]{3,35}\/([0-9a-f]{6,10})/gi;
+export function extractShortIds(text: string | null): string[] {
+  return text ? [...text.matchAll(shortLinkRe)].map((m) => m[1]).filter(onlyUnique) : [];
+}
+
 function onlyUnique<T>(value: T, index: number, arr: T[]) {
   return arr.indexOf(value) === index;
 }

--- a/bin/backfill_short_ids.js
+++ b/bin/backfill_short_ids.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-await-in-loop */
+
+import { program } from 'commander';
+
+import { dbAdapter } from '../app/models';
+import { delay } from '../app/support/timers';
+
+// Backfill short IDs for preexisting posts
+// Usage: yarn babel bin/backfill_short_ids.js --help
+
+const ZERO_UID = '00000000-00000000-00000000-00000000';
+
+program
+  .option('--batch-size <batch size>', 'batch size', (v) => parseInt(v, 10), 1000)
+  .option('--delay <delay>', 'delay between batches, seconds', (v) => parseInt(v, 10), 1);
+program.parse(process.argv);
+
+const [batchSize, delaySec] = [
+  program.getOptionValue('batchSize'),
+  program.getOptionValue('delay'),
+];
+
+if (!isFinite(batchSize) || !isFinite(delaySec)) {
+  process.stderr.write(`⛔ Invalid program option\n`);
+  program.help();
+}
+
+process.stdout.write(`Running with batch size of ${batchSize} and delay of ${delaySec}\n`);
+process.stdout.write(`\n`);
+
+(async () => {
+  try {
+    let lastUID = ZERO_UID;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const longIds = await dbAdapter.database.getCol(
+        `SELECT uid 
+        FROM posts AS p 
+        LEFT JOIN post_short_ids AS s ON p.uid = s.long_id
+        WHERE s.long_id IS NULL AND p.uid > :lastUID
+        ORDER BY uid
+        LIMIT :batchSize`,
+        { lastUID, batchSize },
+      );
+
+      if (longIds.length === 0) {
+        break;
+      }
+
+      for (const longId of longIds) {
+        await dbAdapter.createPostShortId(dbAdapter.database, longId);
+        lastUID = longId;
+      }
+
+      const percent = (parseInt(lastUID.slice(0, 2), 16) * 100) >> 8;
+      process.stdout.write(`\tprocessed ${percent}% of total\n`);
+
+      await delay(1000 * delaySec);
+    }
+
+    process.stdout.write(`All posts were processed.\n`);
+    process.stdout.write(`Done.\n`);
+
+    process.exit(0);
+  } catch (e) {
+    process.stderr.write(`⛔ ERROR: ${e.message}\n`);
+    process.exit(1);
+  }
+})();

--- a/bin/reindex_backlinks.js
+++ b/bin/reindex_backlinks.js
@@ -133,7 +133,7 @@ process.stdout.write(`\n`);
 
               // Only the real post Short Ids
               const shortIdRecords = await dbAdapter.database.getAll(
-                `select long_id, short_id from post_short_ids where short_id = any(:shortIds)`,
+                `SELECT long_id, short_id FROM post_short_ids WHERE short_id = ANY(:shortIds) AND long_id IS NOT NULL`,
                 {
                   shortIds: [...allShortIds],
                 },

--- a/bin/reindex_backlinks.js
+++ b/bin/reindex_backlinks.js
@@ -5,10 +5,10 @@ import path from 'path';
 import { program } from 'commander';
 
 import { dbAdapter } from '../app/models';
-import { extractUUIDs } from '../app/support/backlinks';
+import { extractShortIds, extractUUIDs } from '../app/support/backlinks';
 import { delay } from '../app/support/timers';
 
-// Reindex baclinks in posts and comments.
+// Reindex backlinks in posts and comments.
 // Usage: yarn babel bin/reindex_backlinks.js --help
 
 const allTables = ['posts', 'comments'];
@@ -95,15 +95,22 @@ process.stdout.write(`\n`);
         }
 
         const allUUIDs = new Set();
+        const allShortIds = new Set();
 
         for (const row of rows) {
           const uuids = extractUUIDs(row.body);
+          const shortIds = extractShortIds(row.body);
 
           for (const uuid of uuids) {
             allUUIDs.add(uuid);
           }
 
+          for (const shortId of shortIds) {
+            allShortIds.add(shortId);
+          }
+
           row.uuids = uuids;
+          row.shortIds = shortIds;
         }
 
         let attemptsLeft = retries;
@@ -124,6 +131,20 @@ process.stdout.write(`\n`);
                 }),
               );
 
+              // Only the real post Short Ids
+              const shortIdRecords = await dbAdapter.database.getAll(
+                `select long_id, short_id from post_short_ids where short_id = any(:shortIds)`,
+                {
+                  shortIds: [...allShortIds],
+                },
+              );
+              const realShortIds = new Set();
+              const shortToLong = {};
+              shortIdRecords.forEach((r) => {
+                shortToLong[r.short_id] = r.long_id;
+                realShortIds.add(r.short_id);
+              });
+
               await trx.raw(
                 `create temp table b_data (post_id uuid, ref_post_id uuid, ref_comment_id uuid) on commit drop`,
               );
@@ -135,6 +156,16 @@ process.stdout.write(`\n`);
                 for (const uuid of uuids) {
                   toInsert.push({
                     post_id: uuid,
+                    ref_post_id: row.ref_post_id,
+                    ref_comment_id: row.ref_comment_id,
+                  });
+                }
+
+                const shortIds = row.shortIds.filter((u) => realShortIds.has(u));
+
+                for (const shortId of shortIds) {
+                  toInsert.push({
+                    post_id: shortToLong[shortId],
                     ref_post_id: row.ref_post_id,
                     ref_comment_id: row.ref_comment_id,
                   });

--- a/config/default.js
+++ b/config/default.js
@@ -358,8 +358,11 @@ config.passwordReset = {
   tokenTTL: 8 * 3600, // in seconds
 };
 
-config.postShortIds = {
-  initialLength: 6,
+config.shortLinks = {
+  initialLength: {
+    post: 6,
+    comment: 4,
+  },
   stopWords: ['dea', 'bad', 'bee', 'bab', 'fee'],
   maxAttempts: 3, // max number of attempts (with DB uniqueness check) for selected length, before increasing the length by one
 };

--- a/config/default.js
+++ b/config/default.js
@@ -358,6 +358,12 @@ config.passwordReset = {
   tokenTTL: 8 * 3600, // in seconds
 };
 
+config.postShortIds = {
+  initialLength: 6,
+  stopWords: ['dea', 'bad', 'bee', 'bab', 'fee'],
+  maxAttempts: 3, // max number of attempts (with DB uniqueness check) for selected length, before increasing the length by one
+};
+
 config.userPreferences = {
   /**
    * Default user preferences. This object must satisfy the JSON Schema defined

--- a/migrations/20211024233327_short_links.js
+++ b/migrations/20211024233327_short_links.js
@@ -1,0 +1,12 @@
+export const up = (knex) =>
+  knex.schema.raw(`do $$begin
+  create table post_short_ids (
+    short_id text primary key,
+    long_id uuid unique references posts (uid) on update cascade on delete set null
+  );
+end$$`);
+
+export const down = (knex) =>
+  knex.schema.raw(`do $$begin
+    drop table post_short_ids;
+end$$`);

--- a/migrations/20230723170500_short_links.ts
+++ b/migrations/20230723170500_short_links.ts
@@ -1,4 +1,6 @@
-export const up = (knex) =>
+import type { Knex } from 'knex';
+
+export const up = (knex: Knex) =>
   knex.schema.raw(`do $$begin
   create table post_short_ids (
     short_id text primary key,
@@ -6,7 +8,7 @@ export const up = (knex) =>
   );
 end$$`);
 
-export const down = (knex) =>
+export const down = (knex: Knex) =>
   knex.schema.raw(`do $$begin
     drop table post_short_ids;
 end$$`);

--- a/migrations/20230816195400_comments_short_id.ts
+++ b/migrations/20230816195400_comments_short_id.ts
@@ -1,0 +1,18 @@
+import type { Knex } from 'knex';
+
+export const up = (knex: Knex) =>
+  knex.schema.raw(`do $$begin
+    alter table comments
+      add short_id text;
+      
+    create unique index comments_uid_short_id_unique
+      on comments (uid, short_id);
+end$$`);
+
+export const down = (knex: Knex) =>
+  knex.schema.raw(`do $$begin
+    drop index comments_uid_short_id_unique;
+  
+    alter table comments
+      drop column short_id;
+end$$`);

--- a/test/functional/archives.js
+++ b/test/functional/archives.js
@@ -182,7 +182,7 @@ describe('Archives', () => {
       await dbAdapter.setOldPostName(post.id, oldName, oldUrl);
     });
 
-    it('should return post object with old URL', async () => {
+    it('should return post object with old (FriendFeed) URL', async () => {
       const resp = await testHelper.fetchPost(post.id);
       expect(resp, 'to satisfy', { posts: { friendfeedUrl: oldUrl } });
     });

--- a/test/functional/backlinks.js
+++ b/test/functional/backlinks.js
@@ -131,7 +131,7 @@ describe('Backlinks in realtime', () => {
   });
 
   describe('Mars is public', () => {
-    it(`should deliver 'post:update' to the Luna when Mars creates post with her post ID`, async () => {
+    it(`should deliver 'post:update' to Luna when Mars creates post with her post ID`, async () => {
       const test = lunaSession.receiveWhile(
         'post:update',
         async () =>
@@ -145,14 +145,14 @@ describe('Backlinks in realtime', () => {
       });
     });
 
-    it(`should not deliver 'post:update' to the Luna when Mars updates post keeping her post ID`, async () => {
+    it(`should not deliver 'post:update' to Luna when Mars updates post keeping her post ID`, async () => {
       const test = lunaSession.notReceiveWhile('post:update', () =>
         updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
       );
       await expect(test, 'to be fulfilled');
     });
 
-    it(`should deliver 'post:update' to the Luna when Mars updates post and removes her post ID`, async () => {
+    it(`should deliver 'post:update' to Luna when Mars updates post and removes her post ID`, async () => {
       const test = lunaSession.receiveWhile('post:update', () =>
         updatePostAsync(mars, { body: `As Luna said, hmm...` }),
       );
@@ -161,7 +161,7 @@ describe('Backlinks in realtime', () => {
       });
     });
 
-    it(`should deliver 'post:update' to the Luna when Mars updates post and returns her post ID`, async () => {
+    it(`should deliver 'post:update' to Luna when Mars updates post and restores her post ID`, async () => {
       const test = lunaSession.receiveWhile('post:update', () =>
         updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
       );
@@ -170,7 +170,54 @@ describe('Backlinks in realtime', () => {
       });
     });
 
-    it(`should deliver 'post:update' to the Luna when Mars removes post with her post ID`, async () => {
+    it(`should deliver 'post:update' to Luna when Mars removes post with her post ID`, async () => {
+      const test = lunaSession.receiveWhile('post:update', () =>
+        deletePostAsync(mars, mars.post.id),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 0 },
+      });
+    });
+  });
+
+  describe('Mars uses short links', () => {
+    it(`should deliver 'post:update' to Luna when Mars creates post with her post ID`, async () => {
+      const test = lunaSession.receiveWhile(
+        'post:update',
+        async () =>
+          (mars.post = await createAndReturnPost(mars, `As Luna said, /luna/${luna.post.shortId}`)),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 1 },
+      });
+    });
+
+    it(`should not deliver 'post:update' to Luna when Mars updates post keeping her post ID`, async () => {
+      const test = lunaSession.notReceiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, again, /luna/${luna.post.shortId}` }),
+      );
+      await expect(test, 'to be fulfilled');
+    });
+
+    it(`should deliver 'post:update' to Luna when Mars updates post and removes her post ID`, async () => {
+      const test = lunaSession.receiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, hmm...` }),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 0 },
+      });
+    });
+
+    it(`should deliver 'post:update' to Luna when Mars updates post and restores her post ID`, async () => {
+      const test = lunaSession.receiveWhile('post:update', () =>
+        updatePostAsync(mars, { body: `As Luna said, again, /luna/${luna.post.shortId}` }),
+      );
+      await expect(test, 'when fulfilled', 'to satisfy', {
+        posts: { id: luna.post.id, backlinksCount: 1 },
+      });
+    });
+
+    it(`should deliver 'post:update' to Luna when Mars removes post with her post ID`, async () => {
       const test = lunaSession.receiveWhile('post:update', () =>
         deletePostAsync(mars, mars.post.id),
       );
@@ -184,7 +231,7 @@ describe('Backlinks in realtime', () => {
     before(() => goPrivate(mars));
     after(() => goPublic(mars));
 
-    it(`should not deliver 'post:update' to the Luna when Mars creates post with her post ID`, async () => {
+    it(`should not deliver 'post:update' to Luna when Mars creates post with her post ID`, async () => {
       const test = lunaSession.notReceiveWhile(
         'post:update',
         async () =>
@@ -196,28 +243,28 @@ describe('Backlinks in realtime', () => {
       await expect(test, 'to be fulfilled');
     });
 
-    it(`should not deliver 'post:update' to the Luna when Mars updates post keeping her post ID`, async () => {
+    it(`should not deliver 'post:update' to Luna when Mars updates post keeping her post ID`, async () => {
       const test = lunaSession.notReceiveWhile('post:update', () =>
         updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
       );
       await expect(test, 'to be fulfilled');
     });
 
-    it(`should not deliver 'post:update' to the Luna when Mars updates post and removes her post ID`, async () => {
+    it(`should not deliver 'post:update' to Luna when Mars updates post and removes her post ID`, async () => {
       const test = lunaSession.notReceiveWhile('post:update', () =>
         updatePostAsync(mars, { body: `As Luna said, hmm...` }),
       );
       await expect(test, 'to be fulfilled');
     });
 
-    it(`should not deliver 'post:update' to the Luna when Mars updates post and returns her post ID`, async () => {
+    it(`should not deliver 'post:update' to Luna when Mars updates post and restores her post ID`, async () => {
       const test = lunaSession.notReceiveWhile('post:update', () =>
         updatePostAsync(mars, { body: `As Luna said, again, example.com/${luna.post.id}` }),
       );
       await expect(test, 'to be fulfilled');
     });
 
-    it(`should not deliver 'post:update' to the Luna when Mars removes post with her post ID`, async () => {
+    it(`should not deliver 'post:update' to Luna when Mars removes post with her post ID`, async () => {
       const test = lunaSession.notReceiveWhile('post:update', () =>
         deletePostAsync(mars, mars.post.id),
       );
@@ -230,7 +277,7 @@ describe('Backlinks in realtime', () => {
     after(() => deletePostAsync(mars, mars.post.id));
 
     describe('Mars is public', () => {
-      it(`should deliver 'post:update' to the Luna when Mars creates comment with her post ID`, async () => {
+      it(`should deliver 'post:update' to Luna when Mars creates comment with her post ID`, async () => {
         const test = lunaSession.receiveWhile(
           'post:update',
           async () =>
@@ -245,7 +292,7 @@ describe('Backlinks in realtime', () => {
         });
       });
 
-      it(`should not deliver 'post:update' to the Luna when Mars updates comment keeping her post ID`, async () => {
+      it(`should not deliver 'post:update' to Luna when Mars updates comment keeping her post ID`, async () => {
         const test = lunaSession.notReceiveWhile('post:update', () =>
           updateCommentAsync(
             mars,
@@ -256,7 +303,7 @@ describe('Backlinks in realtime', () => {
         await expect(test, 'to be fulfilled');
       });
 
-      it(`should deliver 'post:update' to the Luna when Mars updates comment and removes her post ID`, async () => {
+      it(`should deliver 'post:update' to Luna when Mars updates comment and removes her post ID`, async () => {
         const test = lunaSession.receiveWhile('post:update', () =>
           updateCommentAsync(mars, mars.comment.id, `As Luna said, hmm...`),
         );
@@ -265,7 +312,7 @@ describe('Backlinks in realtime', () => {
         });
       });
 
-      it(`should deliver 'post:update' to the Luna when Mars updates comment and returns her post ID`, async () => {
+      it(`should deliver 'post:update' to Luna when Mars updates comment and restores her post ID`, async () => {
         const test = lunaSession.receiveWhile('post:update', () =>
           updateCommentAsync(
             mars,
@@ -278,7 +325,66 @@ describe('Backlinks in realtime', () => {
         });
       });
 
-      it(`should deliver 'post:update' to the Luna when Mars removes comment with her post ID`, async () => {
+      it(`should deliver 'post:update' to Luna when Mars removes comment with her post ID`, async () => {
+        const test = lunaSession.receiveWhile('post:update', () =>
+          removeCommentAsync(mars, mars.comment.id),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 0 },
+        });
+      });
+    });
+
+    describe('Mars uses short links', () => {
+      it(`should deliver 'post:update' to Luna when Mars creates comment with her post ID`, async () => {
+        const test = lunaSession.receiveWhile(
+          'post:update',
+          async () =>
+            ({ comments: mars.comment } = await createCommentAsync(
+              mars,
+              mars.post.id,
+              `As Luna said, /luna/${luna.post.shortId}`,
+            ).then((r) => r.json())),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 1 },
+        });
+      });
+
+      it(`should not deliver 'post:update' to Luna when Mars updates comment keeping her post ID`, async () => {
+        const test = lunaSession.notReceiveWhile('post:update', () =>
+          updateCommentAsync(
+            mars,
+            mars.comment.id,
+            `As Luna said, again, /luna/${luna.post.shortId}`,
+          ),
+        );
+        await expect(test, 'to be fulfilled');
+      });
+
+      it(`should deliver 'post:update' to Luna when Mars updates comment and removes her post ID`, async () => {
+        const test = lunaSession.receiveWhile('post:update', () =>
+          updateCommentAsync(mars, mars.comment.id, `As Luna said, hmm...`),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 0 },
+        });
+      });
+
+      it(`should deliver 'post:update' to Luna when Mars updates comment and restores her post ID`, async () => {
+        const test = lunaSession.receiveWhile('post:update', () =>
+          updateCommentAsync(
+            mars,
+            mars.comment.id,
+            `As Luna said, again, /luna/${luna.post.shortId}`,
+          ),
+        );
+        await expect(test, 'when fulfilled', 'to satisfy', {
+          posts: { id: luna.post.id, backlinksCount: 1 },
+        });
+      });
+
+      it(`should deliver 'post:update' to Luna when Mars removes comment with her post ID`, async () => {
         const test = lunaSession.receiveWhile('post:update', () =>
           removeCommentAsync(mars, mars.comment.id),
         );
@@ -292,7 +398,7 @@ describe('Backlinks in realtime', () => {
       before(() => goPrivate(mars));
       after(() => goPublic(mars));
 
-      it(`should not deliver 'post:update' to the Luna when Mars creates comment with her post ID`, async () => {
+      it(`should not deliver 'post:update' to Luna when Mars creates comment with her post ID`, async () => {
         const test = lunaSession.notReceiveWhile(
           'post:update',
           async () =>
@@ -305,7 +411,7 @@ describe('Backlinks in realtime', () => {
         await expect(test, 'to be fulfilled');
       });
 
-      it(`should not deliver 'post:update' to the Luna when Mars updates comment keeping her post ID`, async () => {
+      it(`should not deliver 'post:update' to Luna when Mars updates comment keeping her post ID`, async () => {
         const test = lunaSession.notReceiveWhile('post:update', () =>
           updateCommentAsync(
             mars,
@@ -316,14 +422,14 @@ describe('Backlinks in realtime', () => {
         await expect(test, 'to be fulfilled');
       });
 
-      it(`should not deliver 'post:update' to the Luna when Mars updates comment and removes her post ID`, async () => {
+      it(`should not deliver 'post:update' to Luna when Mars updates comment and removes her post ID`, async () => {
         const test = lunaSession.notReceiveWhile('post:update', () =>
           updateCommentAsync(mars, mars.comment.id, `As Luna said, hmm...`),
         );
         await expect(test, 'to be fulfilled');
       });
 
-      it(`should not deliver 'post:update' to the Luna when Mars updates comment and returns her post ID`, async () => {
+      it(`should not deliver 'post:update' to Luna when Mars updates comment and restores her post ID`, async () => {
         const test = lunaSession.notReceiveWhile('post:update', () =>
           updateCommentAsync(
             mars,
@@ -334,7 +440,7 @@ describe('Backlinks in realtime', () => {
         await expect(test, 'to be fulfilled');
       });
 
-      it(`should not deliver 'post:update' to the Luna when Mars removes comment with her post ID`, async () => {
+      it(`should not deliver 'post:update' to Luna when Mars removes comment with her post ID`, async () => {
         const test = lunaSession.notReceiveWhile('post:update', () =>
           removeCommentAsync(mars, mars.comment.id),
         );

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -12,6 +12,10 @@ export const freefeedAssertions = {
       xpct(subject, 'to match', uuidRegExp);
     });
 
+    unexpected.addAssertion('<string> to be a hexadecimal string', (xpct, subject) => {
+      xpct(subject, 'to match', /^[a-f0-9]{6,10}$/);
+    });
+
     unexpected.addAssertion('<string> to be boolString', (xpct, subject) => {
       xpct(subject, 'to be one of', ['0', '1']);
     });
@@ -195,6 +199,7 @@ export const userOrGroup = (obj) => {
 
 const postBasic = {
   id: expect.it('to be UUID'),
+  shortId: expect.it('to be a hexadecimal string'),
   body: expect.it('to be a string'),
   commentsDisabled: expect.it('to be boolString'),
   createdAt: expect.it('to be timeStampString'),

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -13,7 +13,7 @@ export const freefeedAssertions = {
     });
 
     unexpected.addAssertion('<string> to be a hexadecimal string', (xpct, subject) => {
-      xpct(subject, 'to match', /^[a-f0-9]{6,10}$/);
+      xpct(subject, 'to match', /^[a-f0-9]{3,10}$/);
     });
 
     unexpected.addAssertion('<string> to be boolString', (xpct, subject) => {
@@ -232,6 +232,7 @@ const postBasic = {
 
 const commentBasic = {
   id: expect.it('to be UUID'),
+  shortId: expect.it('to be a hexadecimal string'),
   postId: expect.it('to be UUID'),
   body: expect.it('to be a string'),
   createdAt: expect.it('to be timeStampString'),

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -13,7 +13,7 @@ export const freefeedAssertions = {
     });
 
     unexpected.addAssertion('<string> to be a hexadecimal string', (xpct, subject) => {
-      xpct(subject, 'to match', /^[a-f0-9]{3,10}$/);
+      xpct(subject, 'to match', /^[a-f0-9]{4,10}$/);
     });
 
     unexpected.addAssertion('<string> to be boolString', (xpct, subject) => {

--- a/test/integration/controllers/post-access-required.js
+++ b/test/integration/controllers/post-access-required.js
@@ -11,7 +11,7 @@ import { User, Post } from '../../../app/models';
 describe('postAccessRequired', () => {
   beforeEach(() => cleanDB($pg_database));
 
-  const handler = (ctx, map) => postAccessRequired(map)(ctx, noop);
+  const handler = (ctx) => postAccessRequired()(ctx, noop);
 
   describe("Luna, Mars and Luna's post", () => {
     let luna, mars, post, ctx;
@@ -38,30 +38,9 @@ describe('postAccessRequired', () => {
       await expect(handler(ctx), 'to be rejected with', { status: 500 });
     });
 
-    it('should not allow to view inexistent post', async () => {
+    it('should not allow to view nonexistent post', async () => {
       ctx.params.postId = '00000000-0000-0000-C000-000000000046';
       await expect(handler(ctx), 'to be rejected with', { status: 404 });
-    });
-
-    it('should allow to view post with custom route parameter', async () => {
-      ctx.params.postId2 = ctx.params.postId;
-      Reflect.deleteProperty(ctx.params, 'postId');
-      await expect(handler(ctx, { postId2: 'post2' }), 'to be fulfilled');
-      expect(ctx.state, 'to satisfy', { post2: { id: post.id } });
-    });
-
-    it('should allow to view two posts', async () => {
-      ctx.params.postId2 = ctx.params.postId;
-      await expect(handler(ctx, { postId: 'post', postId2: 'post2' }), 'to be fulfilled');
-      expect(ctx.state, 'to satisfy', { post2: { id: post.id }, post: { id: post.id } });
-    });
-
-    it('should not allow to view two posts if one of them is not exists', async () => {
-      ctx.params.postId2 = ctx.params.postId;
-      ctx.params.postId = '00000000-0000-0000-C000-000000000046';
-      await expect(handler(ctx, { postId: 'post', postId2: 'post2' }), 'to be rejected with', {
-        status: 404,
-      });
     });
 
     it('should allow anonymous to view post', async () => {

--- a/test/integration/models/comment/short-id.js
+++ b/test/integration/models/comment/short-id.js
@@ -1,0 +1,25 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../../../dbCleaner';
+import { User } from '../../../../app/models';
+import { createComment, createPost } from '../../helpers/posts-and-comments';
+
+describe('Comment Short ID', () => {
+  let luna, lunaPost;
+
+  beforeEach(async () => {
+    await cleanDB($pg_database);
+    luna = new User({ username: 'luna', password: 'pw' });
+    await luna.create();
+    lunaPost = await createPost(luna, `Post body`);
+  });
+
+  it('should create a comment with a valid shortId', async () => {
+    const comment1 = await createComment(luna, lunaPost, 'Comment body 1');
+    const comment2 = await createComment(luna, lunaPost, 'Comment body 2');
+    expect(comment1.shortId, 'to match', /^[a-f0-9]{2}1$/);
+    expect(comment2.shortId, 'to match', /^[a-f0-9]{2}2$/);
+  });
+});

--- a/test/integration/models/comment/short-id.js
+++ b/test/integration/models/comment/short-id.js
@@ -17,9 +17,7 @@ describe('Comment Short ID', () => {
   });
 
   it('should create a comment with a valid shortId', async () => {
-    const comment1 = await createComment(luna, lunaPost, 'Comment body 1');
-    const comment2 = await createComment(luna, lunaPost, 'Comment body 2');
-    expect(comment1.shortId, 'to match', /^[a-f0-9]{2}1$/);
-    expect(comment2.shortId, 'to match', /^[a-f0-9]{2}2$/);
+    const comment = await createComment(luna, lunaPost, 'Comment body');
+    expect(comment.shortId, 'to match', /^[a-f0-9]{4,6}$/);
   });
 });

--- a/test/integration/models/post/short-id.js
+++ b/test/integration/models/post/short-id.js
@@ -1,0 +1,40 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../../../dbCleaner';
+import { dbAdapter, User } from '../../../../app/models';
+
+describe('Post Short ID', () => {
+  let luna;
+
+  beforeEach(async () => {
+    await cleanDB($pg_database);
+    luna = new User({ username: 'luna', password: 'pw' });
+    await luna.create();
+  });
+
+  it('should create a post with a valid shortId', async () => {
+    const post = await createPost(luna, { body: 'Post body' });
+    const shortId = await post.getShortId();
+    expect(shortId, 'to match', /^[a-f0-9]{6,10}$/);
+  });
+
+  it('should keep the shortId record with longId=null after the post removal', async () => {
+    const post = await createPost(luna, { body: 'Post body' });
+    const shortId = await post.getShortId();
+    await post.destroy();
+    const records = await dbAdapter.database.getAll(
+      'select * from post_short_ids where short_id = ?',
+      shortId,
+    );
+    expect(records.length, 'to equal', 1);
+    expect(records[0].long_id, 'to equal', null);
+  });
+});
+
+async function createPost(author, postData) {
+  const post = await author.newPost(postData);
+  await post.create();
+  return post;
+}

--- a/test/integration/support/DbAdapter/backlinks.js
+++ b/test/integration/support/DbAdapter/backlinks.js
@@ -246,9 +246,9 @@ describe('Backlinks DB trait', () => {
   describe('Counting backlinks in posts and comments', () => {
     let jupiterCommentNo2;
 
-    after(() => {
-      marsPost.update({ body: `luna post: example.com/${lunaPost.id}` });
-      jupiterCommentNo2.destroy();
+    after(async () => {
+      await marsPost.update({ body: `luna post: example.com/${lunaPost.id}` });
+      await jupiterCommentNo2.destroy();
     });
 
     it(`should increase count by 1 when adding a comment with link`, async () => {

--- a/test/integration/support/events/backlinks.js
+++ b/test/integration/support/events/backlinks.js
@@ -1,6 +1,7 @@
 /* eslint-env node, mocha */
 /* global $pg_database */
 import expect from 'unexpected';
+import { sortBy } from 'lodash';
 
 import { User, Post, Group, dbAdapter, Comment } from '../../../../app/models';
 import cleanDB from '../../../dbCleaner';
@@ -15,7 +16,7 @@ describe('EventService', () => {
     let /** @type {User} */ luna, /** @type {User} */ mars, /** @type {User} */ venus;
     let /** @type {Group} */ dubhe;
     let /** @type {Post} */ lunaPost, /** @type {Post} */ marsPost, /** @type {Post} */ venusPost;
-    let marsPostShortId;
+    let marsPostShortId, venusPostShortId;
 
     before(async () => {
       luna = new User({ username: 'luna', password: 'pw' });
@@ -32,6 +33,7 @@ describe('EventService', () => {
       );
 
       marsPostShortId = await marsPost.getShortId();
+      venusPostShortId = await venusPost.getShortId();
     });
 
     // Clean events before each test
@@ -285,15 +287,31 @@ describe('EventService', () => {
           await expectBacklinkEvents(luna, []);
         });
 
+        it('should create backlink_in_post event for mentioned comment author (short link)', async () => {
+          post = await createPost(
+            luna,
+            `Mentioning /venus/${venusPostShortId}#${marsComment.shortId}`,
+          );
+          await expectBacklinkEvents(mars, [await backlinkInPostEvent(post, marsComment)]);
+          await expectBacklinkEvents(venus, [await backlinkInPostEvent(post, venusPost)]);
+          await expectBacklinkEvents(luna, []);
+        });
+
         it('should not create backlink_in_post event for mentioned comment author', async () => {
           post = await createPost(luna, `Mentioning ${lunaComment.id}`);
           await expectBacklinkEvents(luna, []);
         });
 
         it('should create backlink_in_post event for each mentioned comment', async () => {
-          post = await createPost(luna, `Mentioning ${marsComment.id} ${venusComment.id}`);
+          post = await createPost(
+            luna,
+            `Mentioning /venus/${venusPostShortId}#${marsComment.shortId} ${venusComment.id}`,
+          );
           await expectBacklinkEvents(mars, [await backlinkInPostEvent(post, marsComment)]);
-          await expectBacklinkEvents(venus, [await backlinkInPostEvent(post, venusComment)]);
+          await expectBacklinkEvents(venus, [
+            await backlinkInPostEvent(post, venusPost),
+            await backlinkInPostEvent(post, venusComment),
+          ]);
           await expectBacklinkEvents(luna, []);
         });
 
@@ -351,6 +369,17 @@ describe('EventService', () => {
             await expectBacklinkEvents(mars, [await backlinkInPostEvent(post, marsComment)]);
           });
 
+          it('should create backlink_in_post when post without mention updates with mention (short link)', async () => {
+            post = await createAndUpdatePost(
+              luna,
+              'Post without mentions',
+              `Mentioning /venus/${venusPostShortId}#${marsComment.shortId}`,
+            );
+
+            await expectBacklinkEvents(mars, [await backlinkInPostEvent(post, marsComment)]);
+            await expectBacklinkEvents(venus, [await backlinkInPostEvent(post, venusPost)]);
+          });
+
           it('should not remove backlink_in_post when mention disappears from the post', async () => {
             post = await createAndUpdatePost(
               luna,
@@ -363,11 +392,14 @@ describe('EventService', () => {
           it('should create additional backlink_in_post when a new mention appears in the post', async () => {
             post = await createAndUpdatePost(
               luna,
-              `Mentioning ${marsComment.id}`,
               `Mentioning ${venusComment.id}`,
+              `Mentioning /venus/${venusPostShortId}#${marsComment.shortId}`,
             );
             await expectBacklinkEvents(mars, [await backlinkInPostEvent(post, marsComment)]);
-            await expectBacklinkEvents(venus, [await backlinkInPostEvent(post, venusComment)]);
+            await expectBacklinkEvents(venus, [
+              await backlinkInPostEvent(post, venusPost),
+              await backlinkInPostEvent(post, venusComment),
+            ]);
           });
         });
       });
@@ -382,6 +414,17 @@ describe('EventService', () => {
           await expectBacklinkEvents(luna, []);
         });
 
+        it('should create backlink_in_comment event for mentioned comment author (short link)', async () => {
+          comment = await createComment(
+            luna,
+            venusPost,
+            `Mentioning /venus/${venusPostShortId}#${marsComment.shortId}`,
+          );
+          await expectBacklinkEvents(mars, [await backlinkInCommentEvent(comment, marsComment)]);
+          await expectBacklinkEvents(venus, [await backlinkInCommentEvent(comment, venusPost)]);
+          await expectBacklinkEvents(luna, []);
+        });
+
         it('should not create backlink_in_comment event for mentioned comment author', async () => {
           comment = await createComment(luna, venusPost, `Mentioning ${lunaComment.id}`);
           await expectBacklinkEvents(luna, []);
@@ -391,10 +434,13 @@ describe('EventService', () => {
           comment = await createComment(
             luna,
             venusPost,
-            `Mentioning ${marsComment.id} ${venusComment.id}`,
+            `Mentioning /venus/${venusPostShortId}#${marsComment.shortId} ${venusComment.id}`,
           );
           await expectBacklinkEvents(mars, [await backlinkInCommentEvent(comment, marsComment)]);
-          await expectBacklinkEvents(venus, [await backlinkInCommentEvent(comment, venusComment)]);
+          await expectBacklinkEvents(venus, [
+            await backlinkInCommentEvent(comment, venusPost),
+            await backlinkInCommentEvent(comment, venusComment),
+          ]);
           await expectBacklinkEvents(luna, []);
         });
 
@@ -449,6 +495,17 @@ describe('EventService', () => {
             await expectBacklinkEvents(mars, [await backlinkInCommentEvent(comment, marsComment)]);
           });
 
+          it('should create backlink_in_post when comment without mention updates with mention (short link)', async () => {
+            comment = await createComment(
+              luna,
+              venusPost,
+              'Post without mentions',
+              `Mentioning /venus/${venusPostShortId}#${marsComment.shortId}`,
+            );
+
+            await expectBacklinkEvents(mars, [await backlinkInCommentEvent(comment, marsComment)]);
+          });
+
           it('should not remove backlink_in_post when mention disappears from the comment', async () => {
             comment = await createComment(
               luna,
@@ -463,11 +520,12 @@ describe('EventService', () => {
             comment = await createComment(
               luna,
               venusPost,
-              `Mentioning ${marsComment.id}`,
               `Mentioning ${venusComment.id}`,
+              `Mentioning /venus/${venusPostShortId}#${marsComment.shortId}`,
             );
             await expectBacklinkEvents(mars, [await backlinkInCommentEvent(comment, marsComment)]);
             await expectBacklinkEvents(venus, [
+              await backlinkInCommentEvent(comment, venusPost),
               await backlinkInCommentEvent(comment, venusComment),
             ]);
           });
@@ -504,7 +562,17 @@ async function expectBacklinkEvents(user, shape) {
     'backlink_in_post',
     'backlink_in_comment',
   ]);
-  expect(events, 'to satisfy', shape);
+
+  // If array `shape` has more than one element, it's prone to race conditions
+  // (as `events` may go in random order, not matching the order in `shape`).
+  // So we need to sort both to make the comparison deterministic.
+  if (shape.length > 1) {
+    const events2 = sortBy(events, Object.keys(shape[0]));
+    const shape2 = sortBy(shape, Object.keys(shape[0]));
+    expect(events2, 'to satisfy', shape2);
+  } else {
+    expect(events, 'to satisfy', shape);
+  }
 }
 
 /**

--- a/test/unit/support/backlinks.ts
+++ b/test/unit/support/backlinks.ts
@@ -5,6 +5,7 @@ import expect from 'unexpected';
 import {
   extractUUIDs,
   extractShortIds,
+  extractHashedShortIds,
   notifyBacklinkedLater,
   notifyBacklinkedNow,
 } from '../../../app/support/backlinks';
@@ -76,6 +77,44 @@ describe('Backlinks parser', () => {
     cases.forEach(({ text, result }) => {
       it(`should extract ${result.length} shortId(s) from "${text}"`, () => {
         expect(extractShortIds(text), 'to equal', result);
+      });
+    });
+  });
+
+  describe('extractHashedShortIds', () => {
+    const cases = [
+      { text: 'abc', result: [] },
+      {
+        text: 'abc /venus/f482e5#ad2b',
+        result: ['f482e5#ad2b'],
+      },
+      {
+        text: 'abc /venus/f482e5#ad2b /venus/f482e5#ad2b',
+        result: ['f482e5#ad2b'],
+      },
+      {
+        text: 'abc /venus/f482e5#ad2b /venus/f482e5#bf9',
+        result: ['f482e5#ad2b', 'f482e5#bf9'],
+      },
+      {
+        text: 'abc /venus/f482e5#ad2b /venus/f4g2e5#ad2b',
+        // _______________________________^ (invalid hexadecimal)
+        result: ['f482e5#ad2b'],
+      },
+      {
+        text: 'abc /venus/f482e5#ad2b hello mars/4a39b8#055',
+        // _________________________________^ (no starting slash)
+        result: ['f482e5#ad2b'],
+      },
+      {
+        text: 'abc /venus/f482e5#ad2b /group-for-very-secret-meetings/4a39b8#0a5',
+        result: ['f482e5#ad2b', '4a39b8#0a5'],
+      },
+    ];
+
+    cases.forEach(({ text, result }) => {
+      it(`should extract ${result.length} shortId(s) from "${text}"`, () => {
+        expect(extractHashedShortIds(text), 'to equal', result);
       });
     });
   });

--- a/test/unit/support/backlinks.ts
+++ b/test/unit/support/backlinks.ts
@@ -4,6 +4,7 @@ import expect from 'unexpected';
 
 import {
   extractUUIDs,
+  extractShortIds,
   notifyBacklinkedLater,
   notifyBacklinkedNow,
 } from '../../../app/support/backlinks';
@@ -37,6 +38,44 @@ describe('Backlinks parser', () => {
     cases.forEach(({ text, result }) => {
       it(`should extract ${result.length} UUID(s) from "${text}"`, () => {
         expect(extractUUIDs(text), 'to equal', result);
+      });
+    });
+  });
+
+  describe('extractShortIds', () => {
+    const cases = [
+      { text: 'abc', result: [] },
+      {
+        text: 'abc /venus/f482e5',
+        result: ['f482e5'],
+      },
+      {
+        text: 'abc /venus/f482e5 /venus/f482e5',
+        result: ['f482e5'],
+      },
+      {
+        text: 'abc /venus/f482e5 /venus/f482e8',
+        result: ['f482e5', 'f482e8'],
+      },
+      {
+        text: 'abc /venus/f482e5 /venus/f4g2e5',
+        // _______________________________^ (invalid hexadecimal)
+        result: ['f482e5'],
+      },
+      {
+        text: 'abc /venus/f482e5 hello mars/4a39b8',
+        // ____________________________^ (no starting slash)
+        result: ['f482e5'],
+      },
+      {
+        text: 'abc /venus/f482e5 /group-for-very-secret-meetings/4a39b8',
+        result: ['f482e5', '4a39b8'],
+      },
+    ];
+
+    cases.forEach(({ text, result }) => {
+      it(`should extract ${result.length} shortId(s) from "${text}"`, () => {
+        expect(extractShortIds(text), 'to equal', result);
       });
     });
   });

--- a/test/unit/support/backlinks.ts
+++ b/test/unit/support/backlinks.ts
@@ -93,22 +93,22 @@ describe('Backlinks parser', () => {
         result: ['f482e5#ad2b'],
       },
       {
-        text: 'abc /venus/f482e5#ad2b /venus/f482e5#bf9',
-        result: ['f482e5#ad2b', 'f482e5#bf9'],
+        text: 'abc /venus/f482e5#ad2b /venus/f482e5#bf9e',
+        result: ['f482e5#ad2b', 'f482e5#bf9e'],
       },
       {
         text: 'abc /venus/f482e5#ad2b /venus/f4g2e5#ad2b',
-        // _______________________________^ (invalid hexadecimal)
+        // ____________________________________^ (invalid hexadecimal)
         result: ['f482e5#ad2b'],
       },
       {
-        text: 'abc /venus/f482e5#ad2b hello mars/4a39b8#055',
+        text: 'abc /venus/f482e5#ad2b hello mars/4a39b8#055f',
         // _________________________________^ (no starting slash)
         result: ['f482e5#ad2b'],
       },
       {
-        text: 'abc /venus/f482e5#ad2b /group-for-very-secret-meetings/4a39b8#0a5',
-        result: ['f482e5#ad2b', '4a39b8#0a5'],
+        text: 'abc /venus/f482e5#ad2b /group-for-very-secret-meetings/4a39b8#0a5b',
+        result: ['f482e5#ad2b', '4a39b8#0a5b'],
       },
     ];
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -91,8 +91,11 @@ declare module 'config' {
       tokenTTL: number;
     };
 
-    postShortIds: {
-      initialLength: number;
+    shortLinks: {
+      initialLength: {
+        post: number;
+        comment: number;
+      };
       stopWords: string[];
       maxAttempts: number;
     };

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -91,6 +91,12 @@ declare module 'config' {
       tokenTTL: number;
     };
 
+    postShortIds: {
+      initialLength: number;
+      stopWords: string[];
+      maxAttempts: number;
+    };
+
     jobManager: {
       pollInterval: number;
       jobLockTime: number;


### PR DESCRIPTION
This is the server-side part of the [Short Links](https://github.com/FreeFeed/freefeed-server/issues/542) feature.

- [x] Add options for the short links to the config file
- [x] Add the table to the DB
- [x] Add code for generating short IDs when creating posts
- [x] Add `shortId` prop to Post objects in API responses
- [x] Update single-post API endpoint (`GET /v2/posts/:postId`) to accept post's short ID along with the long ID
- [x] Tests!
- [x] Update backlinks extraction
- [x] Write a script for backfilling short IDs (for old posts)

Part 2:

- [x] Add support to EventService (notifications) 
- [x] Add support for realtime events
- [x] Add support to bin/reindex_backlinks
