### PR TITLE
Use separate table for backlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.104] - Not released
+### Changed
+- The backlinks logic was rewritten to use a separate table for backlinks
+  information. You must run `yarn babel bin/reindex_backlinks.js` to fill the
+  `backlinks` table by the existing links.
+
 ## [1.103.1] - 2021-11-18
 ### Changed
 - Disabled backlinks (performance issues. still)

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -93,6 +93,10 @@ export class Attachment {
 }
 
 export class Comment {
+  static VISIBLE: 0;
+  static DELETED: 1;
+  static HIDDEN_BANNED: 2;
+  static HIDDEN_ARCHIVED: 3;
   id: UUID;
   intId: number;
   body: string;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -171,4 +171,10 @@ export class DbAdapter {
 
   // Backlinks
   getBacklinksCounts(uuids: UUID[], viewerId?: Nullable<UUID>): Promise<Map<UUID, number>>;
+  updateBacklinks(
+    text: string,
+    refPostUID: UUID,
+    refCommentUID?: Nullable<UUID>,
+    db?: Knex,
+  ): Promise<void>;
 }

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -22,8 +22,12 @@ const postsTrait = (superClass) =>
         // https://github.com/knex/knex/issues/2622
         toTSVector(preparedPayload.body).replace(/\?/g, '\\?'),
       );
-      const res = await this.database('posts').returning('uid').insert(preparedPayload);
-      return res[0];
+      const [postId] = await this.database('posts').returning('uid').insert(preparedPayload);
+
+      // Update backlinks in the post body
+      await this.updateBacklinks(payload.body, postId);
+
+      return postId;
     }
 
     async updatePost(postId, payload) {
@@ -35,6 +39,9 @@ const postsTrait = (superClass) =>
           // https://github.com/knex/knex/issues/2622
           toTSVector(preparedPayload.body).replace(/\?/g, '\\?'),
         );
+
+        // Update backlinks in the post body
+        await this.updateBacklinks(payload.body, postId);
       }
 
       return await this.database('posts').where('uid', postId).update(preparedPayload);

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -452,7 +452,7 @@ const timelinesPostsTrait = (superClass) =>
         this.database.getAll(likesSQL),
         this.database.getAll(commentsSQL),
         this.getLikesInfoForPosts(uniqPostsIds, viewerId),
-        new Map(), // this.getBacklinksCounts(uniqPostsIds, viewerId),
+        this.getBacklinksCounts(uniqPostsIds, viewerId),
       ]);
 
       const results = {};

--- a/app/support/backlinks.ts
+++ b/app/support/backlinks.ts
@@ -12,8 +12,8 @@ export function getUpdatedUUIDs(text1: string, text2: string = '') {
 }
 
 export const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
-export function extractUUIDs(text: string): UUID[] {
-  return [...text.matchAll(uuidRe)].map((m) => m[0]).filter(onlyUnique);
+export function extractUUIDs(text: string | null): UUID[] {
+  return text ? [...text.matchAll(uuidRe)].map((m) => m[0]).filter(onlyUnique) : [];
 }
 
 function onlyUnique<T>(value: T, index: number, arr: T[]) {

--- a/bin/reindex_backlinks.js
+++ b/bin/reindex_backlinks.js
@@ -1,0 +1,187 @@
+/* eslint-disable no-await-in-loop */
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { program } from 'commander';
+
+import { dbAdapter } from '../app/models';
+import { extractUUIDs } from '../app/support/backlinks';
+
+// Reindex baclinks in posts and comments.
+// Usage: yarn babel bin/reindex_backlinks.js --help
+
+const allTables = ['posts', 'comments'];
+const ZERO_UID = '00000000-00000000-00000000-00000000';
+const statusFile = path.join(__dirname, '../tmp/reindex_backlinks.json');
+
+program
+  .option('--batch-size <batch size>', 'batch size', (v) => parseInt(v, 10), '1000')
+  .option('--delay <delay>', 'delay between batches, seconds', (v) => parseInt(v, 10), '1')
+  .option('--retries <count>', 'count of retries in case of failure', (v) => parseInt(v, 10), '10')
+  .option('--timeout <timeout>', 'timeout of transaction in PostgreSQL syntax', '1min')
+  .option('--restart', 'start indexing from the beginning and drop the existing backlinks');
+program.parse(process.argv);
+
+const { batchSize, delay, retries, timeout } = program;
+
+if (!isFinite(batchSize) || !isFinite(delay)) {
+  process.stderr.write(`⛔ Invalid program option\n`);
+  program.help();
+}
+
+process.stdout.write(`Running with batch size of ${batchSize} and delay of ${delay}\n`);
+process.stdout.write(`Status file: ${statusFile}\n`);
+process.stdout.write(`\n`);
+
+(async () => {
+  try {
+    let lastUID = ZERO_UID;
+    let [table] = allTables;
+
+    if (!program.restart) {
+      try {
+        const statusText = await fs.readFile(statusFile, { encoding: 'utf8' });
+        ({ lastUID, table } = JSON.parse(statusText));
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          throw new Error(`Cannot read status from ${statusFile}: ${err.message}`);
+        }
+
+        process.stdout.write(`Status file is not found, starting from the beginning...\n`);
+      }
+    } else {
+      // Drop existing backlinks
+      await dbAdapter.database.raw(`truncate table backlinks`);
+    }
+
+    if (!allTables.includes(table)) {
+      throw new Error(`Unknown table name '${table}'`);
+    }
+
+    while (table) {
+      const isComments = table === 'comments';
+      process.stdout.write(`Processing ${table} starting from ${lastUID}...\n`);
+      let indexed = 0;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        let rows;
+
+        if (isComments) {
+          ({ rows } = await dbAdapter.database.raw(
+            `select uid, post_id as ref_post_id, uid as ref_comment_id, body
+              from ${table} where uid > :lastUID order by uid limit :batchSize`,
+            { lastUID, batchSize },
+          ));
+        } else {
+          ({ rows } = await dbAdapter.database.raw(
+            `select uid, uid as ref_post_id, null as ref_comment_id, body
+              from ${table} where uid > :lastUID order by uid limit :batchSize`,
+            { lastUID, batchSize },
+          ));
+        }
+
+        if (rows.length === 0) {
+          break;
+        }
+
+        const allUUIDs = new Set();
+
+        for (const row of rows) {
+          const uuids = extractUUIDs(row.body);
+
+          for (const uuid of uuids) {
+            allUUIDs.add(uuid);
+          }
+
+          row.uuids = uuids;
+        }
+
+        let attemptsLeft = retries;
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const start = Date.now();
+
+          try {
+            await dbAdapter.database.transaction(async (trx) => {
+              // Cannot use placeholder here: Postgres doesn't allow prepared statements for 'set'
+              await trx.raw(`set local statement_timeout to '${timeout.replace(/'/g, `''`)}'`);
+
+              // Only the real post UUIDs
+              const realUUIDs = new Set(
+                await dbAdapter.database.getCol(`select uid from posts where uid = any(:uuids)`, {
+                  uuids: [...allUUIDs],
+                }),
+              );
+
+              await trx.raw(
+                `create temp table b_data (post_id uuid, ref_post_id uuid, ref_comment_id uuid) on commit drop`,
+              );
+              const toInsert = [];
+
+              for (const row of rows) {
+                const uuids = row.uuids.filter((u) => realUUIDs.has(u));
+
+                for (const uuid of uuids) {
+                  toInsert.push({ ...row, post_id: uuid });
+                }
+              }
+
+              await trx('b_data').insert(toInsert);
+
+              await trx.raw(
+                `insert into backlinks (post_id, ref_post_id, ref_comment_id)
+                select * from b_data
+                on conflict do nothing`,
+              );
+            });
+
+            indexed += rows.length;
+            lastUID = rows[rows.length - 1].uid;
+
+            const percent = (parseInt(lastUID.substr(0, 2), 16) * 100) >> 8;
+            const speed = Math.round((batchSize * 1000) / (Date.now() - start));
+            process.stdout.write(
+              `\tprocessed ${indexed} ${table} at ${speed} upd/sec (${percent}% of total)\n`,
+            );
+
+            await saveStatus(lastUID, table);
+
+            break;
+          } catch (e) {
+            if (e.code === '57014' /* query_canceled */ && attemptsLeft > 0) {
+              process.stdout.write(`\tquery canceled at ${Date.now() - start} ms, retrying...\n`);
+              attemptsLeft--;
+            } else {
+              throw e;
+            }
+          }
+
+          await new Promise((resolve) => setTimeout(resolve, 1000 * delay));
+        }
+      }
+
+      process.stdout.write(`Done with ${table}.\n`);
+
+      table = allTables[allTables.indexOf(table) + 1];
+      lastUID = ZERO_UID;
+    }
+
+    process.stdout.write(`All tables were processed.\n`);
+    process.stdout.write(`Starting 'VACUUM ANALYZE backlinks'...\n`);
+    await dbAdapter.database.raw(`vacuum analyze backlinks`);
+    process.stdout.write(`Done.\n`);
+    await fs.unlink(statusFile);
+
+    process.exit(0);
+  } catch (e) {
+    process.stderr.write(`⛔ ERROR: ${e.message}\n`);
+    process.exit(1);
+  }
+})();
+
+async function saveStatus(lastUID, table) {
+  await fs.mkdir(path.dirname(statusFile), { recursive: true });
+  await fs.writeFile(statusFile, JSON.stringify({ lastUID, table }));
+}

--- a/migrations/20211121125243_backlinks_table.js
+++ b/migrations/20211121125243_backlinks_table.js
@@ -1,0 +1,29 @@
+export const up = (knex) =>
+  knex.schema.raw(`do $$begin
+  create table backlinks (
+    -- Mentioned post
+    post_id uuid not null references posts (uid) on delete cascade on update cascade,
+    
+    -- Post that mention the post_id
+    ref_post_id uuid not null references posts (uid) on delete cascade on update cascade,
+
+    -- Comment that mention the post_id
+    -- If it is NULL, then the mention is in the post body
+    ref_comment_id uuid references comments (uid) on delete cascade on update cascade
+  );
+
+  -- Covers the whole table and checks the uniqueness of mentions in comments
+  -- It doesn't check uniqueness when ref_comment_id is NULL
+  create unique index backlinks_ids_idx on backlinks 
+    (post_id, ref_post_id, ref_comment_id);
+
+  -- Checks the uniqueness of mentions in post bodies
+  create unique index backlinks_post_ids_idx on backlinks 
+    (post_id, ref_post_id)
+    where ref_comment_id is null;
+end$$`);
+
+export const down = (knex) =>
+  knex.schema.raw(`do $$begin
+    drop table backlinks;
+end$$`);

--- a/test/functional/backlinks.js
+++ b/test/functional/backlinks.js
@@ -22,7 +22,7 @@ import {
 } from './functional_test_helper';
 import Session from './realtime-session';
 
-xdescribe('Backlinks in API output', () => {
+describe('Backlinks in API output', () => {
   let luna, mars;
   let lunaPostId, marsPostId;
 
@@ -78,7 +78,7 @@ xdescribe('Backlinks in API output', () => {
   });
 });
 
-xdescribe('Backlinks in realtime', () => {
+describe('Backlinks in realtime', () => {
   let luna, mars;
   let lunaSession;
 


### PR DESCRIPTION
The backlinks logic was rewritten to use a separate table for backlinks information. You must run `yarn babel bin/reindex_backlinks.js` to fill the `backlinks` table by the existing links.