### PR TITLE
Allow users to leave direct posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.104] - Not released
+### Added
+- Any recipient of a direct message (except the author of the message) can now
+  leave the direct, i.e. exclude themselves from direct recipients. Any
+  recipient's comments and likes of the post will not be removed.
+
 ## [1.103.1] - 2021-11-18
 ### Changed
 - Disabled backlinks (performance issues. still)

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -56,6 +56,7 @@ export class Post {
   intId: number;
   userId: UUID;
   body: string;
+  destinationFeedIds: number[];
   destroy(destroyedBy?: User): Promise<void>;
   removeLike(user: User): Promise<boolean>;
   getPostedTo(): Promise<Timeline[]>;

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -64,6 +64,7 @@ export class Post {
   getCreatedBy(): Promise<User>;
   isAuthorOrGroupAdmin(user: User): Promise<boolean>;
   usersCanSee(): Promise<List<UUID>>;
+  removeDirectRecipient(user: User): Promise<boolean>;
 }
 
 export class Timeline {

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -144,6 +144,7 @@ export const appTokensScopes = [
       'POST /v1/posts/:postId/unlike',
       'POST /v2/comments/:commentId/like',
       'POST /v2/comments/:commentId/unlike',
+      'POST /v2/posts/:postId/leave',
     ],
   },
   {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -954,15 +954,19 @@ export function addModel(dbAdapter) {
 
       const userDirectsFeed = await user.getDirectsTimeline();
 
+      // Get realtime parameters before changes
+      const [rooms, usersBeforeIds] = await Promise.all([getRoomsOfPost(this), this.usersCanSee()]);
+
       const ok = await dbAdapter.withdrawPostFromDestFeed(userDirectsFeed?.intId, this.id);
 
       if (!ok) {
+        // Nothing changed
         return false;
       }
 
       await EventService.onDirectLeaved(this.id, user);
 
-      // TODO Sent RT
+      await pubSub.updatePost(this.id, { rooms, usersBeforeIds });
 
       return true;
     }

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -964,7 +964,7 @@ export function addModel(dbAdapter) {
         return false;
       }
 
-      await EventService.onDirectLeaved(this.id, user);
+      await EventService.onDirectLeft(this.id, user);
 
       await pubSub.updatePost(this.id, { rooms, usersBeforeIds });
 

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -960,7 +960,9 @@ export function addModel(dbAdapter) {
         return false;
       }
 
-      // TODO Sent RT and notifications
+      await EventService.onDirectLeaved(this.id, user);
+
+      // TODO Sent RT
 
       return true;
     }

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -296,6 +296,7 @@ export default class PubsubListener {
             eventNames.POST_CREATED,
             payload,
             { post, emitter: this._postEventEmitter },
+            { onlyForUsers: newUsers },
           );
 
           userIds = List.difference(userIds, newUserIds).items;
@@ -317,6 +318,7 @@ export default class PubsubListener {
             intersection(removedUserRooms, rooms),
             eventNames.POST_DESTROYED,
             { meta: { postId: post.id } },
+            { onlyForUsers: removedUsers },
           );
 
           userIds = List.difference(userIds, removedUserIds).items;

--- a/app/routes/api/v2/PostsRoute.js
+++ b/app/routes/api/v2/PostsRoute.js
@@ -1,5 +1,5 @@
 import { getBySeqNumber } from '../../../controllers/api/v1/CommentsController';
-import { show, opengraph, getByIds } from '../../../controllers/api/v2/PostsController';
+import { show, opengraph, getByIds, leave } from '../../../controllers/api/v2/PostsController';
 
 export default function addRoutes(app) {
   app.get('/v2/posts/:postId', show);
@@ -7,4 +7,5 @@ export default function addRoutes(app) {
   app.get('/v2/posts/:postId/comments/:seqNumber', getBySeqNumber);
   // We use POST here because this method can accept many post IDs
   app.post('/v2/posts/byIds', getByIds);
+  app.post('/v2/posts/:postId/leave', leave);
 }

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -123,6 +123,7 @@ export class DbAdapter {
   getTimelinesByIds(ids: UUID[]): Promise<Timeline[]>;
   getAllUserNamedFeed(userId: UUID, feedName: string): Promise<Timeline[]>;
   getUserNamedFeed(userId: UUID, feedName: string): Promise<Nullable<Timeline>>;
+  getTimelinesByIntIds(intIds: number[]): Promise<Timeline[]>;
 
   // App tokens
   createAppToken(token: AppTokenCreateParams): Promise<AppTokenV1>;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -108,6 +108,7 @@ export class DbAdapter {
   getPostsByIds(ids: UUID[]): Promise<Post[]>;
   getPostsByIntIds(ids: number[]): Promise<Post[]>;
   filterSuspendedPosts(ids: UUID[]): Promise<UUID[]>;
+  withdrawPostFromDestFeed(feedIntId: number, postUUID: UUID): Promise<boolean>;
 
   // Comments
   getCommentById(id: UUID): Promise<Comment | null>;

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -134,6 +134,20 @@ const postsTrait = (superClass) =>
       ]);
     }
 
+    withdrawPostFromDestFeed(feedIntId, postUUID) {
+      return this.database.getOne(
+        `update posts set
+          feed_ids = (feed_ids - :feedIntId::int),
+          destination_feed_ids = (destination_feed_ids - :feedIntId::int)
+          where uid = :postUUID and destination_feed_ids @@ :feedIntId
+          returning true`,
+        {
+          feedIntId,
+          postUUID,
+        },
+      );
+    }
+
     /**
      * Withdraw post from the commentator Comments feed
      * if there is not other comments from this commentator.

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -238,12 +238,12 @@ const timelinesPostsTrait = (superClass) =>
       let noDirectsSQL = 'true';
 
       if (viewerId && params.withoutDirects) {
-        // Do not show directs-only messages (any messages posted to the viewer's 'Directs' feed and to ONE other feed)
+        // Do not show direct messages (any messages posted to the viewer's 'Directs' feed)
         const [directsIntId] = await this.database
           .pluck('id')
           .from('feeds')
           .where({ user_id: viewerId, name: 'Directs' });
-        noDirectsSQL = `not (destination_feed_ids && '{${directsIntId}}' and array_length(destination_feed_ids, 1) = 2)`;
+        noDirectsSQL = `not (destination_feed_ids && '{${directsIntId}}')`;
       }
 
       const sourceConditionSQL = timelineIntIds

--- a/app/support/EventService.ts
+++ b/app/support/EventService.ts
@@ -463,6 +463,34 @@ export class EventService {
     await createEvent(fromUserIntId, EVENT_TYPES.INVITATION_USED, newUserIntId, newUserIntId);
   }
 
+  static async onDirectLeaved(postId: UUID, initiator: User) {
+    const post = await dbAdapter.getPostById(postId);
+
+    if (!post) {
+      return;
+    }
+
+    const postFeeds = await dbAdapter.getTimelinesByIntIds(post.destinationFeedIds);
+
+    const participantIds = postFeeds.filter((f) => f.isDirects()).map((f) => f.userId);
+    const participants = await dbAdapter.getUsersByIds(participantIds);
+    const postAuthor = participants.find((u) => u.id === post.userId);
+    await Promise.all(
+      [initiator, ...participants].map((user) =>
+        createEvent(
+          user.intId,
+          EVENT_TYPES.DIRECT_LEAVED,
+          initiator.intId,
+          initiator.intId,
+          null, // Directs haven't groups?
+          postId,
+          null,
+          postAuthor?.intId || null,
+        ),
+      ),
+    );
+  }
+
   ////////////////////////////////////////////
 
   static async _processDirectMessagesForPost(

--- a/app/support/EventService.ts
+++ b/app/support/EventService.ts
@@ -463,7 +463,7 @@ export class EventService {
     await createEvent(fromUserIntId, EVENT_TYPES.INVITATION_USED, newUserIntId, newUserIntId);
   }
 
-  static async onDirectLeaved(postId: UUID, initiator: User) {
+  static async onDirectLeft(postId: UUID, initiator: User) {
     const post = await dbAdapter.getPostById(postId);
 
     if (!post) {
@@ -479,7 +479,7 @@ export class EventService {
       [initiator, ...participants].map((user) =>
         createEvent(
           user.intId,
-          EVENT_TYPES.DIRECT_LEAVED,
+          EVENT_TYPES.DIRECT_LEFT,
           initiator.intId,
           initiator.intId,
           null, // Directs haven't groups?

--- a/app/support/EventTypes.ts
+++ b/app/support/EventTypes.ts
@@ -25,6 +25,7 @@ export const EVENT_TYPES = {
   GROUP_ADMIN_DEMOTED: 'group_admin_demoted',
   DIRECT_CREATED: 'direct',
   DIRECT_COMMENT_CREATED: 'direct_comment',
+  DIRECT_LEAVED: 'direct_leaved',
 
   MANAGED_GROUP_SUBSCRIPTION_APPROVED: 'managed_group_subscription_approved',
   MANAGED_GROUP_SUBSCRIPTION_REJECTED: 'managed_group_subscription_rejected',

--- a/app/support/EventTypes.ts
+++ b/app/support/EventTypes.ts
@@ -25,7 +25,7 @@ export const EVENT_TYPES = {
   GROUP_ADMIN_DEMOTED: 'group_admin_demoted',
   DIRECT_CREATED: 'direct',
   DIRECT_COMMENT_CREATED: 'direct_comment',
-  DIRECT_LEAVED: 'direct_leaved',
+  DIRECT_LEFT: 'direct_left',
 
   MANAGED_GROUP_SUBSCRIPTION_APPROVED: 'managed_group_subscription_approved',
   MANAGED_GROUP_SUBSCRIPTION_REJECTED: 'managed_group_subscription_rejected',

--- a/migrations/20211124192043_direct_leaved_event.js
+++ b/migrations/20211124192043_direct_leaved_event.js
@@ -40,7 +40,7 @@ export const up = (knex) =>
       'backlink_in_comment'::text,
 
       -- NEW LINES --
-      'direct_leaved'::text
+      'direct_left'::text
     ]));
 end$$`);
 

--- a/migrations/20211124192043_direct_leaved_event.js
+++ b/migrations/20211124192043_direct_leaved_event.js
@@ -1,0 +1,87 @@
+export const up = (knex) =>
+  knex.schema.raw(`do $$begin
+  -- Add new event types
+  ALTER TABLE events DROP CONSTRAINT events_event_type_check;
+  ALTER TABLE events
+    ADD CONSTRAINT events_event_type_check CHECK (event_type = ANY (ARRAY[
+      'mention_in_post'::text,
+      'mention_in_comment'::text,
+      'mention_comment_to'::text,
+      'banned_user'::text,
+      'unbanned_user'::text,
+      'banned_by_user'::text,
+      'unbanned_by_user'::text,
+      'subscription_requested'::text,
+      'subscription_request_revoked'::text,
+      'user_subscribed'::text,
+      'user_unsubscribed'::text,
+      'subscription_request_approved'::text,
+      'subscription_request_rejected'::text,
+      'group_created'::text,
+      'group_subscription_requested'::text,
+      'group_subscription_request_revoked'::text,
+      'group_subscription_rejected'::text,
+      'group_subscribed'::text,
+      'group_unsubscribed'::text,
+      'group_admin_promoted'::text,
+      'group_admin_demoted'::text,
+      'group_subscription_approved'::text,
+      'group_subscription_rejected'::text,
+      'direct'::text,
+      'direct_comment'::text,
+      'managed_group_subscription_approved'::text,
+      'managed_group_subscription_rejected'::text,
+      'comment_moderated'::text,
+      'comment_moderated_by_another_admin'::text,
+      'post_moderated'::text,
+      'post_moderated_by_another_admin'::text,
+      'invitation_used'::text,
+      'backlink_in_post'::text,
+      'backlink_in_comment'::text,
+
+      -- NEW LINES --
+      'direct_leaved'::text
+    ]));
+end$$`);
+
+export const down = (knex) =>
+  knex.schema.raw(`do $$begin
+  ALTER TABLE events DROP CONSTRAINT events_event_type_check;
+  ALTER TABLE events
+    ADD CONSTRAINT events_event_type_check CHECK (event_type = ANY (ARRAY[
+      'mention_in_post'::text,
+      'mention_in_comment'::text,
+      'mention_comment_to'::text,
+      'banned_user'::text,
+      'unbanned_user'::text,
+      'banned_by_user'::text,
+      'unbanned_by_user'::text,
+      'subscription_requested'::text,
+      'subscription_request_revoked'::text,
+      'user_subscribed'::text,
+      'user_unsubscribed'::text,
+      'subscription_request_approved'::text,
+      'subscription_request_rejected'::text,
+      'group_created'::text,
+      'group_subscription_requested'::text,
+      'group_subscription_request_revoked'::text,
+      'group_subscription_rejected'::text,
+      'group_subscribed'::text,
+      'group_unsubscribed'::text,
+      'group_admin_promoted'::text,
+      'group_admin_demoted'::text,
+      'group_subscription_approved'::text,
+      'group_subscription_rejected'::text,
+      'direct'::text,
+      'direct_comment'::text,
+      'managed_group_subscription_approved'::text,
+      'managed_group_subscription_rejected'::text,
+      'comment_moderated'::text,
+      'comment_moderated_by_another_admin'::text,
+      'post_moderated'::text,
+      'post_moderated_by_another_admin'::text,
+      'invitation_used'::text,
+      'backlink_in_post'::text,
+      'backlink_in_comment'::text
+    ]));
+end$$`);

--- a/test/functional/posts/leave-direct.js
+++ b/test/functional/posts/leave-direct.js
@@ -1,0 +1,179 @@
+/* eslint-env node, mocha */
+/* global $database, $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../../dbCleaner';
+import { getSingleton } from '../../../app/app';
+import { PubSubAdapter } from '../../../app/support/PubSubAdapter';
+import { PubSub } from '../../../app/models';
+import {
+  authHeaders,
+  createAndReturnPostToFeed,
+  createTestUsers,
+  mutualSubscriptions,
+  performJSONRequest,
+} from '../functional_test_helper';
+import Session from '../realtime-session';
+
+describe('POST /v2/posts/:postId/leave', () => {
+  let luna, mars, venus, jupiter;
+  beforeEach(async () => {
+    await cleanDB($pg_database);
+
+    [luna, mars, venus, jupiter] = await createTestUsers(['luna', 'mars', 'venus', 'jupiter']);
+    await mutualSubscriptions([luna, mars, venus, jupiter]);
+  });
+
+  describe('Luna create direct with Mars and Venus', () => {
+    let post;
+    beforeEach(async () => {
+      post = await createAndReturnPostToFeed([mars.user, venus.user], luna, 'Hello');
+    });
+
+    it('should allow Mars to leave direct', async () => {
+      const resp = await leave(post, mars);
+      expect(resp, 'to satisfy', { __httpCode: 200 });
+    });
+
+    it('should allow Venus to leave direct', async () => {
+      const resp = await leave(post, mars);
+      expect(resp, 'to satisfy', { __httpCode: 200 });
+    });
+
+    it('should not allow Luna to leave direct', async () => {
+      const resp = await leave(post, luna);
+      expect(resp, 'to satisfy', { __httpCode: 403 });
+    });
+
+    it('should not allow Jupiter to leave direct', async () => {
+      const resp = await leave(post, jupiter);
+      expect(resp, 'to satisfy', { __httpCode: 403 });
+    });
+
+    it('should not allow anonymous to leave direct', async () => {
+      const resp = await leave(post, null);
+      expect(resp, 'to satisfy', { __httpCode: 401 });
+    });
+
+    describe('Mars leaving direct', () => {
+      beforeEach(() => leave(post, mars));
+
+      it('should not allow Mars to see post', async () => {
+        const resp = await getPost(post, mars);
+        expect(resp, 'to satisfy', { __httpCode: 403 });
+      });
+
+      it('should allow Luna to see post', async () => {
+        const resp = await getPost(post, luna);
+        expect(resp, 'to satisfy', { __httpCode: 200 });
+      });
+
+      it('should allow Venus to see post', async () => {
+        const resp = await getPost(post, venus);
+        expect(resp, 'to satisfy', { __httpCode: 200 });
+      });
+
+      it(`should show post in Luna's homefdeed`, async () => {
+        const resp = await getHome(luna);
+        expect(resp, 'to satisfy', { timelines: { posts: [post.id] } });
+      });
+
+      it(`should show post in Venuses homefdeed`, async () => {
+        const resp = await getHome(venus);
+        expect(resp, 'to satisfy', { timelines: { posts: [post.id] } });
+      });
+
+      it(`should not show post in Marses homefdeed`, async () => {
+        const resp = await getHome(mars);
+        expect(resp, 'to satisfy', { timelines: { posts: [] } });
+      });
+    });
+
+    describe('Mars and Venus leaving direct', () => {
+      beforeEach(async () => {
+        await leave(post, mars);
+        await leave(post, venus);
+      });
+
+      it('should not allow Mars to see post', async () => {
+        const resp = await getPost(post, mars);
+        expect(resp, 'to satisfy', { __httpCode: 403 });
+      });
+
+      it('should allow Luna to see post', async () => {
+        const resp = await getPost(post, luna);
+        expect(resp, 'to satisfy', { __httpCode: 200 });
+      });
+
+      it('should not allow Venus to see post', async () => {
+        const resp = await getPost(post, venus);
+        expect(resp, 'to satisfy', { __httpCode: 403 });
+      });
+
+      it(`should show post in Luna's homefdeed`, async () => {
+        const resp = await getHome(luna);
+        expect(resp, 'to satisfy', { timelines: { posts: [post.id] } });
+      });
+
+      it(`should not show post in Venuses homefdeed`, async () => {
+        const resp = await getHome(venus);
+        expect(resp, 'to satisfy', { timelines: { posts: [] } });
+      });
+
+      it(`should not show post in Marses homefdeed`, async () => {
+        const resp = await getHome(mars);
+        expect(resp, 'to satisfy', { timelines: { posts: [] } });
+      });
+    });
+
+    xdescribe('Realtime', () => {
+      let port;
+
+      before(async () => {
+        const app = await getSingleton();
+        port = process.env.PEPYATKA_SERVER_PORT || app.context.config.port;
+        const pubsubAdapter = new PubSubAdapter($database);
+        PubSub.setPublisher(pubsubAdapter);
+      });
+
+      let lunaSession, marsSession;
+
+      beforeEach(async () => {
+        [lunaSession, marsSession] = await Promise.all([
+          Session.create(port, 'Luna session'),
+          Session.create(port, 'Mars session'),
+        ]);
+
+        await Promise.all([
+          lunaSession.sendAsync('auth', { authToken: luna.authToken }),
+          marsSession.sendAsync('auth', { authToken: mars.authToken }),
+        ]);
+
+        await Promise.all([
+          lunaSession.sendAsync('subscribe', { post: [post.id] }),
+          marsSession.sendAsync('subscribe', { post: [post.id] }),
+        ]);
+      });
+
+      afterEach(() => [lunaSession, marsSession].forEach((s) => s.disconnect()));
+
+      it(`should deliver 'post:destroy' event to Mars when he leaves post`, async () => {
+        const test = marsSession.receiveWhile('post:destroy', () => leave(post, mars));
+        await expect(test, 'to be fulfilled with', { meta: { postId: post.id } });
+      });
+
+      it(`should not deliver 'post:destroy' event to Luna when Mars leaves post`, async () => {
+        const test = lunaSession.notReceiveWhile('post:destroy', () => leave(post, mars));
+        await expect(test, 'to be fulfilled');
+      });
+    });
+  });
+});
+
+const leave = (post, ctx) =>
+  performJSONRequest('POST', `/v2/posts/${post.id}/leave`, {}, authHeaders(ctx));
+
+const getPost = (post, ctx) =>
+  performJSONRequest('GET', `/v2/posts/${post.id}`, null, authHeaders(ctx));
+
+const getHome = (ctx) => performJSONRequest('GET', `/v2/timelines/home`, null, authHeaders(ctx));

--- a/test/functional/posts/posts.js
+++ b/test/functional/posts/posts.js
@@ -5,12 +5,11 @@ import _ from 'lodash';
 import fetch from 'node-fetch';
 import expect from 'unexpected';
 
-import cleanDB from '../dbCleaner';
-import { getSingleton } from '../../app/app';
-import { DummyPublisher } from '../../app/pubsub';
-import { PubSub } from '../../app/models';
-
-import * as funcTestHelper from './functional_test_helper';
+import cleanDB from '../../dbCleaner';
+import { getSingleton } from '../../../app/app';
+import { DummyPublisher } from '../../../app/pubsub';
+import { PubSub } from '../../../app/models';
+import * as funcTestHelper from '../functional_test_helper';
 
 describe('PostsController', () => {
   let app;

--- a/test/functional/posts/postsV2.js
+++ b/test/functional/posts/postsV2.js
@@ -3,11 +3,10 @@
 import fetch from 'node-fetch';
 import expect from 'unexpected';
 
-import cleanDB from '../dbCleaner';
-import { getSingleton } from '../../app/app';
-import { DummyPublisher } from '../../app/pubsub';
-import { PubSub } from '../../app/models';
-
+import cleanDB from '../../dbCleaner';
+import { getSingleton } from '../../../app/app';
+import { DummyPublisher } from '../../../app/pubsub';
+import { PubSub } from '../../../app/models';
 import {
   createUserAsync,
   createAndReturnPost,
@@ -28,8 +27,8 @@ import {
   sendRequestToSubscribe,
   acceptRequestToSubscribe,
   banUser,
-} from './functional_test_helper';
-import { postsByIdsResponse } from './schemaV2-helper';
+} from '../functional_test_helper';
+import { postsByIdsResponse } from '../schemaV2-helper';
 
 describe('TimelinesControllerV2', () => {
   let app;

--- a/test/integration/models/post/removeDirectRecipient.js
+++ b/test/integration/models/post/removeDirectRecipient.js
@@ -1,0 +1,100 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import { dbAdapter, Post, User } from '../../../../app/models';
+import cleanDB from '../../../dbCleaner';
+
+describe('Post removeDirectRecipient method', () => {
+  let /** @type {User} */
+    luna,
+    /** @type {User} */
+    mars,
+    /** @type {User} */
+    venus,
+    /** @type {Post} */
+    post;
+
+  beforeEach(() => cleanDB($pg_database));
+  beforeEach(async () => {
+    luna = new User({ username: 'Luna', password: 'password' });
+    mars = new User({ username: 'Mars', password: 'password' });
+    venus = new User({ username: 'Venus', password: 'password' });
+    await Promise.all([luna.create(), mars.create(), venus.create()]);
+  });
+
+  describe('Luna writes direct post to Mars', () => {
+    beforeEach(async () => {
+      await Promise.all([mars.subscribeTo(luna), luna.subscribeTo(mars)]);
+      const [lunaDirectFeed, marsDirectFeed] = await Promise.all([
+        luna.getDirectsTimeline(),
+        mars.getDirectsTimeline(),
+      ]);
+      post = new Post({
+        body: 'Post body',
+        userId: luna.id,
+        timelineIds: [lunaDirectFeed.id, marsDirectFeed.id],
+      });
+      await post.create();
+    });
+
+    it('should allow Mars to leave post', async () => {
+      const ok = await post.removeDirectRecipient(mars);
+      expect(ok, 'to be true');
+
+      const updatedPost = await dbAdapter.getPostById(post.id);
+      expect(updatedPost.destinationFeedIds, 'to have length', 1);
+
+      const visible = await updatedPost.isVisibleFor(mars);
+      expect(visible, 'to be false');
+    });
+
+    it('should not allow Luna to leave post', async () => {
+      const ok = await post.removeDirectRecipient(luna);
+      expect(ok, 'to be false');
+
+      const updatedPost = await dbAdapter.getPostById(post.id);
+      expect(updatedPost.destinationFeedIds, 'to have length', 2);
+    });
+
+    it('should not allow Venus to leave post', async () => {
+      const ok = await post.removeDirectRecipient(venus);
+      expect(ok, 'to be false');
+
+      const updatedPost = await dbAdapter.getPostById(post.id);
+      expect(updatedPost.destinationFeedIds, 'to have length', 2);
+    });
+  });
+
+  describe('Luna writes direct post to Mars and Venus', () => {
+    beforeEach(async () => {
+      await Promise.all([mars.subscribeTo(luna), luna.subscribeTo(mars)]);
+      const [lunaDirectFeed, marsDirectFeed, venusDirectFeed] = await Promise.all([
+        luna.getDirectsTimeline(),
+        mars.getDirectsTimeline(),
+        venus.getDirectsTimeline(),
+      ]);
+      post = new Post({
+        body: 'Post body',
+        userId: luna.id,
+        timelineIds: [lunaDirectFeed.id, marsDirectFeed.id, venusDirectFeed.id],
+      });
+      await post.create();
+    });
+
+    it('should allow Mars and Venus to simultaneously leave post', async () => {
+      const [ok1, ok2] = await Promise.all([
+        post.removeDirectRecipient(mars),
+        post.removeDirectRecipient(venus),
+      ]);
+      expect(ok1, 'to be true');
+      expect(ok2, 'to be true');
+
+      const updatedPost = await dbAdapter.getPostById(post.id);
+      expect(updatedPost.destinationFeedIds, 'to have length', 1);
+
+      expect(await updatedPost.isVisibleFor(mars), 'to be false');
+      expect(await updatedPost.isVisibleFor(venus), 'to be false');
+    });
+  });
+});

--- a/test/integration/models/post/removeDirectRecipient.js
+++ b/test/integration/models/post/removeDirectRecipient.js
@@ -106,25 +106,25 @@ describe('Post removeDirectRecipient method', () => {
         beforeEach(
           () =>
             (expectedEvent = {
-              event_type: EVENT_TYPES.DIRECT_LEAVED,
+              event_type: EVENT_TYPES.DIRECT_LEFT,
               created_by_user_id: mars.intId,
               target_user_id: mars.intId,
               post_id: post.intId,
             }),
         );
 
-        it(`should send "${EVENT_TYPES.DIRECT_LEAVED}" notification to Luna`, async () => {
-          const events = await dbAdapter.getUserEvents(luna.intId, [EVENT_TYPES.DIRECT_LEAVED]);
+        it(`should send "${EVENT_TYPES.DIRECT_LEFT}" notification to Luna`, async () => {
+          const events = await dbAdapter.getUserEvents(luna.intId, [EVENT_TYPES.DIRECT_LEFT]);
           expect(events, 'to satisfy', [{ ...expectedEvent, user_id: luna.intId }]);
         });
 
-        it(`should send "${EVENT_TYPES.DIRECT_LEAVED}" notification to Mars`, async () => {
-          const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.DIRECT_LEAVED]);
+        it(`should send "${EVENT_TYPES.DIRECT_LEFT}" notification to Mars`, async () => {
+          const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.DIRECT_LEFT]);
           expect(events, 'to satisfy', [{ ...expectedEvent, user_id: mars.intId }]);
         });
 
-        it(`should send "${EVENT_TYPES.DIRECT_LEAVED}" notification to Venus`, async () => {
-          const events = await dbAdapter.getUserEvents(venus.intId, [EVENT_TYPES.DIRECT_LEAVED]);
+        it(`should send "${EVENT_TYPES.DIRECT_LEFT}" notification to Venus`, async () => {
+          const events = await dbAdapter.getUserEvents(venus.intId, [EVENT_TYPES.DIRECT_LEFT]);
           expect(events, 'to satisfy', [{ ...expectedEvent, user_id: venus.intId }]);
         });
       });


### PR DESCRIPTION
Any recipient of a direct message (except the author of the message) can now leave the direct, i.e. exclude themselves from direct recipients. Any recipient's comments and likes of the post will not be removed.