### PR TITLE
Add the `GET /v2/attachments/my` API method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.105.0] - Not released
+### Added
+- The new API method, `GET /v2/attachments/my` returns all attachments created
+  by the current user, paginated and in the reverse date order. 
+  
+  This method accepts two URL parameters: _limit_ (default: 30, maximum: 100)
+  and _page_ (1-based, default: 1). The result format is { attachments:
+  AttObject[], users: UserObject[], hasMore: boolean }.
+- The new API token scope: `read-my-files`. For now it contains only one method:
+  `GET /v2/attachments/my`
+
+### Changed
+- The serialized attachments now have an additional field _postId_. This field
+  is either _null_ or the UUID of the post to which the file is attached.
+
 ## [1.104.2] - 2021-12-13
 ### Fixed
 - Allow to edit direct message without recipients.

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -71,6 +71,11 @@ export const appTokensScopes = [
     ],
   },
   {
+    name: 'read-my-files',
+    title: 'Read information about my uploaded files',
+    routes: ['GET /v2/attachments/my'],
+  },
+  {
     name: 'read-feeds',
     title: 'Read feeds, including my feeds and direct messages',
     routes: [

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,6 +2,7 @@
 import Router from '@koa/router';
 
 import AttachmentsRoute from './routes/api/v1/AttachmentsRoute';
+import AttachmentsRouteV2 from './routes/api/v2/AttachmentsRoute';
 import BookmarkletRoute from './routes/api/v1/BookmarkletRoute';
 import CommentsRoute from './routes/api/v1/CommentsRoute';
 import GroupsRoute from './routes/api/v1/GroupsRoute';
@@ -93,6 +94,7 @@ export function createRouter() {
   AppTokensRoute(router);
   ServerInfoRoute(router);
   ExtAuthRoute(router);
+  AttachmentsRouteV2(router);
 
   return router;
 }

--- a/app/routes/api/v2/AttachmentsRoute.js
+++ b/app/routes/api/v2/AttachmentsRoute.js
@@ -1,0 +1,7 @@
+import { AttachmentsController } from '../../../controllers';
+
+export default function addRoutes(app) {
+  const controller = new AttachmentsController(app);
+
+  app.get('/v2/attachments/my', controller.my);
+}

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -40,6 +40,7 @@ export function serializeAttachment(att) {
       ...(att.mediaType === 'audio' ? ['artist', 'title'] : []),
     ]),
     createdBy: att.userId,
+    postId: att.postId || null,
   };
   return result;
 }

--- a/app/support/DbAdapter/attachments.js
+++ b/app/support/DbAdapter/attachments.js
@@ -36,6 +36,17 @@ const attachmentsTrait = (superClass) =>
       return responses.map(initAttachmentObject);
     }
 
+    async listAttachments({ userId, limit, offset = 0 }) {
+      const rows = await this.database.getAll(
+        `select * from attachments where 
+          user_id = :userId 
+          order by created_at desc limit :limit offset :offset`,
+        { userId, limit, offset },
+      );
+
+      return rows.map(initAttachmentObject);
+    }
+
     updateAttachment(attachmentId, payload) {
       const preparedPayload = prepareModelPayload(
         payload,

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -51,6 +51,12 @@ export type EventRecord = {
   target_comment_id: Nullable<UUID>;
 };
 
+type ListAttachmentsOptions = { userId: UUID; limit: number } & (
+  | { createdBefore?: string }
+  | { createdAfter: string }
+  | { offset: number }
+);
+
 export class DbAdapter {
   constructor(connection: Knex);
 
@@ -118,6 +124,7 @@ export class DbAdapter {
 
   // Attachments
   getAttachmentById(id: UUID): Promise<Attachment | null>;
+  listAttachments(options: ListAttachmentsOptions): Promise<Attachment[]>;
 
   // Timelines
   getTimelinesByIds(ids: UUID[]): Promise<Timeline[]>;

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -226,6 +226,7 @@ const attachmentCommons = {
   createdAt: expect.it('to be timeStampString'),
   updatedAt: expect.it('to be timeStampString'),
   createdBy: expect.it('to be UUID'),
+  postId: expect.it('to be null').or('to be UUID'),
   mediaType: expect.it('to be one of', ['image', 'audio', 'general']),
   fileName: expect.it('to be a string'),
   fileSize: expect.it('to be a string').and('to match', /^\d+$/),

--- a/test/integration/models/attachments-list.js
+++ b/test/integration/models/attachments-list.js
@@ -1,0 +1,54 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import { dbAdapter, User } from '../../../app/models';
+import cleanDB from '../../dbCleaner';
+
+import { createAttachment } from './attachment-helpers';
+
+describe('listAttachments', () => {
+  before(() => cleanDB($pg_database));
+
+  let luna;
+  before(async () => {
+    luna = new User({ username: 'luna', password: 'pw' });
+    await luna.create();
+  });
+
+  describe('Luna creates some attachments', () => {
+    const allAttachments = [];
+    before(async () => {
+      const N = 10;
+
+      for (let i = 0; i < N; i++) {
+        allAttachments.push(
+          // eslint-disable-next-line no-await-in-loop
+          await createAttachment(luna.id, { name: `att${i + 1}`, content: 'bar' }),
+        );
+      }
+    });
+
+    it(`should list the latest attachments`, async () => {
+      const atts = await dbAdapter.listAttachments({ userId: luna.id, limit: 3 });
+      expect(atts, 'to satisfy', [
+        { fileName: 'att10' },
+        { fileName: 'att9' },
+        { fileName: 'att8' },
+      ]);
+    });
+
+    it(`should list attachments with offset`, async () => {
+      const atts = await dbAdapter.listAttachments({
+        userId: luna.id,
+        limit: 3,
+        offset: 2,
+      });
+      expect(atts, 'to satisfy', [
+        { fileName: 'att8' },
+        { fileName: 'att7' },
+        { fileName: 'att6' },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
### Added
- The new API method, `GET /v2/attachments/my` returns all attachments created by the current user, paginated and in the reverse date order. 
  
  This method accepts two URL parameters: _limit_ (default: 30, maximum: 100) and _page_ (1-based, default: 1). The result format is { attachments: AttObject[], users: UserObject[], hasMore: boolean }.
- The new API token scope: `read-my-files`. For now it contains only one method: `GET /v2/attachments/my`

### Changed
- The serialized attachments now have an additional field _postId_. This field is either _null_ or the UUID of the post to which the file is attached.
