### PR TITLE
Fix the post with empty body moderation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.105.0] - Not released
+### Fixed
+- A group administrator could not delete a message with an empty body (and with
+  attachments) from a managed group.
+
 ## [1.104.2] - 2021-12-13
 ### Fixed
 - Allow to edit direct message without recipients.

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -19,8 +19,12 @@ import {
 /**
  * @typedef { import("../models").User } User
  * @typedef { import("../models").Timeline } Timeline
+ * @typedef { import("../support/DbAdapter").DbAdapter } DbAdapter
  */
 
+/**
+ * @param {DbAdapter} dbAdapter
+ */
 export function addModel(dbAdapter) {
   class Post {
     id;
@@ -204,13 +208,15 @@ export function addModel(dbAdapter) {
         );
       }
 
+      // Actualize this.attachments field
+      await this.getAttachmentIds();
+
       let newAttachments = undefined;
 
       if (params.attachments != null) {
         // Calculate changes in attachments
-        const oldAttachments = (await this.getAttachmentIds()) || [];
         newAttachments = params.attachments || [];
-        const removedAttachments = _.difference(oldAttachments, newAttachments);
+        const removedAttachments = _.difference(this.attachments, newAttachments);
 
         // Update post attachments in DB
         afterUpdate.push(() => this.linkAttachments(newAttachments));
@@ -654,8 +660,8 @@ export function addModel(dbAdapter) {
     }
 
     async getAttachmentIds() {
-      this.attachmentIds = await dbAdapter.getPostAttachments(this.id);
-      return this.attachmentIds;
+      this.attachments = await dbAdapter.getPostAttachments(this.id);
+      return this.attachments;
     }
 
     async getAttachments() {

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -118,6 +118,7 @@ export class DbAdapter {
 
   // Attachments
   getAttachmentById(id: UUID): Promise<Attachment | null>;
+  getPostAttachments(id: UUID): Promise<UUID[]>;
 
   // Timelines
   getTimelinesByIds(ids: UUID[]): Promise<Timeline[]>;

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -26,6 +26,8 @@ import {
   mutualSubscriptions,
   performJSONRequest,
   authHeaders,
+  createMockAttachmentAsync,
+  updatePostAsync,
 } from './functional_test_helper';
 import Session from './realtime-session';
 
@@ -579,6 +581,23 @@ describe('Group Moderation', () => {
               });
             });
           });
+        });
+      });
+
+      describe('Moderate post without body and with attachment', () => {
+        beforeEach(async () => {
+          const att = await createMockAttachmentAsync(luna);
+          luna.post = await createAndReturnPostToFeed([celestials, luna], luna, 'Body');
+          await updatePostAsync(luna, {
+            body: '',
+            attachments: [att.id],
+          });
+        });
+
+        it(`should allow Mars to remove Luna's post from group`, async () => {
+          const response = await deletePostAsync(mars, luna.post.id);
+          expect(response.__httpCode, 'to be', 200);
+          expect(response, 'to satisfy', { postStillAvailable: true });
         });
       });
     });


### PR DESCRIPTION
A group administrator could not delete a message with an empty body (and with attachments) from a managed group.