### PR TITLE
Rewrite the password reset logic, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.106.0] - Not released
+## Changed
+- Reduced the password reset token length to 12 bytes. Perhaps enormous tokens
+  (48 bytes = 96 hexadecimal characters) were broken in the email texts. Also
+  reduced the TTL of the token from several years :) to 8 hours.
+
 ## [1.105.0] - 2022-01-05
 ### Fixed
 - A group administrator could not delete a message with an empty body (and with

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -230,13 +230,9 @@ export function addModel(dbAdapter) {
     }
 
     async updateResetPasswordToken() {
-      const now = new Date().getTime();
       const token = await this.generateResetPasswordToken();
 
-      const payload = {
-        resetPasswordToken: token,
-        resetPasswordSentAt: now,
-      };
+      const payload = { resetPasswordToken: token };
 
       await dbAdapter.updateUser(this.id, payload);
 
@@ -245,8 +241,8 @@ export function addModel(dbAdapter) {
     }
 
     async generateResetPasswordToken() {
-      const buf = await randomBytes(48);
-      return buf.toString('hex');
+      const buf = await randomBytes(config.passwordReset.tokenBytesLength);
+      return buf.toString('base64').replace(/\W/g, '');
     }
 
     validPassword(clearPassword) {

--- a/config/default.js
+++ b/config/default.js
@@ -333,4 +333,9 @@ config.maxLength = {
   description: 1500,
 };
 
+config.passwordReset = {
+  tokenBytesLength: 12,
+  tokenTTL: 8 * 3600, // in seconds
+};
+
 module.exports = config;

--- a/test/functional/passwords.js
+++ b/test/functional/passwords.js
@@ -1,11 +1,13 @@
 /* eslint-env node, mocha */
 /* global $pg_database */
+import expect from 'unexpected';
+
 import cleanDB from '../dbCleaner';
 import { getSingleton } from '../../app/app';
 import { DummyPublisher } from '../../app/pubsub';
 import { PubSub } from '../../app/models';
 
-import * as funcTestHelper from './functional_test_helper';
+import { createUserAsync, performJSONRequest, updateUserAsync } from './functional_test_helper';
 
 describe('PasswordsController', () => {
   before(async () => {
@@ -16,77 +18,73 @@ describe('PasswordsController', () => {
   beforeEach(() => cleanDB($pg_database));
 
   describe('#create()', () => {
-    let context = {};
+    let luna;
     const oldEmail = 'test@example.com';
 
     beforeEach(async () => {
-      context = await funcTestHelper.createUserAsync('Luna', 'password', { email: oldEmail });
+      luna = await createUserAsync('Luna', 'password', { email: oldEmail });
     });
 
     it('should require email', async () => {
-      const response = await funcTestHelper.sendResetPassword('');
-      response.status.should.equal(400);
-
-      const data = await response.json();
-      data.should.have.property('err');
-      data.err.should.eql('Email cannot be blank');
+      const resp = await performJSONRequest('POST', '/v1/passwords', { email: '' });
+      expect(resp, 'to satisfy', { __httpCode: 400, err: 'Email cannot be blank' });
     });
 
     it('should generate resetToken by original email of user', async () => {
-      const response = await funcTestHelper.sendResetPassword(oldEmail);
-      response.status.should.equal(200);
-
-      const data = await response.json();
-      data.should.have.property('message');
-      data.message.should.eql(`Password reset link has been sent to ${oldEmail}`);
+      const resp = await performJSONRequest('POST', '/v1/passwords', { email: oldEmail });
+      expect(resp, 'to satisfy', {
+        __httpCode: 200,
+        message: `Password reset link has been sent to ${oldEmail}`,
+      });
     });
 
     it('should generate resetToken by new email of user', async () => {
       const email = 'luna@example.com';
 
-      await funcTestHelper.updateUserAsync(context, { email });
+      await updateUserAsync(luna, { email });
 
-      const errResponse = await funcTestHelper.sendResetPassword(oldEmail);
-      errResponse.status.should.equal(404);
+      {
+        const resp = await performJSONRequest('POST', '/v1/passwords', { email: oldEmail });
+        expect(resp, 'to satisfy', { __httpCode: 404 });
+      }
 
-      const response = await funcTestHelper.sendResetPassword(email);
-      response.status.should.equal(200, `failed to reset password for ${email} email`);
-
-      const data = await response.json();
-      data.should.have.property('message');
-      data.message.should.eql(`Password reset link has been sent to ${email}`);
+      {
+        const resp = await performJSONRequest('POST', '/v1/passwords', { email });
+        expect(resp, 'to satisfy', {
+          __httpCode: 200,
+          message: `Password reset link has been sent to ${email}`,
+        });
+      }
     });
 
     it('should generate resetToken by email with capital letters', async () => {
       const email = 'Luna@example.com';
 
-      await funcTestHelper.updateUserAsync(context, { email });
+      await updateUserAsync(luna, { email });
 
-      const response = await funcTestHelper.sendResetPassword(email);
-      response.status.should.equal(200, `failed to reset password for ${email} email`);
-
-      const data = await response.json();
-      data.should.have.property('message');
-      data.message.should.eql(`Password reset link has been sent to ${email}`);
+      const resp = await performJSONRequest('POST', '/v1/passwords', { email });
+      expect(resp, 'to satisfy', {
+        __httpCode: 200,
+        message: `Password reset link has been sent to ${email}`,
+      });
     });
   });
 
   describe('#update()', () => {
-    let context = {};
+    let luna = {};
     const email = 'luna@example.com';
 
     beforeEach(async () => {
-      context = await funcTestHelper.createUserAsync('Luna', 'password');
-      await funcTestHelper.updateUserAsync(context, { email });
-      await funcTestHelper.sendResetPassword(email);
+      luna = await createUserAsync('Luna', 'password');
+      await updateUserAsync(luna, { email });
+      await performJSONRequest('POST', '/v1/passwords', { email });
     });
 
-    it('should not reset password by invalid resetToken', (done) => {
-      funcTestHelper.resetPassword('token')((err, res) => {
-        res.body.should.not.be.empty;
-        res.body.should.have.property('err');
-        res.body.err.should.eql('Password reset token not found or has expired');
-        done();
+    it('should not reset password by invalid resetToken', async () => {
+      const resp = await performJSONRequest('PUT', '/v1/passwords/token');
+      expect(resp, 'to satisfy', {
+        __httpCode: 404,
+        err: 'Password reset token not found or has expired',
       });
     });
   });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -59,6 +59,11 @@ declare module 'config' {
       comment: number;
       description: number;
     };
+
+    passwordReset: {
+      tokenBytesLength: number;
+      tokenTTL: number;
+    };
   };
 
   const c: Config;


### PR DESCRIPTION
Reduced the password reset token length to 12 bytes. Perhaps enormous tokens (48 bytes = 96 hexadecimal characters) were broken in the email texts. Also reduced the TTL of the token from several years :) to 8 hours.
