### PR TITLE
Fix some notifications bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Users will not longer receive notifications about someone else's actions over
   inaccessible (for recipient) posts. Previously, such notifications were sent
   when a user's comment was deleted in a post that was hidden from him.
+- Multiple 'backlink_in_post' and 'backlink_in_comment' notifications when the
+  author of a post/comment edits its text.
 
 ## [1.109.0] - 2022-05-12
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The ability to override user preference defaults based on user's creation
   time. It allows changing the default values for new users if needed.
 
+### Fixed
+- Users will not longer receive notifications about someone else's actions over
+  inaccessible (for recipient) posts. Previously, such notifications were sent
+  when a user's comment was deleted in a post that was hidden from him.
+
 ## [1.109.0] - 2022-05-12
 ### Fixed
 - Ignore minor exif-errors while sanitizing images.

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -35,6 +35,7 @@ export class User {
   getDirectsTimeline(): Promise<Timeline | null>;
   isValidEmail(): Promise<boolean>;
   static validateEmail(): Promise<void>;
+  newComment(params: { body: string; postId: UUID }): Comment;
 }
 
 export class Group {
@@ -59,6 +60,8 @@ export class Post {
   userId: UUID;
   body: string;
   destinationFeedIds: number[];
+  constructor(params: { userId: UUID; body: string; timelineIds: UUID[] });
+  create(): Promise<this>;
   destroy(destroyedBy?: User): Promise<void>;
   removeLike(user: User): Promise<boolean>;
   getPostedTo(): Promise<Timeline[]>;
@@ -68,6 +71,7 @@ export class Post {
   isAuthorOrGroupAdmin(user: User): Promise<boolean>;
   usersCanSee(): Promise<List<UUID>>;
   removeDirectRecipient(user: User): Promise<boolean>;
+  isVisibleFor(viewer: Nullable<User>): Promise<boolean>;
 }
 
 export class Timeline {
@@ -113,6 +117,8 @@ export class Comment {
   hideType: 0 | 1 | 2 | 3;
   postId: UUID;
   seqNumber: number;
+  create(): Promise<void>;
+  destroy(destroyedBy?: User): Promise<boolean>;
   getPost(): Promise<Post>;
   removeLike(user: User): Promise<boolean>;
   getCreatedBy(): Promise<User>;

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -148,6 +148,7 @@ export function addModel(dbAdapter) {
         getUpdatedUUIDs(this.body, params.body),
       );
 
+      const prevBody = this.body;
       this.updatedAt = new Date().getTime();
       this.body = params.body;
 
@@ -162,7 +163,7 @@ export function addModel(dbAdapter) {
       await Promise.all([
         this.processHashtagsOnUpdate(),
         pubSub.updateComment(this.id),
-        EventService.onCommentChanged(this),
+        EventService.onCommentChanged(this, false, { prevBody }),
         notifyBacklinked(),
       ]);
 

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -195,8 +195,9 @@ export function addModel(dbAdapter) {
       let realtimeRooms = await getRoomsOfPost(this);
       const usersCanSeePostBeforeIds = await this.usersCanSee();
 
+      const prevBody = this.body;
+
       if (params.body != null) {
-        const prevBody = this.body;
         this.body = params.body;
         payload.body = this.body;
 
@@ -262,6 +263,7 @@ export function addModel(dbAdapter) {
           this,
           await dbAdapter.getTimelinesUUIDsByIntIds(this.destinationFeedIds),
           await this.getCreatedBy(),
+          { prevBody },
         );
       });
 

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -82,6 +82,7 @@ export class DbAdapter {
 
   // Users
   getUserById(id: UUID): Promise<User | null>;
+  getUserByIntId(intId: number): Promise<User | null>;
   getUsersByIds(ids: UUID[]): Promise<User[]>;
   getUserByUsername(username: string): Promise<User | null>;
   getUserIdsWhoBannedUser(id: UUID): Promise<UUID[]>;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -187,9 +187,17 @@ export class DbAdapter {
     commentId?: Nullable<UUID>,
     postAuthorIntId?: Nullable<number>,
     targetPostId?: Nullable<UUID>,
-    targetCommntId?: Nullable<UUID>,
+    targetCommentId?: Nullable<UUID>,
   ): Promise<EventRecord>;
   getEventById(eventId: UUID): Promise<Nullable<EventRecord>>;
+  getUserEvents(
+    userIntId: number,
+    eventTypes?: string[],
+    limit?: number,
+    offset?: number,
+    startDate?: Date,
+    endDate?: Date,
+  ): Promise<EventRecord[]>;
 
   getUnreadDirectsNumber(userId: UUID): Promise<number>;
   getUnreadEventsNumber(userId: UUID): Promise<number>;

--- a/app/support/DbAdapter/users.js
+++ b/app/support/DbAdapter/users.js
@@ -266,6 +266,11 @@ const usersTrait = (superClass) =>
       return this.database('users').select('id', 'uid').whereIn('id', intIds);
     }
 
+    async getUserByIntId(intId) {
+      const row = await this.database.getRow(`select * from users where id = :intId`, { intId });
+      return initUserObject(row);
+    }
+
     async getFeedOwnerByUsername(username) {
       let attrs = await this.database('users').first().where('username', username.toLowerCase());
 

--- a/app/support/EventService.ts
+++ b/app/support/EventService.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { difference } from 'lodash';
 
 import { dbAdapter, User, Group, Post, Comment, PubSub as pubSub, Timeline } from '../models';
 
@@ -215,14 +215,19 @@ export class EventService {
     );
   }
 
-  static async onPostCreated(post: Post, destinationFeedIds: UUID[], author: User) {
+  static async onPostCreated(
+    post: Post,
+    destinationFeedIds: UUID[],
+    author: User,
+    { prevBody = '' } = {},
+  ) {
     const destinationFeeds = await dbAdapter.getTimelinesByIds(destinationFeedIds);
     await this._processDirectMessagesForPost(post, destinationFeeds, author);
     await this._processMentionsInPost(post, destinationFeeds, author);
-    await processBacklinks(post);
+    await processBacklinks(post, prevBody);
   }
 
-  static async onCommentChanged(comment: Comment, wasCreated = false) {
+  static async onCommentChanged(comment: Comment, wasCreated = false, { prevBody = '' } = {}) {
     const [post, mentionEvents] = await Promise.all([
       comment.getPost(),
       getMentionEvents(
@@ -231,7 +236,7 @@ export class EventService {
         EVENT_TYPES.MENTION_IN_COMMENT,
         EVENT_TYPES.MENTION_COMMENT_TO,
       ),
-      processBacklinks(comment),
+      processBacklinks(comment, prevBody),
     ]);
     const directEvents = wasCreated
       ? await getDirectEvents(post, comment.userId, EVENT_TYPES.DIRECT_COMMENT_CREATED)
@@ -645,8 +650,10 @@ async function getDirectEvents(post: Post, authorId: Nullable<UUID>, eventType: 
   return directReceivers.map((user) => ({ event: eventType, user }));
 }
 
-async function processBacklinks(srcEntity: Post | Comment) {
-  const uuids = extractUUIDs(srcEntity.body);
+async function processBacklinks(srcEntity: Post | Comment, prevBody = '') {
+  const prevUUIDs = extractUUIDs(prevBody);
+  const newUUIDs = extractUUIDs(srcEntity.body);
+  const uuids = difference(newUUIDs, prevUUIDs);
   const [mentionedPosts, mentionedComments] = await Promise.all([
     dbAdapter.getPostsByIds(uuids),
     dbAdapter.getCommentsByIds(uuids),

--- a/test/integration/helpers/posts-and-comments.ts
+++ b/test/integration/helpers/posts-and-comments.ts
@@ -1,0 +1,21 @@
+import { Comment, Group, Post, User } from '../../../app/models';
+import { UUID } from '../../../app/support/types';
+
+export async function createPost(
+  author: User,
+  body: string,
+  destinations: (User | Group)[] = [author],
+): Promise<Post> {
+  const timelineIds = (await Promise.all(
+    destinations.map((d) => d.getPostsTimelineId()),
+  )) as UUID[];
+  const post = new Post({ userId: author.id, body, timelineIds });
+  await post.create();
+  return post;
+}
+
+export async function createComment(author: User, post: Post, body: string): Promise<Comment> {
+  const comment = author.newComment({ body, postId: post.id });
+  await comment.create();
+  return comment;
+}

--- a/test/integration/models/post/backlink-notifications.js
+++ b/test/integration/models/post/backlink-notifications.js
@@ -1,0 +1,82 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import { dbAdapter, User } from '../../../../app/models';
+import { EVENT_TYPES } from '../../../../app/support/EventTypes';
+import cleanDB from '../../../dbCleaner';
+import { createComment, createPost } from '../../helpers/posts-and-comments';
+
+/**
+ * @typedef { import("../../../../app/models").Post } Post
+ */
+
+describe('Post backlink notifications', () => {
+  beforeEach(() => cleanDB($pg_database));
+
+  let /** @type {User} */ luna, /** @type {User} */ mars;
+  let /** @type {Post} */ lunaPost, /** @type {Post} */ marsPost;
+  let /** @type {Comment} */ lunaComment;
+  beforeEach(async () => {
+    luna = new User({ username: 'luna', password: 'pw' });
+    mars = new User({ username: 'mars', password: 'pw' });
+
+    await Promise.all([luna, mars].map((u) => u.create()));
+
+    marsPost = await createPost(mars, `Some post`);
+    lunaPost = await createPost(luna, `Post mentioned ${marsPost.id}`);
+    lunaComment = await createComment(luna, lunaPost, `Post mentioned ${marsPost.id}`);
+  });
+
+  describe(`'backlink_in_post' notifications`, () => {
+    it(`should have a 'backlink_in_post' notification for Mars`, async () => {
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_POST]);
+      expect(events, 'to have length', 1);
+    });
+
+    it(`should not create additional notifications when Luna updates post with same backlink`, async () => {
+      await lunaPost.update({ body: `Post still mentioned ${marsPost.id}` });
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_POST]);
+      expect(events, 'to have length', 1);
+    });
+
+    it(`should not create additional notifications when Luna removes backlink from post`, async () => {
+      await lunaPost.update({ body: `Post mentioned nothing` });
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_POST]);
+      expect(events, 'to have length', 1);
+    });
+
+    it(`should create additional notifications when Luna removes and then adds backlink to post`, async () => {
+      await lunaPost.update({ body: `Post mentioned nothing` });
+      await lunaPost.update({ body: `Post mentioned ${marsPost.id} again` });
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_POST]);
+      expect(events, 'to have length', 2);
+    });
+  });
+
+  describe(`'backlink_in_comment' notifications`, () => {
+    it(`should have a 'backlink_in_post' notification for Mars`, async () => {
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_COMMENT]);
+      expect(events, 'to have length', 1);
+    });
+
+    it(`should not create additional notifications when Luna updates post with same backlink`, async () => {
+      await lunaComment.update({ body: `Post still mentioned ${marsPost.id}` });
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_COMMENT]);
+      expect(events, 'to have length', 1);
+    });
+
+    it(`should not create additional notifications when Luna removes backlink from post`, async () => {
+      await lunaComment.update({ body: `Post mentioned nothing` });
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_COMMENT]);
+      expect(events, 'to have length', 1);
+    });
+
+    it(`should create additional notifications when Luna removes and then adds backlink to post`, async () => {
+      await lunaComment.update({ body: `Post mentioned nothing` });
+      await lunaComment.update({ body: `Post mentioned ${marsPost.id} again` });
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.BACKLINK_IN_COMMENT]);
+      expect(events, 'to have length', 2);
+    });
+  });
+});

--- a/test/integration/support/events/backlinks.js
+++ b/test/integration/support/events/backlinks.js
@@ -4,6 +4,7 @@ import expect from 'unexpected';
 
 import { User, Post, Group, dbAdapter, Comment } from '../../../../app/models';
 import cleanDB from '../../../dbCleaner';
+import { createPost } from '../../helpers/posts-and-comments';
 
 describe('EventService', () => {
   describe('Backlinks', () => {
@@ -439,19 +440,6 @@ describe('EventService', () => {
     });
   });
 });
-
-/**
- * @param {User} author
- * @param {string} body
- * @param {(User|Group)[]} destinations
- * @returns {Promise<Post>}
- */
-async function createPost(author, body, destinations = [author]) {
-  const timelineIds = await Promise.all(destinations.map((d) => d.getPostsTimelineId()));
-  const post = new Post({ userId: author.id, body, timelineIds });
-  await post.create();
-  return post;
-}
 
 /**
  *

--- a/test/integration/support/events/backlinks.js
+++ b/test/integration/support/events/backlinks.js
@@ -2,8 +2,8 @@
 /* global $pg_database */
 import expect from 'unexpected';
 
-import { User, Post, Group, dbAdapter, Comment } from '../../../app/models';
-import cleanDB from '../../dbCleaner';
+import { User, Post, Group, dbAdapter, Comment } from '../../../../app/models';
+import cleanDB from '../../../dbCleaner';
 
 describe('EventService', () => {
   describe('Backlinks', () => {

--- a/test/integration/support/events/inaccessible-post.js
+++ b/test/integration/support/events/inaccessible-post.js
@@ -1,0 +1,72 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import { dbAdapter, User } from '../../../../app/models';
+import { EVENT_TYPES } from '../../../../app/support/EventTypes';
+import cleanDB from '../../../dbCleaner';
+import { createComment, createPost } from '../../helpers/posts-and-comments';
+
+describe('EventService: action over inaccessible post', () => {
+  describe(`'comment_moderated' notifications`, () => {
+    beforeEach(() => cleanDB($pg_database));
+
+    let /** @type {User} */ luna, /** @type {User} */ mars;
+    let /** @type {Post} */ lunaPost;
+    let /** @type {Comment} */ marsComment;
+
+    beforeEach(async () => {
+      luna = new User({ username: 'luna', password: 'pw' });
+      mars = new User({ username: 'mars', password: 'pw' });
+
+      await Promise.all([luna, mars].map((u) => u.create()));
+
+      lunaPost = await createPost(luna, `${luna.username} post`);
+      marsComment = await createComment(mars, lunaPost, `${mars.username} post`);
+    });
+
+    it(`should create notification for Mars when Luna deletes Mars'es comment`, async () => {
+      await marsComment.destroy(luna);
+      const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.COMMENT_MODERATED]);
+      expect(events, 'to have length', 1);
+    });
+
+    describe('Luna becomes private', () => {
+      beforeEach(async () => {
+        await luna.update({ isPrivate: '1', isProtected: '1' });
+        // re-read post
+        lunaPost = await dbAdapter.getPostById(lunaPost.id);
+      });
+
+      it(`should not allow Mars to see post`, async () => {
+        const ok = await lunaPost.isVisibleFor(mars);
+        expect(ok, 'to be false');
+      });
+
+      it(`should not create notification for Mars when Luna deletes Mars'es comment`, async () => {
+        await marsComment.destroy(luna);
+        const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.COMMENT_MODERATED]);
+        expect(events, 'to be empty');
+      });
+    });
+
+    describe('Luna bans Mars', () => {
+      beforeEach(async () => {
+        await luna.ban(mars.username);
+        // re-read post
+        lunaPost = await dbAdapter.getPostById(lunaPost.id);
+      });
+
+      it(`should not allow Mars to see post`, async () => {
+        const ok = await lunaPost.isVisibleFor(mars);
+        expect(ok, 'to be false');
+      });
+
+      it(`should not create notification for Mars when Luna deletes Mars'es comment`, async () => {
+        await marsComment.destroy(luna);
+        const events = await dbAdapter.getUserEvents(mars.intId, [EVENT_TYPES.COMMENT_MODERATED]);
+        expect(events, 'to be empty');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Users will no longer receive notifications about someone else's actions over inaccessible (for recipient) posts. Previously, such notifications were sent when a user's comment was deleted in a post that was hidden from him.

Fixed multiple 'backlink_in_post' and 'backlink_in_comment' notifications when the author of a post/comment edits its text.