### PR TITLE
Record auth type as monitoring metric tag

### DIFF
--- a/app/controllers/middlewares/index.js
+++ b/app/controllers/middlewares/index.js
@@ -34,7 +34,8 @@ export function monitored(monitorName, monitor = monitorDog) {
 
     try {
       await next();
-      monitor.increment(requestsName);
+      const authTokenType = ctx.state.authJWTPayload?.type || 'anonymous';
+      monitor.increment(requestsName, 1, { auth: authTokenType });
     } finally {
       timer.stop();
 

--- a/test/integration/controllers/middlewares.js
+++ b/test/integration/controllers/middlewares.js
@@ -283,7 +283,11 @@ describe('Controller middlewares', () => {
 
     it(`should increment 'test-requests' counter after successiful call`, async () => {
       await handler(ctx);
-      expect(monitor.increment, 'to have a call satisfying', ['test-requests']);
+      expect(monitor.increment, 'to have a call satisfying', [
+        'test-requests',
+        1,
+        { auth: 'anonymous' },
+      ]);
     });
 
     it(`should not increment 'test-requests' counter after failed call`, async () => {
@@ -310,7 +314,11 @@ describe('Controller middlewares', () => {
 
     it(`should not call monitor methods in nested call`, async () => {
       await nestedHandler(ctx);
-      expect(monitor.increment, 'to have a call satisfying', ['test1-requests']);
+      expect(monitor.increment, 'to have a call satisfying', [
+        'test1-requests',
+        1,
+        { auth: 'anonymous' },
+      ]);
       expect(monitor.timer, 'to have a call satisfying', ['test1-time']);
       expect(monitor.increment, 'was called once');
       expect(monitor.timer, 'was called once');
@@ -320,7 +328,11 @@ describe('Controller middlewares', () => {
     it(`should use custom counter and timer names`, async () => {
       await monitored({ timer: 'timerA', requests: 'requestsB' }, monitor)(ctx, noop);
       expect(monitor.timer, 'to have a call satisfying', ['timerA']);
-      expect(monitor.increment, 'to have a call satisfying', ['requestsB']);
+      expect(monitor.increment, 'to have a call satisfying', [
+        'requestsB',
+        1,
+        { auth: 'anonymous' },
+      ]);
     });
   });
 });

--- a/types/monitor-dog.d.ts
+++ b/types/monitor-dog.d.ts
@@ -1,3 +1,3 @@
 declare module 'monitor-dog' {
-  export function increment(name: string): void;
+  export function increment(name: string, amount?: number, tags?: Record<string, string>): void;
 }


### PR DESCRIPTION
This PR adds auth token type (`"sess.v1"`, `"app.v1"`, or `"anonymous"`) as `auth` tag to all datadog metrics.