### PR TITLE
Group access revolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New event types, 'blocked_in_group' and 'unblocked_in_group', which are sent
     to the (un)blocked user and to the all of group admins.
   - When some user is blocked/unblocked in a group, the 'global:user:update'
-    realtime event _about the group_ is sent. This event doesn't contain
-    information about the block, but it is signals that this group _may_ become
-    unavailable to posting.
-- The `GET /v1/users/:username` now returns additional boolean _acceptsPosts_
-  field. This field is always _false_ for users. It is _true_ for groups only if
-  the current user can create posts in this group. 
+    realtime event _about the group_ is sent. This event contain general group
+    info, including the new  _acceptsPosts_ field (see below), so the listening
+    user can determine, if he can or cannot post to the group.
+- Any serialized group data (not user data) in API responses now have additional
+  boolean _acceptsPosts_ field. This field is _true_ if the current user can
+  create posts in this group. 
   
   This field takes into account all factors, including the user blocking
   described above. It will make it easier for the client to determine if it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Group administrators can now block certain users from write to the group. This
   feature includes:
+  - New API methods for group administrators:
+    - `GET /v2/groups/:groupName/blockedUsers` 
+    - `POST /v2/groups/:groupName/block/:userName`
+    - `POST /v2/groups/:groupName/unblock/:userName`
   - New event types, 'blocked_in_group' and 'unblocked_in_group', which are sent
     to the (un)blocked user and to the all of group admins.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     to the (un)blocked user and to the all of group admins.
 
 ## Changed
+- Users can now write posts to public and protected groups that they are not members of.
 - Notifications: hide the initiator of some events from the event target user.
   It is useful, for example, to protect the anonymity of group admins. The
   affected event types are: 'comment_moderated', 'post_moderated',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.0] - Not released
 ### Added
+- Users can now write posts to public and protected groups that they are not members of.
 - Group administrators can now block certain users from write to the group. This
   feature includes:
   - New API methods for group administrators:
@@ -15,9 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `POST /v2/groups/:groupName/unblock/:userName`
   - New event types, 'blocked_in_group' and 'unblocked_in_group', which are sent
     to the (un)blocked user and to the all of group admins.
+- The `GET /v1/users/:username` now returns additional boolean _acceptsPosts_
+  field. This field is always _false_ for users. It is _true_ for groups only if
+  the current user can create posts in this group. 
+  
+  This field takes into account all factors, including the user blocking
+  described above. It will make it easier for the client to determine if it is
+  possible to post to the group.
 
 ## Changed
-- Users can now write posts to public and protected groups that they are not members of.
 - Notifications: hide the initiator of some events from the event target user.
   It is useful, for example, to protect the anonymity of group admins. The
   affected event types are: 'comment_moderated', 'post_moderated',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.4.0] - Not released
+### Added
+- Group administrators can now block certain users from write to the group. This
+  feature includes:
+  - New event types, 'blocked_in_group' and 'unblocked_in_group', which are sent
+    to the (un)blocked user and to the all of group admins.
+
+## Changed
+- Notifications: hide the initiator of some events from the event target user.
+  It is useful, for example, to protect the anonymity of group admins. The
+  affected event types are: 'comment_moderated', 'post_moderated',
+  'blocked_in_group', 'unblocked_in_group'.
+
 ### Fixed
 - User data deletion process has been optimized for likes and comment likes.
 - Job manager now starting with a random delay for more even distribution of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `POST /v2/groups/:groupName/unblock/:userName`
   - New event types, 'blocked_in_group' and 'unblocked_in_group', which are sent
     to the (un)blocked user and to the all of group admins.
+  - When some user is blocked/unblocked in a group, the 'global:user:update'
+    realtime event _about the group_ is sent. This event doesn't contain
+    information about the block, but it is signals that this group _may_ become
+    unavailable to posting.
 - The `GET /v1/users/:username` now returns additional boolean _acceptsPosts_
   field. This field is always _false_ for users. It is _true_ for groups only if
   the current user can create posts in this group. 

--- a/app/controllers/api/v1/AttachmentsController.js
+++ b/app/controllers/api/v1/AttachmentsController.js
@@ -23,20 +23,21 @@ export default class AttachmentsController {
     async (ctx) => {
       // Accept one file-type field with any name
       const [file] = Object.values(ctx.request.files || []);
+      const { user } = ctx.state;
 
       if (!file) {
         throw new BadRequestException('No file provided');
       }
 
       try {
-        const newAttachment = await ctx.state.user.newAttachment({
+        const newAttachment = await user.newAttachment({
           file: { ...file, path: file.filepath, name: file.originalFilename },
         });
         await newAttachment.create();
 
         ctx.body = {
           attachments: serializeAttachment(newAttachment),
-          users: await serializeUsersByIds([newAttachment.userId]),
+          users: await serializeUsersByIds([newAttachment.userId], user.id),
         };
       } catch (e) {
         if (e.message && e.message.indexOf('Corrupt image') > -1) {
@@ -106,7 +107,7 @@ export default class AttachmentsController {
 
       ctx.body = {
         attachments: attachments.map(serializeAttachment),
-        users: await serializeUsersByIds([user.id]),
+        users: await serializeUsersByIds([user.id], user.id),
         hasMore,
       };
     },

--- a/app/controllers/api/v1/CommentsController.js
+++ b/app/controllers/api/v1/CommentsController.js
@@ -7,7 +7,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '../../../support/exceptions';
-import { serializeComment, serializeCommentForRealtime } from '../../../serializers/v2/comment';
+import { serializeComment, serializeCommentFull } from '../../../serializers/v2/comment';
 import {
   authRequired,
   inputSchemaRequired,
@@ -46,7 +46,7 @@ export const create = compose([
     }
 
     AppTokenV1.addLogPayload(ctx, { commentId: comment.id });
-    ctx.body = await serializeComment(comment);
+    ctx.body = await serializeComment(comment, author.id);
   },
 ]);
 
@@ -87,7 +87,7 @@ export const update = compose([
       throw new BadRequestException(`Can not update comment: ${e.message}`);
     }
 
-    ctx.body = await serializeComment(comment);
+    ctx.body = await serializeComment(comment, user.id);
   },
 ]);
 
@@ -157,7 +157,7 @@ export async function getById(ctx) {
 
   const viewerBans = user ? await dbAdapter.getUserBansIds(user.id) : [];
 
-  const sComment = await serializeCommentForRealtime(comment);
+  const sComment = await serializeCommentFull(comment, user?.id);
 
   if (viewerBans.includes(comment.userId)) {
     sComment.comments.likes = 0;

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -282,7 +282,7 @@ export default class UsersController {
 
       const [serUsers, acceptsDirects, pastUsernames, inHomeFeeds, availableFeeds] =
         await Promise.all([
-          serializeUsersByIds([targetUser.id], true, viewer && viewer.id),
+          serializeUsersByIds([targetUser.id], viewer?.id),
           targetUser.acceptsDirectsFrom(viewer),
           targetUser.getPastUsernames(),
           viewer ? viewer.getHomeFeedIdsSubscribedTo(targetUser) : [],
@@ -374,7 +374,7 @@ export default class UsersController {
         throw new ForbiddenException('User is private');
       }
 
-      let subscribers = await serializeUsersByIds(subscriberIds, true, viewer?.id);
+      let subscribers = await serializeUsersByIds(subscriberIds, viewer?.id);
 
       if (viewer?.id !== user.id) {
         // Sort by 'random' id to mask actual subscription order
@@ -416,7 +416,7 @@ export default class UsersController {
       timelineOwnersIds = timelineOwnersIds.filter((id) => groupsVisibility[id] !== false);
       timelines = timelines.filter(({ userId }) => groupsVisibility[userId] !== false);
 
-      let subscribers = await serializeUsersByIds(timelineOwnersIds, false, viewer?.id);
+      let subscribers = await serializeUsersByIds(timelineOwnersIds, viewer?.id, false);
       let subscriptions = timelines.map((t) => ({
         id: t.id,
         name: t.name,

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -280,12 +280,14 @@ export default class UsersController {
     async (ctx) => {
       const { targetUser, user: viewer } = ctx.state;
 
-      const [serUsers, acceptsDirects, pastUsernames, inHomeFeeds] = await Promise.all([
-        serializeUsersByIds([targetUser.id], true, viewer && viewer.id),
-        targetUser.acceptsDirectsFrom(viewer),
-        targetUser.getPastUsernames(),
-        viewer ? viewer.getHomeFeedIdsSubscribedTo(targetUser) : [],
-      ]);
+      const [serUsers, acceptsDirects, pastUsernames, inHomeFeeds, availableFeeds] =
+        await Promise.all([
+          serializeUsersByIds([targetUser.id], true, viewer && viewer.id),
+          targetUser.acceptsDirectsFrom(viewer),
+          targetUser.getPastUsernames(),
+          viewer ? viewer.getHomeFeedIdsSubscribedTo(targetUser) : [],
+          viewer && targetUser.isGroup() ? targetUser.getFeedsToPost(viewer) : [],
+        ]);
 
       const users = serUsers.find((u) => u.id === targetUser.id);
       const admins = serUsers.filter((u) => u.type === 'user');
@@ -294,6 +296,7 @@ export default class UsersController {
         users,
         admins,
         acceptsDirects,
+        acceptsPosts: availableFeeds.length !== 0,
         pastUsernames,
         inHomeFeeds,
       };

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -280,14 +280,12 @@ export default class UsersController {
     async (ctx) => {
       const { targetUser, user: viewer } = ctx.state;
 
-      const [serUsers, acceptsDirects, pastUsernames, inHomeFeeds, availableFeeds] =
-        await Promise.all([
-          serializeUsersByIds([targetUser.id], viewer?.id),
-          targetUser.acceptsDirectsFrom(viewer),
-          targetUser.getPastUsernames(),
-          viewer ? viewer.getHomeFeedIdsSubscribedTo(targetUser) : [],
-          viewer && targetUser.isGroup() ? targetUser.getFeedsToPost(viewer) : [],
-        ]);
+      const [serUsers, acceptsDirects, pastUsernames, inHomeFeeds] = await Promise.all([
+        serializeUsersByIds([targetUser.id], viewer?.id),
+        targetUser.acceptsDirectsFrom(viewer),
+        targetUser.getPastUsernames(),
+        viewer ? viewer.getHomeFeedIdsSubscribedTo(targetUser) : [],
+      ]);
 
       const users = serUsers.find((u) => u.id === targetUser.id);
       const admins = serUsers.filter((u) => u.type === 'user');
@@ -296,7 +294,6 @@ export default class UsersController {
         users,
         admins,
         acceptsDirects,
-        acceptsPosts: availableFeeds.length !== 0,
         pastUsernames,
         inHomeFeeds,
       };

--- a/app/controllers/api/v2/CommentLikesController.js
+++ b/app/controllers/api/v2/CommentLikesController.js
@@ -60,7 +60,6 @@ export default class CommentLikesController {
 
       const users = await serializeUsersByIds(
         likes.map((l) => l.userId),
-        true,
         user?.id,
       );
 

--- a/app/controllers/api/v2/GroupsController.js
+++ b/app/controllers/api/v2/GroupsController.js
@@ -88,6 +88,11 @@ export default class GroupsController {
     targetUserRequired({ groupName: 'group', userName: 'targetUser' }),
     async (ctx) => {
       const { user, group, targetUser } = ctx.state;
+
+      if (targetUser.isGroup()) {
+        throw new ForbiddenException('You cannot block group account');
+      }
+
       const adminIds = await group.getAdministratorIds();
 
       if (!adminIds.includes(user.id)) {

--- a/app/controllers/api/v2/GroupsController.js
+++ b/app/controllers/api/v2/GroupsController.js
@@ -78,7 +78,7 @@ export default class GroupsController {
       }
 
       const blockedUsers = await dbAdapter.userIdsBlockedInGroup(group.id);
-      const users = await serializeUsersByIds(blockedUsers, false, user.id);
+      const users = await serializeUsersByIds(blockedUsers, user.id);
       ctx.body = { blockedUsers, users };
     },
   ]);
@@ -110,7 +110,7 @@ export default class GroupsController {
       }
 
       const blockedUsers = await dbAdapter.userIdsBlockedInGroup(group.id);
-      const users = await serializeUsersByIds(blockedUsers, false, user.id);
+      const users = await serializeUsersByIds(blockedUsers, user.id);
       ctx.body = { blockedUsers, users };
     },
   ]);
@@ -133,7 +133,7 @@ export default class GroupsController {
       }
 
       const blockedUsers = await dbAdapter.userIdsBlockedInGroup(group.id);
-      const users = await serializeUsersByIds(blockedUsers, false, user.id);
+      const users = await serializeUsersByIds(blockedUsers, user.id);
       ctx.body = { blockedUsers, users };
     },
   ]);

--- a/app/controllers/api/v2/HomeFeedsController.js
+++ b/app/controllers/api/v2/HomeFeedsController.js
@@ -26,7 +26,7 @@ export const listHomeFeeds = compose([
 
     const homeFeeds = await user.getHomeFeeds();
     const timelines = homeFeeds.map((t) => serializeTimeline(t));
-    const users = await serializeUsersByIds([user.id]);
+    const users = await serializeUsersByIds([user.id], user.id);
 
     ctx.body = { timelines, users };
   },
@@ -173,7 +173,6 @@ export const listSubscriptions = compose([
     const usersInHomeFeeds = subs.map((s) => ({ id: s.user_id, homeFeeds: s.homefeed_ids }));
     const users = await serializeUsersByIds(
       [user.id, ...usersInHomeFeeds.map((s) => s.id)],
-      true,
       user.id,
     );
 
@@ -199,7 +198,7 @@ export const getHomeFeedInfo = compose([
     }
 
     const subscribedTo = await feed.getHomeFeedSubscriptions();
-    const users = await serializeUsersByIds([...subscribedTo, feed.userId], true, user.id);
+    const users = await serializeUsersByIds([...subscribedTo, feed.userId], user.id);
 
     ctx.body = {
       timeline: serializeTimeline(feed),

--- a/app/controllers/api/v2/TimelinesRSS.js
+++ b/app/controllers/api/v2/TimelinesRSS.js
@@ -229,5 +229,5 @@ async function loadAllComments(postId, ctx) {
     { foldComments: false },
   );
 
-  return postWithStuff ? postWithStuff.comments.map(serializeComment) : [];
+  return postWithStuff ? postWithStuff.comments.map((c) => serializeComment(c)) : [];
 }

--- a/app/controllers/api/v2/UsersController.js
+++ b/app/controllers/api/v2/UsersController.js
@@ -18,7 +18,7 @@ export default class UsersController {
         state: { user },
       } = ctx;
       const banIds = await user.getBanIds();
-      const users = await serializeUsersByIds(banIds, false);
+      const users = await serializeUsersByIds(banIds, user.id);
       ctx.body = banIds.map((id) => users.find((u) => u.id === id));
     },
   ]);

--- a/app/controllers/api/v2/UsersController.js
+++ b/app/controllers/api/v2/UsersController.js
@@ -3,11 +3,7 @@ import _ from 'lodash';
 import monitor from 'monitor-dog';
 
 import { dbAdapter, PubSub as pubSub } from '../../../models';
-import {
-  serializeSelfUser,
-  serializeUsersByIds,
-  userSerializerFunction,
-} from '../../../serializers/v2/user';
+import { serializeSelfUser, serializeUsersByIds } from '../../../serializers/v2/user';
 import { monitored, authRequired } from '../../middlewares';
 
 export default class UsersController {
@@ -129,45 +125,25 @@ export default class UsersController {
         users.banIds,
       );
 
-      const [allUsers, allStats] = await Promise.all([
-        dbAdapter.getUsersByIdsAssoc(allUIDs),
-        dbAdapter.getUsersStatsAssoc(allUIDs),
-      ]);
-      const allGroupAdmins = await dbAdapter.getGroupsAdministratorsIds(
-        _.map(_.filter(allUsers, { type: 'group' }), 'id'),
-        user.id,
-      );
-
-      {
-        // We need to fetch info for group admins too
-        const additionalUIDs = _.uniq(Object.values(allGroupAdmins).flat()).filter(
-          (id) => !allUsers[id],
-        );
-
-        if (additionalUIDs.length > 0) {
-          const addUsers = await dbAdapter.getUsersByIdsAssoc(additionalUIDs);
-
-          for (const id of Object.keys(addUsers)) {
-            allUsers[id] = addUsers[id];
-          }
-        }
-      }
-
-      const serializeUser = userSerializerFunction(allUsers, allStats, allGroupAdmins);
+      const sAccounts = await serializeUsersByIds(allUIDs, user.id);
+      const sAccountsMap = new Map(sAccounts.map((a) => [a.id, a]));
 
       users.pendingGroupRequests = groupRequestersUIDs.length > 0;
       users.pendingSubscriptionRequests = pendingSubscriptionRequestsUIDs;
       users.subscriptionRequests = subscriptionRequestsUIDs;
       users.subscriptions = _.map(timelinesUserSubscribed, 'id');
-      users.subscribers = subscribersUIDs.map(serializeUser);
-      const subscribers = subscriptionsUIDs.map(serializeUser);
+      users.subscribers = subscribersUIDs.map((id) => sAccountsMap.get(id));
+      const subscribers = subscriptionsUIDs.map((id) => sAccountsMap.get(id));
+
       const requests = _.union(pendingSubscriptionRequestsUIDs, subscriptionRequestsUIDs).map(
-        serializeUser,
+        (id) => sAccountsMap.get(id),
       );
-      const managedGroups = managedGroupUIDs.map(serializeUser).map((group) => {
-        group.requests = (pendingGroupRequests[group.id] || []).map(serializeUser);
-        return group;
-      });
+      const managedGroups = managedGroupUIDs
+        .map((id) => sAccountsMap.get(id))
+        .map((group) => ({
+          ...group,
+          requests: (pendingGroupRequests[group.id] || []).map((id) => sAccountsMap.get(id)),
+        }));
 
       // Only full access tokens can see privateMeta
       if (!authToken.hasFullAccess) {

--- a/app/mailers/NotificationDigestMailer.js
+++ b/app/mailers/NotificationDigestMailer.js
@@ -315,6 +315,32 @@ const notificationTemplates = {
 
     return `${creatorHTML} left a ${postHTML} created by ${postAuthorHTML}`;
   },
+
+  blocked_in_group: (eventData) => {
+    const adminHTML =
+      eventData.recipient.id === eventData.creator.id ? 'You' : makeUserLink(eventData.creator);
+    const victimHTML =
+      eventData.recipient.id === eventData.affectedUser.id
+        ? 'You'
+        : makeUserLink(eventData.affectedUser);
+    const groupLink = makeUserLink(eventData.group);
+
+    return `
+      ${adminHTML} blocked ${victimHTML} in group ${groupLink}`;
+  },
+
+  unblocked_in_group: (eventData) => {
+    const adminHTML =
+      eventData.recipient.id === eventData.creator.id ? 'You' : makeUserLink(eventData.creator);
+    const victimHTML =
+      eventData.recipient.id === eventData.affectedUser.id
+        ? 'You'
+        : makeUserLink(eventData.affectedUser);
+    const groupLink = makeUserLink(eventData.group);
+
+    return `
+      ${adminHTML} unblocked ${victimHTML} in group ${groupLink}`;
+  },
 };
 
 function makeUserLink(user) {

--- a/app/mailers/NotificationDigestMailer.js
+++ b/app/mailers/NotificationDigestMailer.js
@@ -317,29 +317,37 @@ const notificationTemplates = {
   },
 
   blocked_in_group: (eventData) => {
-    const adminHTML =
-      eventData.recipient.id === eventData.creator.id ? 'You' : makeUserLink(eventData.creator);
+    let adminHTML = 'Group admin';
+
+    if (eventData.creator) {
+      adminHTML =
+        eventData.recipient.id === eventData.creator.id ? 'You' : makeUserLink(eventData.creator);
+    }
+
     const victimHTML =
       eventData.recipient.id === eventData.affectedUser.id
         ? 'You'
         : makeUserLink(eventData.affectedUser);
     const groupLink = makeUserLink(eventData.group);
 
-    return `
-      ${adminHTML} blocked ${victimHTML} in group ${groupLink}`;
+    return `${adminHTML} blocked ${victimHTML} in group ${groupLink}`;
   },
 
   unblocked_in_group: (eventData) => {
-    const adminHTML =
-      eventData.recipient.id === eventData.creator.id ? 'You' : makeUserLink(eventData.creator);
+    let adminHTML = 'Group admin';
+
+    if (eventData.creator) {
+      adminHTML =
+        eventData.recipient.id === eventData.creator.id ? 'You' : makeUserLink(eventData.creator);
+    }
+
     const victimHTML =
       eventData.recipient.id === eventData.affectedUser.id
         ? 'You'
         : makeUserLink(eventData.affectedUser);
     const groupLink = makeUserLink(eventData.group);
 
-    return `
-      ${adminHTML} unblocked ${victimHTML} in group ${groupLink}`;
+    return `${adminHTML} unblocked ${victimHTML} in group ${groupLink}`;
   },
 };
 

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -82,6 +82,8 @@ export class Group {
   isGroup(): true;
   isUser(): false;
   getAdministrators(): Promise<User[]>;
+  getActiveAdministrators(): Promise<User[]>;
+  addAdministrator(adminId: UUID): Promise<void>;
   getPostsTimeline(): Promise<Timeline | null>;
   getPostsTimelineId(): Promise<UUID | null>;
 

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -84,6 +84,9 @@ export class Group {
   getAdministrators(): Promise<User[]>;
   getPostsTimeline(): Promise<Timeline | null>;
   getPostsTimelineId(): Promise<UUID | null>;
+
+  blockUser(userId: UUID, adminId: UUID): Promise<boolean>;
+  unblockUser(userId: UUID, adminId: UUID): Promise<boolean>;
 }
 
 export class Post {

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -201,6 +201,9 @@ export const appTokensScopes = [
       'POST /v1/groups/:groupName/acceptRequest/:userName',
       'POST /v1/groups/:groupName/rejectRequest/:userName',
       'POST /v1/groups/:groupName/unsubscribeFromGroup/:userName',
+      'GET /v2/groups/:groupName/blockedUsers',
+      'POST /v2/groups/:groupName/block/:userName',
+      'POST /v2/groups/:groupName/unblock/:userName',
     ],
   },
   {

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -259,7 +259,7 @@ export function addModel(dbAdapter) {
       }
 
       await EventService.onBlockedInGroup(this, userId, adminId);
-      // TODO realtime
+      await pubSub.globalUserUpdate(this.id);
 
       return true;
     }
@@ -282,7 +282,7 @@ export function addModel(dbAdapter) {
       }
 
       await EventService.onUnblockedInGroup(this, userId, adminId);
-      // TODO realtime
+      await pubSub.globalUserUpdate(this.id);
 
       return true;
     }

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -1,6 +1,16 @@
 import { User, PubSub as pubSub } from '../models';
 import { ForbiddenException, ValidationException } from '../support/exceptions';
 
+/**
+ * @typedef { import('../support/DbAdapter').DbAdapter } DbAdapter
+ * @typedef { import('../models').Group } Group
+ * @typedef { import('../support/types').UUID } UUID
+ */
+
+/**
+ * @param {DbAdapter} dbAdapter
+ * @returns {Group}
+ */
 export function addModel(dbAdapter) {
   return class Group extends User {
     // Groups only have 'Posts' feed
@@ -223,6 +233,52 @@ export function addModel(dbAdapter) {
       }
 
       return [timeline];
+    }
+
+    /**
+     * Blocks user in the group. adminId is the id of the admin who blocking the
+     * user. This method doesn't perform any access checks, it even doesn't
+     * check if the admin is actually a group administrator. Returns true if the
+     * user is blocked by this call, false if the user is already blocked.
+     *
+     * @param {UUID} userId
+     * @param {UUID} adminId
+     * @returns {Promise<boolean>}
+     */
+    async blockUser(userId, adminId) {
+      const ok = await dbAdapter.blockUserInGroup(userId, this.id);
+
+      if (!ok) {
+        return false;
+      }
+
+      // TODO notification
+      // TODO realtime
+
+      return true;
+    }
+
+    /**
+     * Unblocks user in the group. adminId is the id of the admin who unblocking
+     * the user. This method doesn't perform any access checks, it even doesn't
+     * check if the admin is actually a group administrator. Returns true if the
+     * user is unblocked by this call, false if the user is already not blocked.
+     *
+     * @param {UUID} userId
+     * @param {UUID} adminId
+     * @returns {Promise<boolean>}
+     */
+    async unblockUser(userId, adminId) {
+      const ok = await dbAdapter.unblockUserInGroup(userId, this.id);
+
+      if (!ok) {
+        return false;
+      }
+
+      // TODO notification
+      // TODO realtime
+
+      return true;
     }
   };
 }

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -224,9 +224,13 @@ export function addModel(dbAdapter) {
         return [];
       }
 
-      const admins = await this.getActiveAdministrators();
+      const [admins, blocked] = await Promise.all([
+        this.getActiveAdministrators(),
+        dbAdapter.groupIdsBlockedUser(postingUser.id, [this.id]),
+      ]);
 
       if (
+        blocked.length > 0 ||
         admins.length === 0 ||
         (this.isRestricted === '1' && !admins.some((a) => a.id === postingUser.id))
       ) {

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -1,4 +1,5 @@
 import { User, PubSub as pubSub } from '../models';
+import { EventService } from '../support/EventService';
 import { ForbiddenException, ValidationException } from '../support/exceptions';
 
 /**
@@ -252,7 +253,7 @@ export function addModel(dbAdapter) {
         return false;
       }
 
-      // TODO notification
+      await EventService.onBlockedInGroup(this, userId, adminId);
       // TODO realtime
 
       return true;
@@ -275,7 +276,7 @@ export function addModel(dbAdapter) {
         return false;
       }
 
-      // TODO notification
+      await EventService.onUnblockedInGroup(this, userId, adminId);
       // TODO realtime
 
       return true;

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -5,6 +5,7 @@ import { ForbiddenException, ValidationException } from '../support/exceptions';
 /**
  * @typedef { import('../support/DbAdapter').DbAdapter } DbAdapter
  * @typedef { import('../models').Group } Group
+ * @typedef { import('../models').Timeline } Timeline
  * @typedef { import('../support/types').UUID } UUID
  */
 
@@ -213,14 +214,14 @@ export function addModel(dbAdapter) {
      * and returns array of destination timelines or empty array if
      * user can not post to this group.
      *
-     * @param {string} postingUser
-     * @returns {Timeline[]}
+     * @param {User} postingUser
+     * @returns {Promise<Timeline[]>}
      */
     async getFeedsToPost(postingUser) {
       const timeline = await dbAdapter.getUserNamedFeed(this.id, 'Posts');
       const isSubscribed = await dbAdapter.isUserSubscribedToTimeline(postingUser.id, timeline.id);
 
-      if (!isSubscribed) {
+      if (this.isPrivate === '1' && !isSubscribed) {
         return [];
       }
 

--- a/app/routes/api/v2/GroupsRoute.js
+++ b/app/routes/api/v2/GroupsRoute.js
@@ -3,4 +3,7 @@ import { GroupsControllerV2 } from '../../../controllers';
 export default function addRoutes(app) {
   app.get('/v2/managedGroups', GroupsControllerV2.managedGroups);
   app.get('/v2/allGroups', GroupsControllerV2.allGroups);
+  app.get('/v2/groups/:groupName/blockedUsers', GroupsControllerV2.getBlockedUsers);
+  app.post('/v2/groups/:groupName/block/:userName', GroupsControllerV2.blockUser);
+  app.post('/v2/groups/:groupName/unblock/:userName', GroupsControllerV2.unblockUser);
 }

--- a/app/serializers/v2/comment.js
+++ b/app/serializers/v2/comment.js
@@ -2,24 +2,22 @@ import { pick } from 'lodash';
 
 import { serializeUsersByIds } from './user';
 
-export async function serializeComment(comment) {
+export async function serializeComment(comment, viewerId) {
   const comments = {
     ...pick(comment, ['id', 'body', 'createdAt', 'seqNumber']),
     createdBy: comment.userId,
   };
 
-  const users = await serializeUsersByIds([comment.userId], false);
+  const users = await serializeUsersByIds([comment.userId], viewerId);
 
   return { comments, users, admins: users };
 }
 
-export async function serializeCommentForRealtime(comment) {
+export async function serializeCommentFull(comment, viewerId) {
   const comments = {
     ...pick(comment, ['id', 'body', 'createdAt', 'updatedAt', 'seqNumber', 'postId', 'hideType']),
     createdBy: comment.userId,
   };
-
-  const users = await serializeUsersByIds([comment.userId], false);
-
+  const users = await serializeUsersByIds([comment.userId], viewerId);
   return { comments, users, admins: users };
 }

--- a/app/serializers/v2/event.ts
+++ b/app/serializers/v2/event.ts
@@ -1,6 +1,7 @@
 import { dbAdapter } from '../../models';
 import { Nullable, UUID } from '../../support/types';
 import type { EventRecord } from '../../support/DbAdapter';
+import { HIDDEN_CREATOR_EVENT_TYPES } from '../../support/EventTypes';
 
 import { userSerializerFunction } from './user';
 
@@ -10,6 +11,13 @@ export async function serializeEvents(events: EventRecord[], viewerId: Nullable<
   const commentIntIds = new Set<Nullable<number>>();
 
   for (const event of events) {
+    if (
+      HIDDEN_CREATOR_EVENT_TYPES.includes(event.event_type) &&
+      event.user_id === event.target_user_id
+    ) {
+      event.created_by_user_id = null;
+    }
+
     accountIntIds.add(event.user_id);
     accountIntIds.add(event.target_user_id);
     accountIntIds.add(event.created_by_user_id);

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -118,7 +118,7 @@ export async function serializeFeed(
     allPosts.push(sPost);
     allDestinations.push(...destinations);
     allSubscribers.push(...destinations.map((d) => d.user));
-    allComments.push(...comments.map(serializeComment));
+    allComments.push(...comments.map((c) => serializeComment(c, viewerId)));
     allAttachments.push(...attachments.map(serializeAttachment));
 
     allUserIds.add(sPost.createdBy);

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -82,16 +82,16 @@ export function userSerializerFunction(allUsers, allStats, allGroupAdmins = {}) 
 }
 
 /**
- * Serialises users by their ids
+ * Serializes users by their ids
  *
  * Keeps userIds order, but adds uniqueness and puts admins (if withAdmins is
  * true) to the end of list.
  *
- * @param {Array.<string>} userIds
+ * @param {UUID[]} userIds
  * @param {boolean} withAdmins
  * @returns {Promise<Array>}
  */
-export async function serializeUsersByIds(userIds, withAdmins = true, viewerId = null) {
+export async function serializeUsersByIds(userIds, viewerId = null, withAdmins = true) {
   let allUserIds = uniq(userIds);
   const adminsAssoc = await dbAdapter.getGroupsAdministratorsIds(userIds, viewerId);
 

--- a/app/support/DbAdapter/group-blocks.js
+++ b/app/support/DbAdapter/group-blocks.js
@@ -27,7 +27,14 @@ const groupBlocksTrait = (superClass) =>
       );
     }
 
-    groupIdsBlockedUser(userId) {
+    groupIdsBlockedUser(userId, fromGroupIds = null) {
+      if (fromGroupIds) {
+        return this.database.getCol(
+          `select group_id from group_blocks where blocked_user_id = :userId and group_id = any(:fromGroupIds)`,
+          { userId, fromGroupIds },
+        );
+      }
+
       return this.database.getCol(
         `select group_id from group_blocks where blocked_user_id = :userId order by group_id`,
         { userId },

--- a/app/support/DbAdapter/group-blocks.js
+++ b/app/support/DbAdapter/group-blocks.js
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////
+// Group blocks
+///////////////////////////////////////////////////
+
+const groupBlocksTrait = (superClass) =>
+  class extends superClass {
+    async blockUserInGroup(userId, groupId) {
+      const { rows } = await this.database.raw(
+        `insert into group_blocks (blocked_user_id, group_id) values (:userId, :groupId) on conflict do nothing returning 1`,
+        { userId, groupId },
+      );
+      return rows.length > 0;
+    }
+
+    async unblockUserInGroup(userId, groupId) {
+      const { rows } = await this.database.raw(
+        `delete from group_blocks where (blocked_user_id, group_id) = (:userId, :groupId) returning 1`,
+        { userId, groupId },
+      );
+      return rows.length > 0;
+    }
+
+    userIdsBlockedInGroup(groupId) {
+      return this.database.getCol(
+        `select blocked_user_id from group_blocks where group_id = :groupId order by blocked_user_id`,
+        { groupId },
+      );
+    }
+
+    groupIdsBlockedUser(userId) {
+      return this.database.getCol(
+        `select group_id from group_blocks where blocked_user_id = :userId order by group_id`,
+        { userId },
+      );
+    }
+  };
+
+export default groupBlocksTrait;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -229,4 +229,10 @@ export class DbAdapter {
   deleteJob(id: UUID): Promise<void>;
   fetchJobs(count: number, lockTime: number): Promise<Job[]>;
   getAllJobs(names?: string[]): Promise<Job[]>; // For testing purposes only
+
+  // Group blocks
+  blockUserInGroup(userId: UUID, groupId: UUID): Promise<boolean>;
+  unblockUserInGroup(userId: UUID, groupId: UUID): Promise<boolean>;
+  userIdsBlockedInGroup(groupId: UUID): Promise<UUID[]>;
+  groupIdsBlockedUser(userId: UUID): Promise<UUID[]>;
 }

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -235,4 +235,7 @@ export class DbAdapter {
   unblockUserInGroup(userId: UUID, groupId: UUID): Promise<boolean>;
   userIdsBlockedInGroup(groupId: UUID): Promise<UUID[]>;
   groupIdsBlockedUser(userId: UUID, fromGroupIds?: UUID[]): Promise<UUID[]>;
+
+  // Subscriptions
+  getOnlySubscribedTo(subscriberId: UUID | null, toUserIds: UUID[]): Promise<UUID[]>;
 }

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -234,5 +234,5 @@ export class DbAdapter {
   blockUserInGroup(userId: UUID, groupId: UUID): Promise<boolean>;
   unblockUserInGroup(userId: UUID, groupId: UUID): Promise<boolean>;
   userIdsBlockedInGroup(groupId: UUID): Promise<UUID[]>;
-  groupIdsBlockedUser(userId: UUID): Promise<UUID[]>;
+  groupIdsBlockedUser(userId: UUID, fromGroupIds?: UUID[]): Promise<UUID[]>;
 }

--- a/app/support/DbAdapter/index.js
+++ b/app/support/DbAdapter/index.js
@@ -35,6 +35,7 @@ import nowTrait from './now';
 import jobsTrait from './jobs';
 import authSessionsTrait from './auth-sessions';
 import backlinksTrait from './backlinks';
+import groupBlocksTrait from './group-blocks';
 
 class DbAdapterBase {
   constructor(database) {
@@ -100,4 +101,5 @@ export const DbAdapter = _.flow([
   jobsTrait,
   authSessionsTrait,
   backlinksTrait,
+  groupBlocksTrait,
 ])(DbAdapterBase);

--- a/app/support/DbAdapter/subscriptions.js
+++ b/app/support/DbAdapter/subscriptions.js
@@ -34,6 +34,28 @@ const subscriptionsTrait = (superClass) =>
       return rows.length > 0;
     }
 
+    /**
+     * Return only those toUserIds that have a subscriberId subscribed to
+     *
+     * @param {UUID|null} subscriberId
+     * @param {UUID[]} toUserIds
+     * @returns {Promise<UUID[]>}
+     */
+    getOnlySubscribedTo(subscriberId, toUserIds) {
+      if (!subscriberId || toUserIds.length === 0) {
+        return [];
+      }
+
+      return this.database.getCol(
+        `select f.user_id from
+          feeds f
+          join subscriptions s on s.feed_id = f.uid and f.name = 'Posts'
+          where s.user_id = :subscriberId and f.user_id = any(:toUserIds)
+        `,
+        { subscriberId, toUserIds },
+      );
+    }
+
     async areUsersSubscribedToOneOfTimelines(userIds, timelineIds) {
       if (userIds.length === 0 || timelineIds.length === 0) {
         return [];

--- a/app/support/EventService.ts
+++ b/app/support/EventService.ts
@@ -317,7 +317,7 @@ export class EventService {
         commentAuthor.intId,
         EVENT_TYPES.COMMENT_MODERATED,
         destroyedBy.intId,
-        null,
+        commentAuthor.intId,
         groups.length === 0 ? null : groups[0].intId,
         post.id,
         null,

--- a/app/support/EventTypes.ts
+++ b/app/support/EventTypes.ts
@@ -75,3 +75,18 @@ export const DIGEST_EVENT_TYPES = _.difference(Object.values(EVENT_TYPES), [
   'post_moderated_by_another_admin',
   'invitation_used',
 ] as const);
+
+/**
+ * Hide the initiator of action from the action target user
+ *
+ * It is useful, for example, to protect the anonymity of group admins.
+ *
+ * Technically, we should not show (serialize) the 'created_by' field of these
+ * types when 'user_id' (recipient) is the same as 'target_user_id'.
+ */
+export const HIDDEN_CREATOR_EVENT_TYPES = [
+  EVENT_TYPES.COMMENT_MODERATED,
+  EVENT_TYPES.POST_MODERATED,
+  EVENT_TYPES.BLOCKED_IN_GROUP,
+  EVENT_TYPES.UNBLOCKED_IN_GROUP,
+] as T_EVENT_TYPE[];

--- a/app/support/EventTypes.ts
+++ b/app/support/EventTypes.ts
@@ -39,6 +39,9 @@ export const EVENT_TYPES = {
 
   BACKLINK_IN_POST: 'backlink_in_post',
   BACKLINK_IN_COMMENT: 'backlink_in_comment',
+
+  BLOCKED_IN_GROUP: 'blocked_in_group',
+  UNBLOCKED_IN_GROUP: 'unblocked_in_group',
 } as const;
 
 export type T_EVENT_TYPE = typeof EVENT_TYPES[keyof typeof EVENT_TYPES];

--- a/migrations/20220724202953_group_blocks.js
+++ b/migrations/20220724202953_group_blocks.js
@@ -1,0 +1,17 @@
+export const up = (knex) =>
+  knex.schema.raw(`do $$begin
+  create table group_blocks (
+    group_id uuid not null
+      references users (uid) on delete cascade on update cascade,
+    blocked_user_id uuid not null
+      references users (uid) on delete cascade on update cascade,
+    created_at timestamptz not null default now(),
+    
+    primary key (group_id, blocked_user_id)
+  );
+end$$`);
+
+export const down = (knex) =>
+  knex.schema.raw(`do $$begin
+  drop table group_blocks;
+end$$`);

--- a/migrations/20220724202953_group_blocks.js
+++ b/migrations/20220724202953_group_blocks.js
@@ -9,9 +9,95 @@ export const up = (knex) =>
     
     primary key (group_id, blocked_user_id)
   );
+
+  -- Add new event types
+  ALTER TABLE events DROP CONSTRAINT events_event_type_check;
+  ALTER TABLE events
+  ADD CONSTRAINT events_event_type_check CHECK (event_type = ANY (ARRAY[
+    'mention_in_post'::text,
+    'mention_in_comment'::text,
+    'mention_comment_to'::text,
+    'banned_user'::text,
+    'unbanned_user'::text,
+    'banned_by_user'::text,
+    'unbanned_by_user'::text,
+    'subscription_requested'::text,
+    'subscription_request_revoked'::text,
+    'user_subscribed'::text,
+    'user_unsubscribed'::text,
+    'subscription_request_approved'::text,
+    'subscription_request_rejected'::text,
+    'group_created'::text,
+    'group_subscription_requested'::text,
+    'group_subscription_request_revoked'::text,
+    'group_subscription_rejected'::text,
+    'group_subscribed'::text,
+    'group_unsubscribed'::text,
+    'group_admin_promoted'::text,
+    'group_admin_demoted'::text,
+    'group_subscription_approved'::text,
+    'group_subscription_rejected'::text,
+    'direct'::text,
+    'direct_comment'::text,
+    'managed_group_subscription_approved'::text,
+    'managed_group_subscription_rejected'::text,
+    'comment_moderated'::text,
+    'comment_moderated_by_another_admin'::text,
+    'post_moderated'::text,
+    'post_moderated_by_another_admin'::text,
+    'invitation_used'::text,
+    'backlink_in_post'::text,
+    'backlink_in_comment'::text,
+    'direct_left'::text,
+
+    -- NEW LINES --
+    'blocked_in_group'::text,
+    'unblocked_in_group'::text
+  ]));
+
 end$$`);
 
 export const down = (knex) =>
   knex.schema.raw(`do $$begin
   drop table group_blocks;
+
+  ALTER TABLE events DROP CONSTRAINT events_event_type_check;
+  ALTER TABLE events
+    ADD CONSTRAINT events_event_type_check CHECK (event_type = ANY (ARRAY[
+      'mention_in_post'::text,
+      'mention_in_comment'::text,
+      'mention_comment_to'::text,
+      'banned_user'::text,
+      'unbanned_user'::text,
+      'banned_by_user'::text,
+      'unbanned_by_user'::text,
+      'subscription_requested'::text,
+      'subscription_request_revoked'::text,
+      'user_subscribed'::text,
+      'user_unsubscribed'::text,
+      'subscription_request_approved'::text,
+      'subscription_request_rejected'::text,
+      'group_created'::text,
+      'group_subscription_requested'::text,
+      'group_subscription_request_revoked'::text,
+      'group_subscription_rejected'::text,
+      'group_subscribed'::text,
+      'group_unsubscribed'::text,
+      'group_admin_promoted'::text,
+      'group_admin_demoted'::text,
+      'group_subscription_approved'::text,
+      'group_subscription_rejected'::text,
+      'direct'::text,
+      'direct_comment'::text,
+      'managed_group_subscription_approved'::text,
+      'managed_group_subscription_rejected'::text,
+      'comment_moderated'::text,
+      'comment_moderated_by_another_admin'::text,
+      'post_moderated'::text,
+      'post_moderated_by_another_admin'::text,
+      'invitation_used'::text,
+      'backlink_in_post'::text,
+      'backlink_in_comment'::text,
+      'direct_left'::text
+    ]));
 end$$`);

--- a/test/functional/group-accepts-posts.js
+++ b/test/functional/group-accepts-posts.js
@@ -30,68 +30,76 @@ describe('Group acceptsPosts field', () => {
   });
 
   it(`should show acceptsPosts: true for all users for public group`, async () => {
-    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { users: { acceptsPosts: true } });
   });
 
   it(`should show acceptsPosts: true for all users for protected group`, async () => {
     await updateGroupAsync(selenites.group, luna, { isProtected: '1' });
-    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { users: { acceptsPosts: true } });
   });
 
   it(`should show acceptsPosts: true only for members of private group`, async () => {
     await updateGroupAsync(selenites.group, luna, { isPrivate: '1' });
-    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { users: { acceptsPosts: false } });
   });
 
   it(`should show acceptsPosts: true only for admins of restricted group`, async () => {
     await updateGroupAsync(selenites.group, luna, { isRestricted: '1' });
-    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
-    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: false } });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { users: { acceptsPosts: false } });
   });
 
   describe('Mars is blocked in group', () => {
     beforeEach(() => blockUserInGroup(mars, selenites, luna));
 
     it(`should show acceptsPosts: true for all users (except Mars) for public group`, async () => {
-      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
-      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: false } });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', {
+        users: { acceptsPosts: true },
+      });
     });
 
     it(`should show acceptsPosts: true for all users (except Mars) for protected group`, async () => {
       await updateGroupAsync(selenites.group, luna, { isProtected: '1' });
-      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
-      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: false } });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', {
+        users: { acceptsPosts: true },
+      });
     });
 
     it(`should show acceptsPosts: true only for members (except Mars) of private group`, async () => {
       await updateGroupAsync(selenites.group, luna, { isPrivate: '1' });
-      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
-      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: false } });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', {
+        users: { acceptsPosts: false },
+      });
     });
 
     it(`should show acceptsPosts: true only for admins of restricted group`, async () => {
       await updateGroupAsync(selenites.group, luna, { isRestricted: '1' });
-      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
-      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
-      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { users: { acceptsPosts: false } });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { users: { acceptsPosts: true } });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', {
+        users: { acceptsPosts: false },
+      });
     });
   });
 });

--- a/test/functional/group-accepts-posts.js
+++ b/test/functional/group-accepts-posts.js
@@ -1,0 +1,110 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../dbCleaner';
+
+import {
+  authHeaders,
+  createGroupAsync,
+  createTestUsers,
+  performJSONRequest,
+  promoteToAdmin,
+  subscribeToAsync,
+  updateGroupAsync,
+} from './functional_test_helper';
+
+describe('Group acceptsPosts field', () => {
+  beforeEach(() => cleanDB($pg_database));
+
+  let luna, mars, venus, jupiter, selenites;
+
+  beforeEach(async () => {
+    [luna, mars, venus, jupiter] = await createTestUsers(['luna', 'mars', ' venus', 'jupiter']);
+    selenites = await createGroupAsync(luna, 'selenites');
+    await Promise.all([
+      subscribeToAsync(mars, selenites),
+      subscribeToAsync(venus, selenites),
+      promoteToAdmin(selenites, luna, venus),
+    ]);
+  });
+
+  it(`should show acceptsPosts: true for all users for public group`, async () => {
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+  });
+
+  it(`should show acceptsPosts: true for all users for protected group`, async () => {
+    await updateGroupAsync(selenites.group, luna, { isProtected: '1' });
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+  });
+
+  it(`should show acceptsPosts: true only for members of private group`, async () => {
+    await updateGroupAsync(selenites.group, luna, { isPrivate: '1' });
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+  });
+
+  it(`should show acceptsPosts: true only for admins of restricted group`, async () => {
+    await updateGroupAsync(selenites.group, luna, { isRestricted: '1' });
+    expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
+    expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+    expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+  });
+
+  describe('Mars is blocked in group', () => {
+    beforeEach(() => blockUserInGroup(mars, selenites, luna));
+
+    it(`should show acceptsPosts: true for all users (except Mars) for public group`, async () => {
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+    });
+
+    it(`should show acceptsPosts: true for all users (except Mars) for protected group`, async () => {
+      await updateGroupAsync(selenites.group, luna, { isProtected: '1' });
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: true });
+    });
+
+    it(`should show acceptsPosts: true only for members (except Mars) of private group`, async () => {
+      await updateGroupAsync(selenites.group, luna, { isPrivate: '1' });
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+    });
+
+    it(`should show acceptsPosts: true only for admins of restricted group`, async () => {
+      await updateGroupAsync(selenites.group, luna, { isRestricted: '1' });
+      expect(await getUserInfo(selenites, luna), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, mars), 'to satisfy', { acceptsPosts: false });
+      expect(await getUserInfo(selenites, venus), 'to satisfy', { acceptsPosts: true });
+      expect(await getUserInfo(selenites, jupiter), 'to satisfy', { acceptsPosts: false });
+    });
+  });
+});
+
+function getUserInfo(groupCtx, ctx) {
+  return performJSONRequest('GET', `/v1/users/${groupCtx.username}`, null, authHeaders(ctx));
+}
+
+function blockUserInGroup(user, group, admin) {
+  return performJSONRequest(
+    'POST',
+    `/v2/groups/${group.username}/block/${user.username}`,
+    {},
+    authHeaders(admin),
+  );
+}

--- a/test/functional/group-blocks.js
+++ b/test/functional/group-blocks.js
@@ -1,0 +1,104 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../dbCleaner';
+
+import {
+  authHeaders,
+  createGroupAsync,
+  createTestUsers,
+  performJSONRequest,
+  promoteToAdmin,
+  subscribeToAsync,
+} from './functional_test_helper';
+
+describe('Group Blocks', () => {
+  beforeEach(() => cleanDB($pg_database));
+
+  let luna, mars, venus, jupiter, selenites;
+
+  beforeEach(async () => {
+    [luna, mars, venus, jupiter] = await createTestUsers(['luna', 'mars', ' venus', 'jupiter']);
+    selenites = await createGroupAsync(luna, 'selenites');
+    await Promise.all([promoteToAdmin(selenites, luna, venus), subscribeToAsync(mars, selenites)]);
+  });
+
+  it(`should block Mars in Selenites`, async () => {
+    {
+      const resp = await blockUserInGroup(mars, selenites, luna);
+      expect(resp, 'to satisfy', { __httpCode: 200, blockedUsers: [mars.user.id] });
+    }
+
+    {
+      const resp = await getBlockedUsers(selenites, luna);
+      expect(resp, 'to satisfy', { __httpCode: 200, blockedUsers: [mars.user.id] });
+    }
+  });
+
+  it(`should not block Venus (as admin) in Selenites`, async () => {
+    const resp = await blockUserInGroup(venus, selenites, luna);
+    expect(resp, 'to satisfy', { __httpCode: 403 });
+  });
+
+  it(`should not allow Mars (as non-admin) to block anyone in Selenites`, async () => {
+    const resp = await blockUserInGroup(jupiter, selenites, mars);
+    expect(resp, 'to satisfy', { __httpCode: 403 });
+  });
+
+  describe('Mars is blocked in Selenites', () => {
+    beforeEach(() => blockUserInGroup(mars, selenites, luna));
+
+    it(`should allow Luna to unblock Mars`, async () => {
+      const resp = await unblockUserInGroup(mars, selenites, luna);
+      expect(resp, 'to satisfy', { __httpCode: 200, blockedUsers: [] });
+    });
+
+    it(`should not allow Jupiter (as non-admin) to unblock Mars`, async () => {
+      const resp = await unblockUserInGroup(mars, selenites, jupiter);
+      expect(resp, 'to satisfy', { __httpCode: 403 });
+    });
+
+    it(`should not allow Mars to create post in Selenites`, async () => {
+      const resp = await performJSONRequest(
+        'POST',
+        '/v1/posts',
+        {
+          post: { body: 'Hello' },
+          meta: { feeds: [selenites.username] },
+        },
+        authHeaders(mars),
+      );
+      expect(resp, 'to satisfy', { __httpCode: 403 });
+    });
+  });
+});
+
+// Helpers
+
+function blockUserInGroup(user, group, admin) {
+  return performJSONRequest(
+    'POST',
+    `/v2/groups/${group.username}/block/${user.username}`,
+    {},
+    authHeaders(admin),
+  );
+}
+
+function unblockUserInGroup(user, group, admin) {
+  return performJSONRequest(
+    'POST',
+    `/v2/groups/${group.username}/unblock/${user.username}`,
+    {},
+    authHeaders(admin),
+  );
+}
+
+function getBlockedUsers(group, admin) {
+  return performJSONRequest(
+    'GET',
+    `/v2/groups/${group.username}/blockedUsers`,
+    {},
+    authHeaders(admin),
+  );
+}

--- a/test/functional/group-blocks.js
+++ b/test/functional/group-blocks.js
@@ -20,11 +20,14 @@ import Session from './realtime-session';
 describe('Group Blocks', () => {
   beforeEach(() => cleanDB($pg_database));
 
-  let luna, mars, venus, jupiter, selenites;
+  let luna, mars, venus, jupiter, selenites, celestials;
 
   beforeEach(async () => {
     [luna, mars, venus, jupiter] = await createTestUsers(['luna', 'mars', ' venus', 'jupiter']);
-    selenites = await createGroupAsync(luna, 'selenites');
+    [selenites, celestials] = await Promise.all([
+      createGroupAsync(luna, 'selenites'),
+      createGroupAsync(luna, 'celestials'),
+    ]);
     await Promise.all([promoteToAdmin(selenites, luna, venus), subscribeToAsync(mars, selenites)]);
   });
 
@@ -42,6 +45,11 @@ describe('Group Blocks', () => {
 
   it(`should not block Venus (as admin) in Selenites`, async () => {
     const resp = await blockUserInGroup(venus, selenites, luna);
+    expect(resp, 'to satisfy', { __httpCode: 403 });
+  });
+
+  it(`should not block Celestials (as group) in Selenites`, async () => {
+    const resp = await blockUserInGroup(celestials, selenites, luna);
     expect(resp, 'to satisfy', { __httpCode: 403 });
   });
 

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -178,7 +178,7 @@ describe('Group Moderation', () => {
           expect(marsEvents, 'to satisfy', [
             {
               event_type: EVENT_TYPES.COMMENT_MODERATED,
-              created_user_id: luna.user.id,
+              created_user_id: null,
               post_id: post.id,
             },
           ]);
@@ -194,7 +194,7 @@ describe('Group Moderation', () => {
           expect(marsEvents, 'to satisfy', [
             {
               event_type: EVENT_TYPES.COMMENT_MODERATED,
-              created_user_id: jupiter.user.id,
+              created_user_id: null,
               post_id: post.id,
               group_id: expect.it('to be one of', [gods.group.id, celestials.group.id]),
             },
@@ -212,7 +212,7 @@ describe('Group Moderation', () => {
           expect(lunaEvents, 'to satisfy', [
             {
               event_type: EVENT_TYPES.COMMENT_MODERATED,
-              created_user_id: mars.user.id,
+              created_user_id: null,
               post_id: post.id,
               group_id: expect.it('to be one of', [gods.group.id, celestials.group.id]),
             },
@@ -279,7 +279,7 @@ describe('Group Moderation', () => {
           expect(lunaEvents, 'to satisfy', [
             {
               event_type: EVENT_TYPES.POST_MODERATED,
-              created_user_id: mars.user.id,
+              created_user_id: null,
               group_id: celestials.group.id,
             },
           ]);
@@ -382,7 +382,7 @@ describe('Group Moderation', () => {
               expect(lunaEvents, 'to satisfy', [
                 {
                   event_type: EVENT_TYPES.POST_MODERATED,
-                  created_user_id: mars.user.id,
+                  created_user_id: null,
                   group_id: expect.it('to be one of', [gods.group.id, celestials.group.id]),
                   post_id: post.id,
                 },
@@ -444,7 +444,7 @@ describe('Group Moderation', () => {
               expect(lunaEvents, 'to satisfy', [
                 {
                   event_type: EVENT_TYPES.POST_MODERATED,
-                  created_user_id: jupiter.user.id,
+                  created_user_id: null,
                   group_id: gods.group.id,
                   post_id: post.id,
                 },

--- a/test/functional/posts/posts.js
+++ b/test/functional/posts/posts.js
@@ -610,7 +610,7 @@ describe('PostsController', () => {
           });
       });
 
-      it('should not allow a user to post to a group to which they are not subscribed', (done) => {
+      it('should allow a user to post to a public group to which they are not subscribed', (done) => {
         request
           .post(`${app.context.config.host}/v1/posts`)
           .send({
@@ -618,9 +618,10 @@ describe('PostsController', () => {
             meta: { feeds: [groupName] },
             authToken: otherUserAuthToken,
           })
-          .end((err) => {
-            err.should.not.be.empty;
-            err.status.should.eql(403);
+          .end((err, res) => {
+            res.status.should.eql(200);
+            const post = res.body.posts;
+            post.body.should.eql('Post body');
             done();
           });
       });
@@ -1118,9 +1119,9 @@ describe('PostsController', () => {
           expect(postedToUsernames(res), 'to equal', [luna.username]);
         });
 
-        it('should not be able to add a group to post when Luna not in the group', async () => {
+        it('should be able to add a public group to post when Luna not in the group', async () => {
           const call = updatePost(post, luna, { feeds: [luna.username, evilmartians.username] });
-          await expect(call, 'to be rejected with', /\(403\)/);
+          await expect(call, 'to be fulfilled');
         });
 
         it('should not be able to add a direct recipient to post', async () => {

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -158,6 +158,7 @@ export const userBasic = {
 export const groupBasic = {
   ...userBasic,
   isRestricted: expect.it('to be boolString'),
+  acceptsPosts: expect.it('to be a boolean'),
   type: expect.it('to equal', 'group'),
 };
 

--- a/test/integration/models/group-blocks.js
+++ b/test/integration/models/group-blocks.js
@@ -1,0 +1,55 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../../dbCleaner';
+import { dbAdapter, User, Group } from '../../../app/models';
+
+describe('Group blocks', () => {
+  beforeEach(() => cleanDB($pg_database));
+
+  let luna, mars, selenites;
+
+  beforeEach(async () => {
+    luna = new User({ username: 'luna', password: 'pw' });
+    mars = new User({ username: 'mars', password: 'pw' });
+    await Promise.all([luna.create(), mars.create()]);
+
+    selenites = new Group({ username: 'selenites' });
+    await selenites.create(luna.id);
+  });
+
+  it(`should block Mars in Selenites`, async () => {
+    const ok = await selenites.blockUser(mars.id, luna.id);
+    expect(ok, 'to be true');
+    const blockedIds = await dbAdapter.userIdsBlockedInGroup(selenites.id);
+    expect(blockedIds, 'to equal', [mars.id]);
+  });
+
+  describe(`Mars is blocked in Selenites`, () => {
+    beforeEach(() => selenites.blockUser(mars.id, luna.id));
+
+    it(`should not block Mars in Selenites twice`, async () => {
+      const ok = await selenites.blockUser(mars.id, luna.id);
+      expect(ok, 'to be false');
+      const blockedIds = await dbAdapter.userIdsBlockedInGroup(selenites.id);
+      expect(blockedIds, 'to equal', [mars.id]);
+    });
+
+    it(`should unblock Mars in Selenites`, async () => {
+      const ok = await selenites.unblockUser(mars.id, luna.id);
+      expect(ok, 'to be true');
+      const blockedIds = await dbAdapter.userIdsBlockedInGroup(selenites.id);
+      expect(blockedIds, 'to equal', []);
+    });
+
+    it(`should not unblock Mars in Selenites twice`, async () => {
+      let ok = await selenites.unblockUser(mars.id, luna.id);
+      expect(ok, 'to be true');
+      ok = await selenites.unblockUser(mars.id, luna.id);
+      expect(ok, 'to be false');
+      const blockedIds = await dbAdapter.userIdsBlockedInGroup(selenites.id);
+      expect(blockedIds, 'to equal', []);
+    });
+  });
+});

--- a/test/integration/models/group-blocks.js
+++ b/test/integration/models/group-blocks.js
@@ -4,19 +4,22 @@ import expect from 'unexpected';
 
 import cleanDB from '../../dbCleaner';
 import { dbAdapter, User, Group } from '../../../app/models';
+import { EVENT_TYPES } from '../../../app/support/EventTypes';
 
 describe('Group blocks', () => {
   beforeEach(() => cleanDB($pg_database));
 
-  let luna, mars, selenites;
+  let luna, mars, venus, selenites;
 
   beforeEach(async () => {
     luna = new User({ username: 'luna', password: 'pw' });
     mars = new User({ username: 'mars', password: 'pw' });
-    await Promise.all([luna.create(), mars.create()]);
+    venus = new User({ username: 'venus', password: 'pw' });
+    await Promise.all([luna.create(), mars.create(), venus.create()]);
 
     selenites = new Group({ username: 'selenites' });
     await selenites.create(luna.id);
+    await selenites.addAdministrator(venus.id);
   });
 
   it(`should block Mars in Selenites`, async () => {
@@ -24,6 +27,24 @@ describe('Group blocks', () => {
     expect(ok, 'to be true');
     const blockedIds = await dbAdapter.userIdsBlockedInGroup(selenites.id);
     expect(blockedIds, 'to equal', [mars.id]);
+  });
+
+  it(`should create notifications for Mars and all Selenites admins on block`, async () => {
+    await selenites.blockUser(mars.id, luna.id);
+
+    for (const user of [luna, mars, venus]) {
+      // eslint-disable-next-line no-await-in-loop
+      const events = await dbAdapter.getUserEvents(user.intId, [EVENT_TYPES.BLOCKED_IN_GROUP]);
+      expect(events, 'to satisfy', [
+        {
+          user_id: user.intId,
+          event_type: EVENT_TYPES.BLOCKED_IN_GROUP,
+          created_by_user_id: luna.intId,
+          target_user_id: mars.intId,
+          group_id: selenites.intId,
+        },
+      ]);
+    }
   });
 
   describe(`Mars is blocked in Selenites`, () => {
@@ -50,6 +71,34 @@ describe('Group blocks', () => {
       expect(ok, 'to be false');
       const blockedIds = await dbAdapter.userIdsBlockedInGroup(selenites.id);
       expect(blockedIds, 'to equal', []);
+    });
+
+    it(`should create notifications for Mars and all Selenites admins on unblock`, async () => {
+      await selenites.unblockUser(mars.id, luna.id);
+
+      for (const user of [luna, mars, venus]) {
+        // eslint-disable-next-line no-await-in-loop
+        const events = await dbAdapter.getUserEvents(user.intId, [
+          EVENT_TYPES.BLOCKED_IN_GROUP,
+          EVENT_TYPES.UNBLOCKED_IN_GROUP,
+        ]);
+        expect(events, 'to satisfy', [
+          {
+            user_id: user.intId,
+            event_type: EVENT_TYPES.UNBLOCKED_IN_GROUP,
+            created_by_user_id: luna.intId,
+            target_user_id: mars.intId,
+            group_id: selenites.intId,
+          },
+          {
+            user_id: user.intId,
+            event_type: EVENT_TYPES.BLOCKED_IN_GROUP,
+            created_by_user_id: luna.intId,
+            target_user_id: mars.intId,
+            group_id: selenites.intId,
+          },
+        ]);
+      }
     });
   });
 });


### PR DESCRIPTION
### Added
- Users can now write posts to public and protected groups that they are not members of.
- Group administrators can now block certain users from write to the group. This feature includes:
  - New API methods for group administrators:
    - `GET /v2/groups/:groupName/blockedUsers` 
    - `POST /v2/groups/:groupName/block/:userName`
    - `POST /v2/groups/:groupName/unblock/:userName`
  - New event types, 'blocked_in_group' and 'unblocked_in_group', which are sent to the (un)blocked user and to the all of group admins.
  - When some user is blocked/unblocked in a group, the 'global:user:update' realtime event _about the group_ is sent. This event contain general group info, including the new  _acceptsPosts_ field (see below), so the listening user can determine, if he can or cannot post to the group.
- Any serialized group data (not user data) in API responses now have additional boolean acceptsPosts field. This field is true_ if the current user can create posts in this group. 
  
  This field takes into account all factors, including the user blocking described above. It will make it easier for the client to determine if it is possible to post to the group.

## Changed
- Notifications: hide the initiator of some events from the event target user. It is useful, for example, to protect the anonymity of group admins. The affected event types are: 'comment_moderated', 'post_moderated', 'blocked_in_group', 'unblocked_in_group'.
