### PR TITLE
Fix notification digest links

### DIFF
--- a/app/mailers/NotificationDigestMailer.js
+++ b/app/mailers/NotificationDigestMailer.js
@@ -386,9 +386,9 @@ function getEventMarkup(eventText) {
 
 function makeBacklinkLink({ targetPostId, targetCommentId }) {
   if (targetCommentId) {
-    return `<a href="/post/${targetPostId}#comment-${targetCommentId}">comment</a>`;
+    return `<a href="${config.host}/post/${targetPostId}#comment-${targetCommentId}">comment</a>`;
   } else if (targetPostId) {
-    return `<a href="/post/${targetPostId}">post</a>`;
+    return `<a href="${config.host}/post/${targetPostId}">post</a>`;
   }
 
   return 'deleted entry';


### PR DESCRIPTION
Backlink's post/comment links was relative instead of absolute