### PR TITLE
Admin API improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.7.0] - Not Released
 ### Added
+- New Admin API methods:
+  - `GET /api/admin/users` method returns all users sorted by registration date.
+  - `GET /api/admin/users/:username/info` method returns information about the
+    specific user.
+  - `POST /users/:username/suspend` and `POST /users/:username/unsuspend`
+    methods suspended/unsuspended given user.
 - The server administrator can disallow registration without invites. The
   ability to create new invites can be limited or disabled for the given user.
   One can see who invited the user (this is public information).
@@ -45,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     'undisable_bans';
   - There are two new events in user notifications: 'bans_in_group_disabled' and
     'bans_in_group_enabled'.
+
+### Changed
+- The GONE_SUSPENDED user status now doesn't allow user to activate her account
+  back.
+- The `POST /api/admin/users/:username/freeze` methods now accepts 'freezeUntil'
+  parameter in the following formats:
+  - ISO Datetime
+  - ISO Date
+  - ISO Duration ("P...")
+  - The "Infinity" string (means forever freeze)
+- The admin user serializer now returns 'freezeUntil' and 'goneStatus' fields.
 
 ## [2.6.0] - 2023-01-18
 ### Added

--- a/app/controllers/api/admin/ModeratorController.ts
+++ b/app/controllers/api/admin/ModeratorController.ts
@@ -8,7 +8,7 @@ import { ForbiddenException, ValidationException } from '../../../support/except
 import { ACT_FREEZE_USER, ACT_UNFREEZE_USER } from '../../../models/admins';
 
 import { getQueryParams } from './query-params';
-import { serializeUsers } from './serializers';
+import { serializeUser, serializeUsers } from './serializers';
 import { freezeUserInputSchema } from './data-schemes/freeze';
 
 export async function listAll(ctx: Ctx) {
@@ -88,5 +88,16 @@ export const unfreezeUser = compose([
     });
 
     ctx.body = {};
+  },
+]);
+
+export const userInfo = compose([
+  targetUserRequired(),
+  async (ctx: Ctx<{ targetUser: User }>) => {
+    const { targetUser } = ctx.state;
+
+    ctx.body = {
+      user: await serializeUser(targetUser.id),
+    };
   },
 ]);

--- a/app/controllers/api/admin/ModeratorController.ts
+++ b/app/controllers/api/admin/ModeratorController.ts
@@ -11,6 +11,19 @@ import { getQueryParams } from './query-params';
 import { serializeUsers } from './serializers';
 import { freezeUserInputSchema } from './data-schemes/freeze';
 
+export async function listAll(ctx: Ctx) {
+  const { limit, offset } = getQueryParams(ctx.request.query);
+
+  const userIds = await dbAdapter.getAllUsersIds(limit + 1, offset, ['user']);
+  const isLastPage = userIds.length <= limit;
+
+  if (!isLastPage) {
+    userIds.length = limit;
+  }
+
+  ctx.body = { users: await serializeUsers(userIds), isLastPage };
+}
+
 export async function listFrozen(ctx: Ctx) {
   const { limit, offset } = getQueryParams(ctx.request.query);
 

--- a/app/controllers/api/admin/ModeratorController.ts
+++ b/app/controllers/api/admin/ModeratorController.ts
@@ -1,5 +1,5 @@
 import compose from 'koa-compose';
-import { DateTime } from 'luxon';
+import { DateTime, Duration } from 'luxon';
 
 import { User, dbAdapter } from '../../../models';
 import { Ctx } from '../../../support/types';
@@ -52,21 +52,31 @@ export const freezeUser = compose([
     }
 
     const { freezeUntil } = ctx.request.body as { freezeUntil: string };
-    const freezeTime = DateTime.fromISO(freezeUntil, { zone: ctx.config.ianaTimeZone });
 
-    if (!freezeTime.isValid) {
-      throw new ValidationException(`Invalid ISO datetime in 'freezeUntil'`);
-    }
+    if (freezeUntil === 'Infinity') {
+      // ok
+    } else if (freezeUntil.startsWith('P')) {
+      // Duration
+      if (!Duration.fromISO(freezeUntil).isValid) {
+        throw new ValidationException(`Invalid duration string in 'freezeUntil'`);
+      }
+    } else {
+      // Time as ISO time string
+      const d = DateTime.fromISO(freezeUntil, { zone: ctx.config.ianaTimeZone });
 
-    if (freezeTime.diffNow().valueOf() < 0) {
-      throw new ValidationException(`'freezeUntil' should be in the future`);
+      if (!d.isValid) {
+        throw new ValidationException(`Invalid datetime string in 'freezeUntil'`);
+      }
+
+      if (d.diffNow().valueOf() < 60 * 1000) {
+        throw new ValidationException(`'freezeUntil' should be in the future`);
+      }
     }
 
     await dbAdapter.doInTransaction(async () => {
-      await targetUser.freeze(freezeTime.toISO());
-      await dbAdapter.createAdminAction(ACT_FREEZE_USER, user, targetUser, {
-        freezeUntil: freezeTime.toISO(),
-      });
+      await targetUser.freeze(freezeUntil);
+      const until = await targetUser.frozenUntil();
+      await dbAdapter.createAdminAction(ACT_FREEZE_USER, user, targetUser, { freezeUntil: until });
     });
 
     ctx.body = {};
@@ -83,7 +93,7 @@ export const unfreezeUser = compose([
     }
 
     await dbAdapter.doInTransaction(async () => {
-      await targetUser.freeze(0);
+      await targetUser.freeze('P0D');
       await dbAdapter.createAdminAction(ACT_UNFREEZE_USER, user, targetUser);
     });
 

--- a/app/controllers/api/admin/data-schemes/freeze.ts
+++ b/app/controllers/api/admin/data-schemes/freeze.ts
@@ -5,6 +5,13 @@ export const freezeUserInputSchema = {
   required: ['freezeUntil'],
 
   properties: {
-    freezeUntil: { type: 'string', format: 'date-time' },
+    freezeUntil: {
+      oneOf: [
+        { const: 'Infinity' },
+        { type: 'string', format: 'date-time' },
+        { type: 'string', format: 'date' },
+        { type: 'string', pattern: 'P\\w+', description: 'Duration' },
+      ],
+    },
   },
 };

--- a/app/controllers/api/admin/serializers.ts
+++ b/app/controllers/api/admin/serializers.ts
@@ -6,13 +6,17 @@ import { dbAdapter } from '../../../models';
 export async function serializeUsers(userIds: UUID[]) {
   const users = (await dbAdapter.getUsersByIds(uniq(userIds))).filter((u) => u.isUser());
   userIds = users.map((u) => u.id);
-  const rolesAssoc = await dbAdapter.getUsersAdminRolesAssoc(userIds);
-  return users.map((user) => ({
+  const [rolesAssoc, frozensUntil] = await Promise.all([
+    dbAdapter.getUsersAdminRolesAssoc(userIds),
+    dbAdapter.usersFrozenUntil(userIds),
+  ]);
+  return users.map((user, i) => ({
     id: user.id,
     username: user.username,
     screenName: user.screenName,
     profilePicture: user.profilePictureLargeUrl,
     goneStatus: user.goneStatusName,
+    frozenUntil: frozensUntil[i],
     roles: rolesAssoc[user.id] ?? [],
   }));
 }

--- a/app/controllers/api/admin/serializers.ts
+++ b/app/controllers/api/admin/serializers.ts
@@ -12,6 +12,7 @@ export async function serializeUsers(userIds: UUID[]) {
     username: user.username,
     screenName: user.screenName,
     profilePicture: user.profilePictureLargeUrl,
+    goneStatus: user.goneStatusName,
     roles: rolesAssoc[user.id] ?? [],
   }));
 }

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex';
 import { DbAdapter, type InvitationRecord } from './support/DbAdapter';
 import PubSubAdapter from './pubsub';
 import { GONE_NAMES } from './models/user';
-import { Nullable, UUID } from './support/types';
+import { ISO8601DateTimeString, ISO8601DurationString, Nullable, UUID } from './support/types';
 import { SessionTokenV1Store } from './models/auth-tokens';
 import { List } from './support/open-lists';
 
@@ -74,7 +74,7 @@ export class User {
   getMyDiscussionsTimelineIntId(): Promise<number | null>;
   getSavesTimelineIntId(): Promise<number | null>;
 
-  freeze(freezeTime: number | string): Promise<void>;
+  freeze(freezeTime: ISO8601DateTimeString | ISO8601DurationString | 'Infinity'): Promise<void>;
   isFrozen(): Promise<boolean>;
   frozenUntil(): Promise<Date | null>;
 

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -37,7 +37,9 @@ export class User {
   readonly isActive: boolean;
   type: 'user';
   invitationId: number | null;
-  setGoneStatus(status: keyof typeof GONE_NAMES): Promise<void>;
+  goneStatus: keyof typeof GONE_NAMES | null;
+  goneStatusName: string;
+  setGoneStatus(status: keyof typeof GONE_NAMES | null): Promise<void>;
   unban(usernames: string): Promise<1>;
   unsubscribeFrom(targetUser: User): Promise<boolean>;
   getHomeFeeds(): Promise<Timeline[]>;

--- a/app/models/admins.ts
+++ b/app/models/admins.ts
@@ -6,8 +6,12 @@ export const ACT_GIVE_MODERATOR_RIGHTS = 'give_moderator_rights';
 export const ACT_REMOVE_MODERATOR_RIGHTS = 'remove_moderator_rights';
 export const ACT_FREEZE_USER = 'freeze_user';
 export const ACT_UNFREEZE_USER = 'unfreeze_user';
+export const ACT_SUSPEND_USER = 'suspend_user';
+export const ACT_UNSUSPEND_USER = 'unsuspend_user';
 export type AdminAction =
   | typeof ACT_GIVE_MODERATOR_RIGHTS
   | typeof ACT_REMOVE_MODERATOR_RIGHTS
   | typeof ACT_FREEZE_USER
-  | typeof ACT_UNFREEZE_USER;
+  | typeof ACT_UNFREEZE_USER
+  | typeof ACT_SUSPEND_USER
+  | typeof ACT_UNSUSPEND_USER;

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -198,7 +198,7 @@ export function addModel(dbAdapter) {
      * User.isResumable is true if user is gone but can be resumed
      */
     get isResumable() {
-      return [GONE_COOLDOWN, GONE_SUSPENDED].includes(this.goneStatus);
+      return [GONE_COOLDOWN].includes(this.goneStatus);
     }
 
     static stopList(skipExtraList) {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -563,6 +563,14 @@ export function addModel(dbAdapter) {
       await Promise.all(managedGroupIds.map((id) => pubSub.globalUserUpdate(id)));
     }
 
+    get goneStatusName() {
+      if (this.goneStatus === null) {
+        return 'ACTIVE';
+      }
+
+      return GONE_NAMES[this.goneStatus] ?? `STATUS_${this.goneStatus}`;
+    }
+
     async getPastUsernames() {
       return await dbAdapter.getPastUsernames(this.id);
     }

--- a/app/routes/api/admin/ModeratorRoute.ts
+++ b/app/routes/api/admin/ModeratorRoute.ts
@@ -7,6 +7,7 @@ import {
   freezeUser,
   listAll,
   listFrozen,
+  suspendUser,
   unfreezeUser,
   userInfo,
 } from '../../../controllers/api/admin/ModeratorController';
@@ -20,4 +21,6 @@ export default function addRoutes(router: Router<DefaultState, AppContext>) {
   router.get('/users/:username/info', mw, userInfo);
   router.post('/users/:username/freeze', mw, freezeUser);
   router.post('/users/:username/unfreeze', mw, unfreezeUser);
+  router.post('/users/:username/suspend', mw, suspendUser(true));
+  router.post('/users/:username/unsuspend', mw, suspendUser(false));
 }

--- a/app/routes/api/admin/ModeratorRoute.ts
+++ b/app/routes/api/admin/ModeratorRoute.ts
@@ -8,6 +8,7 @@ import {
   listAll,
   listFrozen,
   unfreezeUser,
+  userInfo,
 } from '../../../controllers/api/admin/ModeratorController';
 import { AppContext } from '../../../support/types';
 
@@ -16,6 +17,7 @@ export default function addRoutes(router: Router<DefaultState, AppContext>) {
 
   router.get('/users', mw, listAll);
   router.get('/users/frozen', mw, listFrozen);
+  router.get('/users/:username/info', mw, userInfo);
   router.post('/users/:username/freeze', mw, freezeUser);
   router.post('/users/:username/unfreeze', mw, unfreezeUser);
 }

--- a/app/routes/api/admin/ModeratorRoute.ts
+++ b/app/routes/api/admin/ModeratorRoute.ts
@@ -5,6 +5,7 @@ import { adminRolesRequired } from '../../../controllers/middlewares/admin-only'
 import { ROLE_MODERATOR } from '../../../models/admins';
 import {
   freezeUser,
+  listAll,
   listFrozen,
   unfreezeUser,
 } from '../../../controllers/api/admin/ModeratorController';
@@ -13,6 +14,7 @@ import { AppContext } from '../../../support/types';
 export default function addRoutes(router: Router<DefaultState, AppContext>) {
   const mw = adminRolesRequired(ROLE_MODERATOR);
 
+  router.get('/users', mw, listAll);
   router.get('/users/frozen', mw, listFrozen);
   router.post('/users/:username/freeze', mw, freezeUser);
   router.post('/users/:username/unfreeze', mw, unfreezeUser);

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -144,6 +144,7 @@ export class DbAdapter {
   ): Promise<
     Map<UUID, typeof User.ACCEPT_DIRECTS_FROM_ALL | typeof User.ACCEPT_DIRECTS_FROM_FRIENDS>
   >;
+  getAllUsersIds(limit?: number, offset?: number, types?: ('user' | 'group')[]): Promise<UUID[]>;
 
   getUsersIdsByIntIds(intIds: number[]): Promise<{ id: number; uid: UUID }[]>;
   getPostsIdsByIntIds(intIds: number[]): Promise<{ id: number; uid: UUID }[]>;

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -160,6 +160,7 @@ export class DbAdapter {
     freezeTime: ISO8601DateTimeString | ISO8601DurationString | 'Infinity',
   ): Promise<void>;
   userFrozenUntil(userId: UUID): Promise<Date | null>;
+  usersFrozenUntil(userIds: UUID[]): Promise<(Date | null)[]>;
   isUserFrozen(userId: UUID): Promise<boolean>;
   cleanFrozenUsers(): Promise<void>;
   getFrozenUsers(

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -1,6 +1,6 @@
 import { Knex } from 'knex';
 
-import { IPAddr, Nullable, UUID } from '../types';
+import { IPAddr, ISO8601DateTimeString, ISO8601DurationString, Nullable, UUID } from '../types';
 import { AppTokenV1, Attachment, Comment, Group, Post, Timeline, User, Job } from '../../models';
 import {
   AppTokenCreateParams,
@@ -155,7 +155,10 @@ export class DbAdapter {
   setUserSysPrefs<T>(userId: UUID, key: string, value: T): Promise<void>;
 
   // Freeze
-  freezeUser(userId: UUID, freezeTime: number | string): Promise<void>;
+  freezeUser(
+    userId: UUID,
+    freezeTime: ISO8601DateTimeString | ISO8601DurationString | 'Infinity',
+  ): Promise<void>;
   userFrozenUntil(userId: UUID): Promise<Date | null>;
   isUserFrozen(userId: UUID): Promise<boolean>;
   cleanFrozenUsers(): Promise<void>;

--- a/app/support/DbAdapter/users.js
+++ b/app/support/DbAdapter/users.js
@@ -621,6 +621,16 @@ const usersTrait = (superClass) =>
         { path: [key], value: JSON.stringify(value), userId },
       );
     }
+
+    getAllUsersIds(limit = 30, offset = 0, types = ['user']) {
+      return this.database.getCol(
+        `select uid from users 
+          where type = any(:types)
+          order by created_at desc
+          limit :limit offset :offset`,
+        { limit, offset, types },
+      );
+    }
   };
 
 export default usersTrait;

--- a/app/support/DbAdapter/users.js
+++ b/app/support/DbAdapter/users.js
@@ -1,17 +1,20 @@
 import config from 'config';
 import _ from 'lodash';
 import validator from 'validator';
-import { DateTime } from 'luxon';
+import { DateTime, Duration } from 'luxon';
 import { camelizeKeys } from 'humps';
 
 import { User, Group, Comment } from '../../models';
 import { normalizeEmail } from '../email-norm';
 import { List } from '../open-lists';
+import { MAX_DATE } from '../constants';
 
 import { initObject, prepareModelPayload } from './utils';
 
 /**
  * @typedef {import('../types').UUID} UUID
+ * @typedef {import('../types').ISO8601DateTimeString} ISO8601DateTimeString
+ * @typedef {import('../types').ISO8601DurationString} ISO8601DurationString
  */
 
 const usersTrait = (superClass) =>
@@ -550,22 +553,38 @@ const usersTrait = (superClass) =>
 
     /**
      * @param {UUID} userId
-     * @param {string|number} freezeTime
+     * @param {ISO8601DateTimeString | ISO8601DurationString | "Infinity"} freezeTime
      * @returns {Promise<void>}
      */
     async freezeUser(userId, freezeTime) {
-      if (Number.isFinite(freezeTime)) {
-        // Time in seconds
-        freezeTime = this.database.raw(`now() + ? * '1 second'::interval`, freezeTime);
+      let expiresAt;
+
+      if (freezeTime === 'Infinity') {
+        expiresAt = freezeTime;
+      } else if (freezeTime.startsWith('P')) {
+        // Duration
+        const d = Duration.fromISO(freezeTime);
+
+        if (!d.isValid) {
+          throw new Error(`Invalid duration string: "${freezeTime}"`);
+        }
+
+        expiresAt = this.database.raw(`now() + ?`, freezeTime);
       } else {
         // Time as ISO time string
-        freezeTime = DateTime.fromISO(freezeTime, { zone: config.ianaTimeZone }).toJSDate();
+        const d = DateTime.fromISO(freezeTime, { zone: config.ianaTimeZone });
+
+        if (!d.isValid) {
+          throw new Error(`Invalid datetime string: "${freezeTime}"`);
+        }
+
+        expiresAt = DateTime.fromISO(freezeTime, { zone: config.ianaTimeZone }).toJSDate();
       }
 
       await this.database.raw(
-        `insert into frozen_users (user_id, expires_at) values (:userId, :freezeTime)
+        `insert into frozen_users (user_id, expires_at) values (:userId, :expiresAt)
         on conflict (user_id) do update set expires_at = excluded.expires_at`,
-        { userId, freezeTime },
+        { userId, expiresAt },
       );
     }
 
@@ -586,7 +605,12 @@ const usersTrait = (superClass) =>
         `select expires_at from frozen_users where user_id = :userId and expires_at > now()`,
         { userId },
       );
-      return exp || null;
+
+      if (!exp || exp instanceof Date) {
+        return exp ?? null;
+      }
+
+      return MAX_DATE;
     }
 
     async cleanFrozenUsers() {

--- a/app/support/constants.ts
+++ b/app/support/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_DATE = new Date(8640000000000000);

--- a/app/support/types/branded.ts
+++ b/app/support/types/branded.ts
@@ -2,4 +2,5 @@ import { Branded } from './helpers';
 
 export type UUID = Branded<string, 'uuid'>;
 export type IPAddr = Branded<string, 'IP address'>;
+export type ISO8601DateTimeString = Branded<string, 'ISO 8601 DateTime'>;
 export type ISO8601DurationString = Branded<string, 'ISO 8601 Duration'>;

--- a/bin/usermod.js
+++ b/bin/usermod.js
@@ -148,7 +148,7 @@ function freezeUser(setDays) {
       throw new Error(`Invalid 'days' value`);
     }
 
-    await account.freeze(days * 24 * 3600);
+    await account.freeze(`P${days}D`);
     const upTo = await account.frozenUntil();
 
     if (upTo) {

--- a/test/functional/admin.ts
+++ b/test/functional/admin.ts
@@ -278,11 +278,10 @@ describe('Admin API', () => {
     });
 
     it(`should freeze Venus with 'freezeUntil' in the future`, async () => {
-      const now = await dbAdapter.now();
       const response = await performJSONRequest(
         'POST',
         `/api/admin/users/${venus.username}/freeze`,
-        { freezeUntil: DateTime.fromJSDate(now).plus({ days: 1 }).toISO() },
+        { freezeUntil: 'P1D' },
         authHeaders(mars),
       );
       await expect(response, 'to satisfy', { __httpCode: 200 });

--- a/test/functional/admin.ts
+++ b/test/functional/admin.ts
@@ -393,7 +393,7 @@ describe('Admin API', () => {
     });
   });
 
-  describe('List of all users', () => {
+  describe('Users list and user info', () => {
     it(`should return list of all users ordered by createdAt`, async () => {
       const sortedUsers = [luna, mars, venus].sort(
         (a, b) => parseInt(b.user.createdAt) - parseInt(a.user.createdAt),
@@ -403,6 +403,19 @@ describe('Admin API', () => {
         __httpCode: 200,
         users: sortedUsers.map((c) => ({ id: c.user.id })),
         isLastPage: true,
+      });
+    });
+
+    it(`should return info about user`, async () => {
+      const response = await performJSONRequest(
+        'GET',
+        `/api/admin/users/${luna.username}/info`,
+        null,
+        authHeaders(mars),
+      );
+      await expect(response, 'to satisfy', {
+        __httpCode: 200,
+        user: { id: luna.user.id },
       });
     });
   });

--- a/test/functional/admin.ts
+++ b/test/functional/admin.ts
@@ -392,4 +392,18 @@ describe('Admin API', () => {
       });
     });
   });
+
+  describe('List of all users', () => {
+    it(`should return list of all users ordered by createdAt`, async () => {
+      const sortedUsers = [luna, mars, venus].sort(
+        (a, b) => parseInt(b.user.createdAt) - parseInt(a.user.createdAt),
+      );
+      const response = await performJSONRequest('GET', `/api/admin/users`, null, authHeaders(mars));
+      await expect(response, 'to satisfy', {
+        __httpCode: 200,
+        users: sortedUsers.map((c) => ({ id: c.user.id })),
+        isLastPage: true,
+      });
+    });
+  });
 });

--- a/test/functional/functional_test_helper.d.ts
+++ b/test/functional/functional_test_helper.d.ts
@@ -18,6 +18,6 @@ export function performJSONRequest(
   header?: Record<string, string>,
 ): Promise<{ __httpCode: number }>;
 
-export function authHeaders(userCtx: UserCtx): { Authorization?: `Bearer ${string}` };
+export function authHeaders(userCtx: UserCtx | null): { Authorization?: `Bearer ${string}` };
 
 export function cmpBy<T>(key: keyof T): (a: T, b: T) => number;

--- a/test/functional/gone-users.js
+++ b/test/functional/gone-users.js
@@ -359,12 +359,25 @@ describe('Gone users', () => {
   });
 
   describe(`Session`, () => {
-    it(`should not allow Luna to start session`, async () => {
+    it(`should not allow Luna to start session but allow to resume account`, async () => {
       const resp = await performJSONRequest('POST', `/v1/session`, {
         username: luna.username,
         password: luna.password,
       });
-      expect(resp, 'to satisfy', { __httpCode: 401 });
+      expect(resp, 'to satisfy', { __httpCode: 401, resumeToken: expect.it('to be a string') });
+    });
+
+    describe(`Luna is in GONE_SUSPENDED status`, () => {
+      beforeEach(() => setGoneStatus(luna, GONE_SUSPENDED));
+
+      it(`should not allow Luna to start session nor to resume account`, async () => {
+        const resp = await performJSONRequest('POST', `/v1/session`, {
+          username: luna.username,
+          password: luna.password,
+        });
+        expect(resp, 'to satisfy', { __httpCode: 401 });
+        expect(resp, 'not to have property', 'resumeToken');
+      });
     });
   });
 

--- a/test/functional/user-freeze.js
+++ b/test/functional/user-freeze.js
@@ -42,7 +42,7 @@ describe('User freeze', () => {
       );
 
       // Freeze!
-      await freeze(luna.user.id, 10);
+      await freeze(luna.user.id, 'PT10S');
     });
 
     it(`should not allow Luna to sign in by login and password`, async () => {


### PR DESCRIPTION
The GONE_SUSPENDED user status now doesn't allow user to activate her account back.

### Added
- New Admin API methods:
  - `GET /api/admin/users` method returns all users sorted by registration date.
  - `GET /api/admin/users/:username/info` method returns information about the specific user.
  - `POST /users/:username/suspend` and `POST /users/:username/unsuspend` methods suspended/unsuspended given user.

### Changed
- The `POST /api/admin/users/:username/freeze` methods now accepts 'freezeUntil' parameter in the following formats:
  - ISO Datetime
  - ISO Date
  - ISO Duration ("P...")
  - The "Infinity" string (means forever freeze)
- The admin user serializer now returns 'freezeUntil' and 'goneStatus' fields.
