### PR TITLE
Improve invitation handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.8.0] - Not released
+### Added
+- New Datadog counters for invitations:'invitation.create-time',
+  'invitation.create-requests', and 'invitation.use-requests'.
+
 ### Changed
 - Invitations from inactive (i.e. in some 'gone' status) users stop working.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.8.0] - Not released
+### Fixed
+- Invitations are no longer deleted when their author's data is deleted. These
+  invitations are instead anonymized. This is important for keeping a connection
+  with invited users.
 
 ## [2.7.0] - 2023-01-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.8.0] - Not released
+### Changed
+- Invitations from inactive (i.e. in some 'gone' status) users stop working.
+
 ### Fixed
 - Invitations are no longer deleted when their author's data is deleted. These
   invitations are instead anonymized. This is important for keeping a connection

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -760,6 +760,12 @@ async function validateInvitationAndSelectUsers(invitation, invitationId) {
     throw new NotFoundException(`Invitation "${invitationId}" not found`);
   }
 
+  const invAuthor = await dbAdapter.getUserByIntId(invitation.author);
+
+  if (!invAuthor.isActive) {
+    throw new NotFoundException(`Invitation "${invitationId}" not found`);
+  }
+
   if (invitation.registrations_count > 0 && invitation.single_use) {
     throw new ValidationException(`Somebody has already used invitation "${invitationId}"`);
   }

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import util from 'util';
 
+import monitorDog from 'monitor-dog';
 import _ from 'lodash';
 import compose from 'koa-compose';
 import jwt from 'jsonwebtoken';
@@ -810,6 +811,7 @@ async function validateInvitationAndSelectUsers(invitation, invitationId) {
 
 async function useInvitation(newUser, invitation, cancel_subscription = false) {
   await dbAdapter.useInvitation(invitation.secure_id);
+  monitorDog.increment('invitation.use-requests', 1);
   await EventService.onInvitationUsed(invitation.author, newUser.intId);
 
   if (cancel_subscription) {

--- a/app/controllers/api/v2/InvitationsController.js
+++ b/app/controllers/api/v2/InvitationsController.js
@@ -9,7 +9,7 @@ import {
   ValidationException,
 } from '../../../support/exceptions';
 import { serializeUsersByIds } from '../../../serializers/v2/user';
-import { authRequired } from '../../middlewares';
+import { authRequired, monitored } from '../../middlewares';
 import { TOO_OFTEN, TOO_SOON } from '../../../models/invitations';
 
 /**
@@ -85,6 +85,7 @@ export default class InvitationsController {
 
   static createInvitation = compose([
     authRequired(),
+    monitored('invitation.create'),
     /** @param {Ctx} ctx */
     async (ctx) => {
       const { user } = ctx.state;

--- a/app/controllers/api/v2/InvitationsController.js
+++ b/app/controllers/api/v2/InvitationsController.js
@@ -26,7 +26,7 @@ export default class InvitationsController {
 
     const invAuthor = await dbAdapter.getUserByIntId(invitation.author);
 
-    if (await invAuthor.isInvitesDisabled()) {
+    if (!invAuthor.isActive || (await invAuthor.isInvitesDisabled())) {
       throw new NotFoundException(`Can't find invitation '${ctx.params.secureId}'`);
     }
 

--- a/app/models/admins.ts
+++ b/app/models/admins.ts
@@ -8,6 +8,7 @@ export const ACT_FREEZE_USER = 'freeze_user';
 export const ACT_UNFREEZE_USER = 'unfreeze_user';
 export const ACT_SUSPEND_USER = 'suspend_user';
 export const ACT_UNSUSPEND_USER = 'unsuspend_user';
+
 export type AdminAction =
   | typeof ACT_GIVE_MODERATOR_RIGHTS
   | typeof ACT_REMOVE_MODERATOR_RIGHTS

--- a/app/support/user-deletion.ts
+++ b/app/support/user-deletion.ts
@@ -46,7 +46,7 @@ export const deleteAllUserData = combineTasks(
   deleteAppTokens,
   deleteExtAuthProfiles,
   deleteArchives,
-  deleteInvitations,
+  anonymizeInvitations,
   deleteLocalBumps,
   deleteSentEmailsLog,
   resetUserStatistics,
@@ -301,9 +301,17 @@ export async function deleteArchives(userId: UUID) {
   await dbAdapter.database.raw(`delete from hidden_likes where user_id = ?`, userId);
 }
 
-export async function deleteInvitations(userId: UUID) {
+export async function anonymizeInvitations(userId: UUID) {
   const user = await dbAdapter.getUserById(userId);
-  user && (await dbAdapter.database.raw(`delete from invitations where author = ?`, user.intId));
+  user &&
+    (await dbAdapter.database.raw(
+      `update invitations set
+          message='',
+          lang='en',
+          recommendations='{}'
+       where author = ?`,
+      user.intId,
+    ));
 }
 
 export async function deleteLocalBumps(userId: UUID) {


### PR DESCRIPTION
### Added
- New Datadog counters for invitations:'invitation.create-time', 'invitation.create-requests', and 'invitation.use-requests'.

### Changed
- Invitations from inactive (i.e. in some 'gone' status) users stop working.

### Fixed
- Invitations are no longer deleted when their author's data is deleted. These invitations are instead anonymized. This is important for keeping a connection with invited users.
