### PR TITLE
Bump Postgres version in dockerfile to 15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - 6379:6379
 
   postgres:
-    image: postgres:10
+    image: postgres:15
     restart: always
     environment:
       POSTGRES_DB: freefeed


### PR DESCRIPTION
This PR bumps postgres version used in dev docker container to 15 (because https://github.com/FreeFeed/freefeed-server/blob/stable/migrations/20221225135452_admin.ts doesn't work in v10)