### PR TITLE
Allow moderator to disable/enable invitations for specific user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.8.0] - Not released
+### Added
+- Allow moderator to disable/enable invitations for specific user. Methods are:
+  - `POST /users/:username/disable-invites`
+  - `POST /users/:username/enable-invites`
 
 ## [2.7.0] - 2023-01-19
 ### Added

--- a/app/models/admins.ts
+++ b/app/models/admins.ts
@@ -8,10 +8,14 @@ export const ACT_FREEZE_USER = 'freeze_user';
 export const ACT_UNFREEZE_USER = 'unfreeze_user';
 export const ACT_SUSPEND_USER = 'suspend_user';
 export const ACT_UNSUSPEND_USER = 'unsuspend_user';
+export const ACT_DISABLE_INVITES_FOR_USER = 'disable_invites_for_user';
+export const ACT_ENABLE_INVITES_FOR_USER = 'enable_invites_for_user';
 export type AdminAction =
   | typeof ACT_GIVE_MODERATOR_RIGHTS
   | typeof ACT_REMOVE_MODERATOR_RIGHTS
   | typeof ACT_FREEZE_USER
   | typeof ACT_UNFREEZE_USER
   | typeof ACT_SUSPEND_USER
-  | typeof ACT_UNSUSPEND_USER;
+  | typeof ACT_UNSUSPEND_USER
+  | typeof ACT_DISABLE_INVITES_FOR_USER
+  | typeof ACT_ENABLE_INVITES_FOR_USER;

--- a/app/routes/api/admin/ModeratorRoute.ts
+++ b/app/routes/api/admin/ModeratorRoute.ts
@@ -4,6 +4,7 @@ import { DefaultState } from 'koa';
 import { adminRolesRequired } from '../../../controllers/middlewares/admin-only';
 import { ROLE_MODERATOR } from '../../../models/admins';
 import {
+  disableInvitesForUser,
   freezeUser,
   listAll,
   listFrozen,
@@ -23,4 +24,6 @@ export default function addRoutes(router: Router<DefaultState, AppContext>) {
   router.post('/users/:username/unfreeze', mw, unfreezeUser);
   router.post('/users/:username/suspend', mw, suspendUser(true));
   router.post('/users/:username/unsuspend', mw, suspendUser(false));
+  router.post('/users/:username/disable-invites', mw, disableInvitesForUser(true));
+  router.post('/users/:username/enable-invites', mw, disableInvitesForUser(false));
 }

--- a/test/functional/admin.ts
+++ b/test/functional/admin.ts
@@ -412,15 +412,8 @@ describe('Admin API', () => {
 
   describe('Users list and user info', () => {
     it(`should return list of all users ordered by createdAt`, async () => {
-      const sortedUsers = [luna, mars, venus].sort((a, b) => {
-        const tsDiff = parseInt(b.user.createdAt) - parseInt(a.user.createdAt);
-
-        if (tsDiff != 0) {
-          return tsDiff;
-        }
-
-        return b.user.intId - a.user.intId;
-      });
+      // Use the fact that intId is assigned sequentially
+      const sortedUsers = [luna, mars, venus].sort((a, b) => b.user.intId - a.user.intId);
       const response = await performJSONRequest('GET', `/api/admin/users`, null, authHeaders(mars));
       await expect(response, 'to satisfy', {
         __httpCode: 200,


### PR DESCRIPTION
Methods are:
  - `POST /users/:username/disable-invites`
  - `POST /users/:username/enable-invites`

Also fixed the stability of users list test