### PR TITLE
Mask client IDs before logging them in datadog

### DIFF
--- a/app/support/rateLimiter.ts
+++ b/app/support/rateLimiter.ts
@@ -1,9 +1,12 @@
+import crypto from 'crypto';
+
 import monitor from 'monitor-dog'; // search keyword: datadog
 import { Context, Next } from 'koa';
 import RateLimiter from 'async-ratelimiter';
 import Redis from 'ioredis';
 import config from 'config';
 import createDebug from 'debug';
+import { Duration } from 'luxon';
 
 import { TooManyRequestsException } from './exceptions';
 
@@ -14,46 +17,67 @@ const options = {
   port: config.redis.port,
   db: config.database,
 };
+const redis = new Redis(options);
 const rateLimiter = new RateLimiter({
-  db: new Redis(options),
+  db: redis,
 });
+
+const MASKING_KEY = 'masking-key';
+const maskingKeyRotationIntervalSeconds =
+  Duration.fromISO(config.rateLimit.maskingKeyRotationInterval).toMillis() * 1000;
+
+const changeMaskingKey = async () => {
+  const newMaskingKey = crypto.randomBytes(64).toString('hex');
+  await redis.set(MASKING_KEY, newMaskingKey, 'EX', maskingKeyRotationIntervalSeconds);
+  return newMaskingKey;
+};
+
+const maskClientId = (clientId: string, key: string): string => {
+  return crypto.createHmac('sha1', key).update(clientId).digest('hex');
+};
 
 export async function rateLimiterMiddleware(ctx: Context, next: Next) {
   const authTokenType = ctx.state.authJWTPayload?.type || 'anonymous';
   const requestId = ctx.state.id;
   const requestMethod = ctx.request.method;
 
-  let clientId, rateLimiterConfig;
+  let realClientId, maskedClientId, rateLimiterConfig;
+
+  let maskingKey = await redis.get(MASKING_KEY);
+
+  if (!maskingKey) {
+    maskingKey = await changeMaskingKey();
+  }
 
   if (ctx.state.authJWTPayload?.userId) {
-    clientId = ctx.state.authJWTPayload.userId;
+    realClientId = ctx.state.authJWTPayload.userId;
+    maskedClientId = `u-${maskClientId(realClientId, maskingKey)}`;
     rateLimiterConfig = ctx.config.rateLimit.authenticated;
   } else {
-    clientId = ctx.ip;
+    realClientId = ctx.ip;
+    maskedClientId = `a-${maskClientId(realClientId, maskingKey)}`;
     rateLimiterConfig = ctx.config.rateLimit.anonymous;
   }
 
-  const requestTags = { method: requestMethod, auth: authTokenType, clientId };
+  const requestTags = { method: requestMethod, auth: authTokenType, clientId: maskedClientId };
   monitor.increment('requests', 1, requestTags);
 
   debug(
-    `${requestId}: ${requestMethod} ${ctx.request.originalUrl} request from ${clientId} (${authTokenType})`,
+    `${requestId}: ${requestMethod} ${ctx.request.originalUrl} request from ${realClientId} (${authTokenType})`,
   );
 
   if (ctx.config.rateLimit.enabled) {
-    if (ctx.config.rateLimit.allowlist.includes(clientId)) {
+    if (ctx.config.rateLimit.allowlist.includes(realClientId)) {
       debug(`${requestId}: Client allowlisted, request allowed`);
     } else {
-      const duration =
-        rateLimiterConfig.methodOverrides?.[requestMethod]?.duration || rateLimiterConfig.duration;
-      const maxRequests =
-        rateLimiterConfig.methodOverrides?.[requestMethod]?.maxRequests ||
-        rateLimiterConfig.maxRequests;
+      const methodOverride = rateLimiterConfig.methodOverrides?.[requestMethod];
+      const duration = methodOverride?.duration || rateLimiterConfig.duration;
+      const maxRequests = methodOverride?.maxRequests || rateLimiterConfig.maxRequests;
 
       const limit = await rateLimiter.get({
-        id: clientId,
+        id: realClientId,
         max: maxRequests,
-        duration,
+        duration: Duration.fromISO(duration).toMillis(),
       });
 
       debug(`${requestId}: Remaining requests: ${limit.remaining}, max ${limit.total}`);
@@ -68,6 +92,12 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
     }
   } else {
     debug(`${requestId}: Rate limiter not enabled`);
+  }
+
+  const keyTTL = await redis.ttl(MASKING_KEY);
+
+  if (keyTTL < maskingKeyRotationIntervalSeconds / 10) {
+    await changeMaskingKey();
   }
 
   await next();

--- a/config/default.js
+++ b/config/default.js
@@ -422,7 +422,7 @@ config.rateLimit = {
   enabled: false,
   allowlist: ['::ffff:127.0.0.1'], // ip addresses or user ids
   anonymous: {
-    duration: 60 * 1000, // milliseconds
+    duration: 'PT1M', // ISO 8601 duration
     maxRequests: 10,
     methodOverrides: {
       // optional
@@ -430,13 +430,14 @@ config.rateLimit = {
     },
   },
   authenticated: {
-    duration: 60 * 1000, // milliseconds
+    duration: 'PT1M', // ISO 8601 duration
     maxRequests: 30,
     methodOverrides: {
       GET: { maxRequests: 200 },
       POST: { maxRequests: 60 },
     },
   },
+  maskingKeyRotationInterval: 'P7D', // ISO 8601 duration
 };
 
 config.invitations = {

--- a/test/unit/support/rateLimiter.ts
+++ b/test/unit/support/rateLimiter.ts
@@ -8,7 +8,7 @@ import { rateLimiterMiddleware } from '../../../app/support/rateLimiter';
 
 const MAX_ANONYMOUS_REQUESTS = 5;
 const MAX_AUTHENTICATED_REQUESTS = 7;
-const DURATION = 5 * 1000;
+const DURATION = 'PT5S';
 
 const baseContext = {
   ip: '127.0.0.1',

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -129,15 +129,22 @@ declare module 'config' {
       enabled: boolean;
       allowlist: string[];
       anonymous: {
-        duration: number;
+        duration: ISO8601DurationString;
         maxRequests: number;
-        methodOverrides?: Record<string, { duration?: number; maxRequests?: number }>;
+        methodOverrides?: Record<
+          string,
+          { duration?: ISO8601DurationString; maxRequests?: number }
+        >;
       };
       authenticated: {
-        duration: number;
+        duration: ISO8601DurationString;
         maxRequests: number;
-        methodOverrides?: Record<string, { duration?: number; maxRequests?: number }>;
+        methodOverrides?: Record<
+          string,
+          { duration?: ISO8601DurationString; maxRequests?: number }
+        >;
       };
+      maskingKeyRotationInterval: ISO8601DurationString;
     };
 
     ianaTimeZone: string;


### PR DESCRIPTION
This PR adds masking for client IDs when recording datadog metrics