### PR TITLE
Add new API method for batch retrieval of comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   'invitation.create-requests', and 'invitation.use-requests'.
 - Allow moderator to disable/enable invitations for specific user. Methods are:
   - `POST /users/:username/disable-invites`
-  - `POST /users/:username/enable-invites`
+  - `POST /users/:username/enable-invites` 
+- New method `POST /v2/comments/byIds` for batch retrieval of comments. The
+  request body has form `{ "commentsId": [...] }`.
 
 ### Changed
 - Invitations from inactive (i.e. in some 'gone' status) users stop working.

--- a/app/controllers/api/v1/data-schemes/comments.js
+++ b/app/controllers/api/v1/data-schemes/comments.js
@@ -44,3 +44,21 @@ export const commentUpdateInputSchema = {
     },
   },
 };
+
+export const getCommentsByIdsInputSchema = {
+  $schema: 'http://json-schema.org/schema#',
+
+  definitions,
+
+  type: 'object',
+  required: ['commentIds'],
+
+  properties: {
+    commentIds: {
+      type: 'array',
+      items: { $ref: '#/definitions/uuid' },
+      uniqueItems: true,
+      default: [],
+    },
+  },
+};

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -97,6 +97,7 @@ export const appTokensScopes = [
       'GET /vN/comments/:commentId',
       'GET /vN/posts/:postId/comments/:seqNumber',
       'POST /vN/posts/byIds',
+      'POST /vN/comments/byIds',
     ],
   },
   {

--- a/app/routes/api/v1/CommentsRoute.js
+++ b/app/routes/api/v1/CommentsRoute.js
@@ -1,8 +1,16 @@
-import { create, update, destroy, getById } from '../../../controllers/api/v1/CommentsController';
+import {
+  create,
+  update,
+  destroy,
+  getById,
+  getByIds,
+} from '../../../controllers/api/v1/CommentsController';
 
 export default function addRoutes(app) {
   app.post('/comments', create);
   app.put('/comments/:commentId', update);
   app.delete('/comments/:commentId', destroy);
   app.get('/comments/:commentId', getById);
+  // We use POST here because this method can accept many comment IDs
+  app.post('/comments/byIds', getByIds);
 }

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -192,6 +192,10 @@ export class DbAdapter {
 
   // Comment likes
   deleteCommentLike(commentUUID: UUID, likerUUID: UUID): Promise<boolean>;
+  getLikesInfoForComments(
+    commentsUUIDs: UUID[],
+    viewerUUID?: UUID,
+  ): Promise<{ uid: UUID; c_likes: string; has_own_like: boolean }[]>;
 
   // Attachments
   getAttachmentById(id: UUID): Promise<Attachment | null>;
@@ -216,6 +220,11 @@ export class DbAdapter {
   ): Promise<string>;
   isPostVisibleForViewer(postId: UUID, viewerId?: UUID): Promise<boolean>;
   getUsersWhoCanSeePost(postProps: { authorId: UUID; destFeeds: number[] }): Promise<List<UUID>>;
+  isCommentBannedForViewer(commentId: UUID, viewerId?: UUID): Promise<boolean>;
+  areCommentsBannedForViewerAssoc(
+    commentIds: UUID[],
+    viewerId?: UUID,
+  ): Promise<{ [id: UUID]: boolean }>;
 
   // App tokens
   createAppToken(token: AppTokenCreateParams): Promise<AppTokenV1>;


### PR DESCRIPTION
### Added
- New method `POST /v2/comments/byIds` for batch retrieval of comments. The request body has form `{ "commentsId": [...] }`.
