### PR TITLE
Do not hide initiator of COMMENT_MODERATED event when it is a post author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Invitations from inactive (i.e. in some 'gone' status) users stop working.
+- The serialized view of COMMENT_MODERATED event now contains non-null
+  'created_user_id' field when the event initiator is a post author. This event
+  can be fired by group moderator or by the post author. In the first case we
+  should hide the initiator, in the second case we should not.
 
 ### Fixed
 - Invitations are no longer deleted when their author's data is deleted. These

--- a/app/serializers/v2/event.ts
+++ b/app/serializers/v2/event.ts
@@ -1,7 +1,7 @@
 import { dbAdapter } from '../../models';
 import { Nullable, UUID } from '../../support/types';
 import type { EventRecord } from '../../support/DbAdapter';
-import { HIDDEN_CREATOR_EVENT_TYPES } from '../../support/EventTypes';
+import { EVENT_TYPES, HIDDEN_CREATOR_EVENT_TYPES } from '../../support/EventTypes';
 
 import { serializeUsersByIds } from './user';
 
@@ -13,6 +13,14 @@ export async function serializeEvents(events: EventRecord[], viewerId: Nullable<
   for (const event of events) {
     if (
       HIDDEN_CREATOR_EVENT_TYPES.includes(event.event_type) &&
+      event.user_id === event.target_user_id
+    ) {
+      event.created_by_user_id = null;
+    }
+
+    if (
+      event.event_type === EVENT_TYPES.COMMENT_MODERATED &&
+      event.created_by_user_id !== event.post_author_id &&
       event.user_id === event.target_user_id
     ) {
       event.created_by_user_id = null;

--- a/app/support/EventTypes.ts
+++ b/app/support/EventTypes.ts
@@ -88,7 +88,9 @@ export const DIGEST_EVENT_TYPES = _.difference(Object.values(EVENT_TYPES), [
  * types when 'user_id' (recipient) is the same as 'target_user_id'.
  */
 export const HIDDEN_CREATOR_EVENT_TYPES = [
-  EVENT_TYPES.COMMENT_MODERATED,
+  // We don't include the COMMENT_MODERATED event here because it can be
+  // triggered by the author of the post and can still have a visible initiator.
+  // It has the separate processing logic in serializer.
   EVENT_TYPES.POST_MODERATED,
   EVENT_TYPES.BLOCKED_IN_GROUP,
   EVENT_TYPES.UNBLOCKED_IN_GROUP,

--- a/test/functional/group-moderation.js
+++ b/test/functional/group-moderation.js
@@ -178,7 +178,8 @@ describe('Group Moderation', () => {
           expect(marsEvents, 'to satisfy', [
             {
               event_type: EVENT_TYPES.COMMENT_MODERATED,
-              created_user_id: null,
+              // Luna is a post author, so we expect her here
+              created_user_id: luna.user.id,
               post_id: post.id,
             },
           ]);
@@ -194,6 +195,7 @@ describe('Group Moderation', () => {
           expect(marsEvents, 'to satisfy', [
             {
               event_type: EVENT_TYPES.COMMENT_MODERATED,
+              // Jupiter is not a post author, so we shouldn't see him here
               created_user_id: null,
               post_id: post.id,
               group_id: expect.it('to be one of', [gods.group.id, celestials.group.id]),


### PR DESCRIPTION
The serialized view of COMMENT_MODERATED event now contains non-null  'created_user_id' field when the event initiator is a post author. This event  can be fired by group moderator or by the post author. In the first case we  should hide the initiator, in the second case we should not.