### PR TITLE
Rate limiter fixes

### DIFF
--- a/app/support/rateLimiter.ts
+++ b/app/support/rateLimiter.ts
@@ -22,9 +22,14 @@ const rateLimiter = new RateLimiter({
   db: redis,
 });
 
-const MASKING_KEY = 'masking-key';
-const maskingKeyRotationIntervalSeconds =
-  Duration.fromISO(config.rateLimit.maskingKeyRotationInterval).toMillis() * 1000;
+const durationToSeconds = (duration: string): number => {
+  return Duration.fromISO(duration).toMillis() / 1000;
+};
+
+const MASKING_KEY = 'maskingkey';
+const maskingKeyRotationIntervalSeconds = durationToSeconds(
+  config.rateLimit.maskingKeyRotationInterval,
+);
 
 const changeMaskingKey = async () => {
   const newMaskingKey = crypto.randomBytes(64).toString('hex');

--- a/app/support/rateLimiter.ts
+++ b/app/support/rateLimiter.ts
@@ -26,6 +26,9 @@ const durationToSeconds = (duration: string): number => {
   return Duration.fromISO(duration).toMillis() / 1000;
 };
 
+const USER_BLOCKED_KEY_PREFIX = 'blocked-';
+const BLOCK_COUNTER_KEY_PREFIX = 'blockcounter-';
+
 const MASKING_KEY = 'maskingkey';
 const maskingKeyRotationIntervalSeconds = durationToSeconds(
   config.rateLimit.maskingKeyRotationInterval,
@@ -39,6 +42,33 @@ const changeMaskingKey = async () => {
 
 const maskClientId = (clientId: string, key: string): string => {
   return crypto.createHmac('sha1', key).update(clientId).digest('hex');
+};
+
+const isClientBlocked = async (clientId: string): Promise<boolean> => {
+  return Boolean(await redis.get(`${USER_BLOCKED_KEY_PREFIX}${clientId}`));
+};
+
+const setClientBlocked = async (
+  clientId: string,
+  baseDuration: string,
+  durationMultiplier: number,
+) => {
+  const durationSeconds = durationToSeconds(baseDuration) * durationMultiplier;
+  return await redis.set(`${USER_BLOCKED_KEY_PREFIX}${clientId}`, 'true', 'EX', durationSeconds);
+};
+
+const getClientBlockedDuration = async (clientId: string) => {
+  return await redis.ttl(`${USER_BLOCKED_KEY_PREFIX}${clientId}`);
+};
+
+const getRepeatBlocksCount = async (clientId: string): Promise<number> => {
+  const count = await redis.get(`${BLOCK_COUNTER_KEY_PREFIX}${clientId}`);
+  return count ? parseInt(count, 10) : 0;
+};
+
+const setRepeatBlocksCount = async (clientId: string, count: number, duration: string) => {
+  const durationSeconds = durationToSeconds(duration);
+  return await redis.set(`${BLOCK_COUNTER_KEY_PREFIX}${clientId}`, count, 'EX', durationSeconds);
 };
 
 export async function rateLimiterMiddleware(ctx: Context, next: Next) {
@@ -74,10 +104,16 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
   if (ctx.config.rateLimit.enabled) {
     if (ctx.config.rateLimit.allowlist.includes(realClientId)) {
       debug(`${requestId}: Client allowlisted, request allowed`);
+    } else if (await isClientBlocked(realClientId)) {
+      monitor.increment('requests-rate-limited', 1, requestTags);
+      const blockTTL = await getClientBlockedDuration(realClientId);
+      debug(`${requestId}: Client is already blocked, ${blockTTL} sec remaining, request denied`);
+
+      throw new TooManyRequestsException('Slow down');
     } else {
-      const methodOverride = rateLimiterConfig.methodOverrides?.[requestMethod];
-      const duration = methodOverride?.duration || rateLimiterConfig.duration;
-      const maxRequests = methodOverride?.maxRequests || rateLimiterConfig.maxRequests;
+      const methodConfig = rateLimiterConfig.methodOverrides?.[requestMethod];
+      const duration = methodConfig?.duration || rateLimiterConfig.duration;
+      const maxRequests = methodConfig?.maxRequests || rateLimiterConfig.maxRequests;
 
       const limit = await rateLimiter.get({
         id: realClientId,
@@ -89,7 +125,22 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
 
       if (!limit.remaining) {
         monitor.increment('requests-rate-limited', 1, requestTags);
-        debug(`${requestId}: Client blocked until ${limit.reset}, request denied`);
+        const previousBlocksCount = await getRepeatBlocksCount(realClientId);
+        setClientBlocked(
+          realClientId,
+          ctx.config.rateLimit.blockDuration,
+          previousBlocksCount * ctx.config.rateLimit.repeatBlockMultiplier || 1,
+        );
+        setRepeatBlocksCount(
+          realClientId,
+          previousBlocksCount + 1,
+          ctx.config.rateLimit.repeatBlockCounterDuration,
+        );
+
+        debug(
+          `${requestId}: Client blocked (previous blocks: ${previousBlocksCount}), request denied`,
+        );
+
         throw new TooManyRequestsException('Slow down');
       } else {
         debug(`${requestId}: Request allowed`);

--- a/config/default.js
+++ b/config/default.js
@@ -423,7 +423,7 @@ config.rateLimit = {
   allowlist: ['::ffff:127.0.0.1'], // ip addresses or user ids
   anonymous: {
     duration: 'PT1M', // ISO 8601 duration
-    maxRequests: 10,
+    maxRequests: 10, // all methods
     methodOverrides: {
       // optional
       GET: { maxRequests: 100 },
@@ -438,6 +438,9 @@ config.rateLimit = {
     },
   },
   maskingKeyRotationInterval: 'P7D', // ISO 8601 duration
+  blockDuration: 'PT1M', // duration of a block if threshold is breached
+  repeatBlockCounterDuration: 'PT10M', // how long to remember about a breach
+  repeatBlockMultiplier: 2, // block duration multiplier for repeated breaches
 };
 
 config.invitations = {

--- a/test/unit/support/rateLimiter.ts
+++ b/test/unit/support/rateLimiter.ts
@@ -27,6 +27,9 @@ const baseContext = {
         duration: DURATION,
         maxRequests: MAX_AUTHENTICATED_REQUESTS,
       },
+      blockDuration: 'PT1M',
+      repeatBlockCounterDuration: 'PT10M',
+      repeatBlockMultiplier: 2,
     },
   },
   request: {


### PR DESCRIPTION
1. Fix wrong masking key rotation interval
2. Add blocking of clients for breaching rate limiter thresholds with configurable duration (and multipliers for repeated breaches) 