### PR TITLE
Make sure we remember about blocking people for longer than they are blocked

### DIFF
--- a/app/support/rateLimiter.ts
+++ b/app/support/rateLimiter.ts
@@ -22,7 +22,7 @@ const rateLimiter = new RateLimiter({
   db: redis,
 });
 
-const durationToSeconds = (duration: string): number => {
+export const durationToSeconds = (duration: string): number => {
   return Duration.fromISO(duration).toMillis() / 1000;
 };
 
@@ -107,14 +107,12 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
 
       throw new TooManyRequestsException('Slow down');
     } else {
-      const methodConfigOverride = rateLimiterConfigByAuthType.methodOverrides?.[requestMethod];
-      const duration = methodConfigOverride?.duration || rateLimiterConfigByAuthType.duration;
-      const maxRequests =
-        methodConfigOverride?.maxRequests || rateLimiterConfigByAuthType.maxRequests;
+      const { duration, maxRequests } = rateLimiterConfigByAuthType;
+      const maxRequestsForMethod = maxRequests[requestMethod] || maxRequests.all;
 
       const limit = await rateLimiter.get({
         id: realClientId,
-        max: maxRequests,
+        max: maxRequestsForMethod,
         duration: Duration.fromISO(duration).toMillis(),
       });
 

--- a/app/support/rateLimiter.ts
+++ b/app/support/rateLimiter.ts
@@ -48,12 +48,7 @@ const isClientBlocked = async (clientId: string): Promise<boolean> => {
   return Boolean(await redis.get(`${USER_BLOCKED_KEY_PREFIX}${clientId}`));
 };
 
-const setClientBlocked = async (
-  clientId: string,
-  baseDuration: string,
-  durationMultiplier: number,
-) => {
-  const durationSeconds = durationToSeconds(baseDuration) * durationMultiplier;
+const setClientBlocked = async (clientId: string, durationSeconds: number) => {
   return await redis.set(`${USER_BLOCKED_KEY_PREFIX}${clientId}`, 'true', 'EX', durationSeconds);
 };
 
@@ -66,8 +61,7 @@ const getRepeatBlocksCount = async (clientId: string): Promise<number> => {
   return count ? parseInt(count, 10) : 0;
 };
 
-const setRepeatBlocksCount = async (clientId: string, count: number, duration: string) => {
-  const durationSeconds = durationToSeconds(duration);
+const setRepeatBlocksCount = async (clientId: string, count: number, durationSeconds: number) => {
   return await redis.set(`${BLOCK_COUNTER_KEY_PREFIX}${clientId}`, count, 'EX', durationSeconds);
 };
 
@@ -75,8 +69,9 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
   const authTokenType = ctx.state.authJWTPayload?.type || 'anonymous';
   const requestId = ctx.state.id;
   const requestMethod = ctx.request.method;
+  const rateLimitConfig = ctx.config.rateLimit;
 
-  let realClientId, maskedClientId, rateLimiterConfig;
+  let realClientId, maskedClientId, rateLimiterConfigByAuthType;
 
   let maskingKey = await redis.get(MASKING_KEY);
 
@@ -87,11 +82,11 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
   if (ctx.state.authJWTPayload?.userId) {
     realClientId = ctx.state.authJWTPayload.userId;
     maskedClientId = `u-${maskClientId(realClientId, maskingKey)}`;
-    rateLimiterConfig = ctx.config.rateLimit.authenticated;
+    rateLimiterConfigByAuthType = rateLimitConfig.authenticated;
   } else {
     realClientId = ctx.ip;
     maskedClientId = `a-${maskClientId(realClientId, maskingKey)}`;
-    rateLimiterConfig = ctx.config.rateLimit.anonymous;
+    rateLimiterConfigByAuthType = rateLimitConfig.anonymous;
   }
 
   const requestTags = { method: requestMethod, auth: authTokenType, clientId: maskedClientId };
@@ -101,9 +96,10 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
     `${requestId}: ${requestMethod} ${ctx.request.originalUrl} request from ${realClientId} (${authTokenType})`,
   );
 
-  if (ctx.config.rateLimit.enabled) {
-    if (ctx.config.rateLimit.allowlist.includes(realClientId)) {
+  if (rateLimitConfig.enabled) {
+    if (rateLimitConfig.allowlist.includes(realClientId)) {
       debug(`${requestId}: Client allowlisted, request allowed`);
+      // do nothing
     } else if (await isClientBlocked(realClientId)) {
       monitor.increment('requests-rate-limited', 1, requestTags);
       const blockTTL = await getClientBlockedDuration(realClientId);
@@ -111,9 +107,10 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
 
       throw new TooManyRequestsException('Slow down');
     } else {
-      const methodConfig = rateLimiterConfig.methodOverrides?.[requestMethod];
-      const duration = methodConfig?.duration || rateLimiterConfig.duration;
-      const maxRequests = methodConfig?.maxRequests || rateLimiterConfig.maxRequests;
+      const methodConfigOverride = rateLimiterConfigByAuthType.methodOverrides?.[requestMethod];
+      const duration = methodConfigOverride?.duration || rateLimiterConfigByAuthType.duration;
+      const maxRequests =
+        methodConfigOverride?.maxRequests || rateLimiterConfigByAuthType.maxRequests;
 
       const limit = await rateLimiter.get({
         id: realClientId,
@@ -125,20 +122,34 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
 
       if (!limit.remaining) {
         monitor.increment('requests-rate-limited', 1, requestTags);
+
+        // When a client breaches the threshold for the first time, we block them for
+        // rateLimitConfig.blockDuration (1 minute by default) and set a "previous blocks counter" to "1" which
+        // lives for rateLimitConfig.blockDuration + rateLimitConfig.repeatBlockCounterDuration (1 + 10
+        // = 11 minutes by default). If the same client breaches the threshold again during
+        // these 11 minutes, we block them for a longer time (using rateLimitConfig.repeatBlockMultiplier,
+        // 2 x 1 = 2 minutes by default), increment the counter and set it for longer as well (2 x 1 + 10 = 12
+        // minutes). With each subsequent breach the counter and the multiplier increment, so the block time grows
+        // longer and longer (1, 2, 4, 6, 8 minutes...) and we remember about it for longer and longer (11, 12, 14,
+        // 16, 18 minutes...). If a client behaves well during these 11/12/14... minutes then the counter expires
+        // and all past breaches get forgotten and forgiven
+
+        const baseBlockDuration = durationToSeconds(rateLimitConfig.blockDuration);
         const previousBlocksCount = await getRepeatBlocksCount(realClientId);
-        setClientBlocked(
-          realClientId,
-          ctx.config.rateLimit.blockDuration,
-          previousBlocksCount * ctx.config.rateLimit.repeatBlockMultiplier || 1,
+        const blockDurationMultiplier =
+          previousBlocksCount * rateLimitConfig.repeatBlockMultiplier || 1;
+        const blockDurationSeconds = baseBlockDuration * blockDurationMultiplier;
+
+        setClientBlocked(realClientId, blockDurationSeconds);
+
+        const baseRepeatBlockCounterDuration = durationToSeconds(
+          rateLimitConfig.repeatBlockCounterDuration,
         );
-        setRepeatBlocksCount(
-          realClientId,
-          previousBlocksCount + 1,
-          ctx.config.rateLimit.repeatBlockCounterDuration,
-        );
+        const repeatBlockCounterDuration = baseRepeatBlockCounterDuration + blockDurationSeconds;
+        setRepeatBlocksCount(realClientId, previousBlocksCount + 1, repeatBlockCounterDuration);
 
         debug(
-          `${requestId}: Client blocked (previous blocks: ${previousBlocksCount}), request denied`,
+          `${requestId}: Client blocked for ${blockDurationSeconds} sec (previous blocks: ${previousBlocksCount}), request denied`,
         );
 
         throw new TooManyRequestsException('Slow down');

--- a/config/default.js
+++ b/config/default.js
@@ -424,18 +424,17 @@ config.rateLimit = {
   allowlist: ['::ffff:127.0.0.1'], // ip addresses or user ids
   anonymous: {
     duration: 'PT1M', // ISO 8601 duration
-    maxRequests: 10, // all methods
-    methodOverrides: {
-      // optional
-      GET: { maxRequests: 100 },
+    maxRequests: {
+      all: 10, // all methods
+      GET: 100, // optional
     },
   },
   authenticated: {
     duration: 'PT1M', // ISO 8601 duration
-    maxRequests: 30,
-    methodOverrides: {
-      GET: { maxRequests: 200 },
-      POST: { maxRequests: 60 },
+    maxRequests: {
+      all: 30,
+      GET: 200,
+      POST: 60,
     },
   },
   maskingKeyRotationInterval: 'P7D', // ISO 8601 duration

--- a/test/unit/support/rateLimiter.ts
+++ b/test/unit/support/rateLimiter.ts
@@ -4,16 +4,18 @@ import { Context, Next } from 'koa';
 import { v4 as uuidv4 } from 'uuid';
 import { merge } from 'lodash';
 
-import { rateLimiterMiddleware } from '../../../app/support/rateLimiter';
+import { rateLimiterMiddleware, durationToSeconds } from '../../../app/support/rateLimiter';
 
-const MAX_ANONYMOUS_REQUESTS = 5;
-const MAX_AUTHENTICATED_REQUESTS = 7;
+const MAX_ANONYMOUS_REQUESTS = 3;
+const MAX_AUTHENTICATED_REQUESTS = 5;
 const DURATION = 'PT5S';
+const BLOCK_DURATION = 'PT5S';
+const BLOCK_MULTIPLIER = 2;
 
 const baseContext = {
   ip: '127.0.0.1',
   state: {
-    authToken: {},
+    authJWTPayload: {},
   },
   config: {
     rateLimit: {
@@ -21,15 +23,19 @@ const baseContext = {
       allowlist: [],
       anonymous: {
         duration: DURATION,
-        maxRequests: MAX_ANONYMOUS_REQUESTS,
+        maxRequests: {
+          all: MAX_ANONYMOUS_REQUESTS,
+        },
       },
       authenticated: {
         duration: DURATION,
-        maxRequests: MAX_AUTHENTICATED_REQUESTS,
+        maxRequests: {
+          all: MAX_AUTHENTICATED_REQUESTS,
+        },
       },
-      blockDuration: 'PT1M',
-      repeatBlockCounterDuration: 'PT10M',
-      repeatBlockMultiplier: 2,
+      blockDuration: BLOCK_DURATION,
+      repeatBlockCounterDuration: 'PT1M',
+      repeatBlockMultiplier: BLOCK_MULTIPLIER,
     },
   },
   request: {
@@ -38,6 +44,11 @@ const baseContext = {
 } as unknown as Context;
 
 const next: Next = async () => {};
+
+function sleep(sec: number) {
+  console.log('Sleeping', sec);
+  return new Promise((resolve) => setTimeout(resolve, sec * 1000));
+}
 
 describe('Rate limiter', () => {
   it('should allow too many requests if rate limiter is disabled', () => {
@@ -67,7 +78,9 @@ describe('Rate limiter', () => {
   });
 
   it('should not allow too many requests if rate limiter is enabled', () => {
-    const ctx = merge({}, baseContext, { state: { authToken: { userId: uuidv4() } } });
+    const ctx = merge({}, baseContext, {
+      state: { authJWTPayload: { type: 'sess.v1', userId: uuidv4() } },
+    });
 
     const requests = [];
 
@@ -76,5 +89,52 @@ describe('Rate limiter', () => {
     }
 
     return expect(Promise.all(requests), 'to be rejected with', 'Slow down');
+  });
+
+  it('should block for a configurable amount of time', async () => {
+    const ctx = merge({}, baseContext, {
+      config: { rateLimit: { enabled: true } },
+      state: { authJWTPayload: { type: 'sess.v1', userId: uuidv4() } },
+    });
+
+    const blockDurationInSeconds = durationToSeconds(BLOCK_DURATION);
+
+    for (let i = 0; i < MAX_AUTHENTICATED_REQUESTS; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(() => rateLimiterMiddleware(ctx, next), 'to be fulfilled');
+    }
+
+    // send too many requests and get blocked for the first time
+    await expect(() => rateLimiterMiddleware(ctx, next), 'to be rejected with', 'Slow down');
+
+    // wait for half of block time
+    await sleep(blockDurationInSeconds / 2);
+
+    // should still be blocked
+    await expect(() => rateLimiterMiddleware(ctx, next), 'to be rejected with', 'Slow down');
+
+    // wait more so block expires
+    await sleep(blockDurationInSeconds);
+
+    // should no longer be blocked
+    for (let i = 0; i < MAX_AUTHENTICATED_REQUESTS; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(() => rateLimiterMiddleware(ctx, next), 'to be fulfilled');
+    }
+
+    // send too many requests and get blocked for the second time
+    await expect(() => rateLimiterMiddleware(ctx, next), 'to be rejected with', 'Slow down');
+
+    // wait for more than normal full block time but less than block * multiplier time
+    await sleep(blockDurationInSeconds * BLOCK_MULTIPLIER * 0.75);
+
+    // should still be blocked because of multiplier
+    await expect(() => rateLimiterMiddleware(ctx, next), 'to be rejected with', 'Slow down');
+
+    // wait more so block expires
+    await sleep(blockDurationInSeconds * BLOCK_MULTIPLIER);
+
+    // should no longer be blocked
+    return expect(rateLimiterMiddleware(ctx, next), 'to be fulfilled');
   });
 });


### PR DESCRIPTION
This PR fixes a problem in incremental blocking by rate limiter, where after a certain point the block time (which would grow with each subsequent block) would be longer than the TTL of the "how many times was this client blocked previously" counter (which is always 10 minutes). With this change we remember about previous blocks for 10 minutes _plus_ the time of the actual block.

Also added some descriptive comments and improved variable names to make the code more readable.