### PR TITLE
Keep separate request counts per method

### DIFF
--- a/app/support/rateLimiter.ts
+++ b/app/support/rateLimiter.ts
@@ -109,9 +109,10 @@ export async function rateLimiterMiddleware(ctx: Context, next: Next) {
     } else {
       const { duration, maxRequests } = rateLimiterConfigByAuthType;
       const maxRequestsForMethod = maxRequests[requestMethod] || maxRequests.all;
+      const clientIdWithMethod = `${realClientId}${requestMethod}`;
 
       const limit = await rateLimiter.get({
-        id: realClientId,
+        id: clientIdWithMethod,
         max: maxRequestsForMethod,
         duration: Duration.fromISO(duration).toMillis(),
       });


### PR DESCRIPTION
This PR fixes a bug in rate limiter, where clients sending a large number of GET requests (above POST threshold but below GET threshold) and then a single POST request would get blocked. Now, requests for each method should be correctly counterd with separate counters.