### PR TITLE
Remove node 14 and pg 12 from build checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14, 16, 18]
-        postgres-version: ["12.13", "13.9", "14.6", "15.1"]
+        node-version: [16, 18, 20]
+        postgres-version: ["13.10", "14.7", "15.2"]
         redis-version: [6, 7]
 
     services:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -21,51 +20,51 @@ jobs:
           POSTGRES_USER: freefeed
           POSTGRES_PASSWORD: freefeed
           POSTGRES_DB: freefeed_test
-        ports: ['5432:5432']
+        ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - name: Start Redis v${{ matrix.redis-version }}
-      uses: supercharge/redis-github-action@1.4.0
-      with:
-        redis-version: ${{ matrix.redis-version }}
+      - name: Start Redis v${{ matrix.redis-version }}
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: ${{ matrix.redis-version }}
 
-    - name: install GraphicsMagick
-      run: |
-        sudo apt-get update
-        sudo apt-get install graphicsmagick
+      - name: install GraphicsMagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install graphicsmagick
 
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v3
-      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
+      - uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-    - name: create directories for attachments
-      run: |
-        mkdir -p /tmp/pepyatka-media/attachments
-        mkdir /tmp/pepyatka-media/attachments/thumbnails
-        mkdir /tmp/pepyatka-media/attachments/thumbnails2
-        mkdir /tmp/pepyatka-media/attachments/anotherTestSize
+      - name: create directories for attachments
+        run: |
+          mkdir -p /tmp/pepyatka-media/attachments
+          mkdir /tmp/pepyatka-media/attachments/thumbnails
+          mkdir /tmp/pepyatka-media/attachments/thumbnails2
+          mkdir /tmp/pepyatka-media/attachments/anotherTestSize
 
-    - name: Install dependencies
-      run: yarn
+      - name: Install dependencies
+        run: yarn
 
-    - name: run lint
-      run: yarn lint
+      - name: run lint
+        run: yarn lint
 
-    - name: run tests
-      run: yarn test
+      - name: run tests
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@types/lodash": "~4.14.194",
     "@types/mocha": "~10.0.1",
     "@types/n3": "~1.10.4",
-    "@types/node": "~14.18.42",
+    "@types/node": "~16.18.25",
     "@types/pg": "~8.6.6",
     "@types/pg-format": "~1.0.2",
     "@types/raven": "~2.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,10 +2329,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:~14.18.42":
-  version: 14.18.42
-  resolution: "@types/node@npm:14.18.42"
-  checksum: 1c92f04a482ab54a21342b3911fc6f0093f04d3314197bc0e2f20012e9efc929c44e2ea41990b9b3cde420d7859c9ed716733f3e65c0cd6c2910a55799465f6b
+"@types/node@npm:~16.18.25":
+  version: 16.18.25
+  resolution: "@types/node@npm:16.18.25"
+  checksum: 181760ad6b54fcc498dfeb249e98bbf0be51d7c35e92e760e1a82004fa42b86e8c33a8f8dd7743b5ef872bda0753d9e6a5b8e3f0aed63e9eb79b4e65760c1fbe
   languageName: node
   linkType: hard
 
@@ -5954,7 +5954,7 @@ __metadata:
     "@types/lodash": ~4.14.194
     "@types/mocha": ~10.0.1
     "@types/n3": ~1.10.4
-    "@types/node": ~14.18.42
+    "@types/node": ~16.18.25
     "@types/pg": ~8.6.6
     "@types/pg-format": ~1.0.2
     "@types/raven": ~2.5.4


### PR DESCRIPTION
This PR removes node 14 and postgres 12 from build checks. 