### PR TITLE
Manually delete EXIF orientation tag after autorotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.13.0] - Not released
+### Fixed
+- After version 1.23.1 the 'gm' package stopped clearing image metadata after
+  orientation correction. As a result, the picture was rotated, but the
+  "Orientation" EXIF tag remained the same. This caused the image to display
+  incorrectly in the browser. We now clear this tag if a rotation occurred.
 
 ## [2.12.1] - 2023-05-26
 ### Fixed

--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -16,6 +16,7 @@ import mv from 'mv';
 import gifsicle from 'gifsicle';
 import probe from 'probe-image-size';
 import Raven from 'raven';
+import { exiftool } from 'exiftool-vendored';
 
 import { getS3 } from '../support/s3';
 import { sanitizeMediaMetadata, SANITIZE_NONE, SANITIZE_VERSION } from '../support/sanitize-media';
@@ -371,6 +372,8 @@ export function addModel(dbAdapter) {
             .autoOrient()
             .quality(95);
           await img.writeAsync(originalFile);
+          // Clear orientation tag
+          await exiftool.write(originalFile, { 'Orientation#': null }, ['-overwrite_original']);
 
           originalImage = gm(originalFile);
           originalImage.orientationAsync = util.promisify(originalImage.orientation);
@@ -438,7 +441,6 @@ export function addModel(dbAdapter) {
           await originalImage // eslint-disable-line no-await-in-loop
             .resizeExact(w, h)
             .profile(`${__dirname}/../../lib/assets/sRGB.icm`)
-            .autoOrient()
             // Use white background for transparent images
             .background('white')
             .extent('0x0')

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ff-url-finder": "~2.3.7",
     "file-type": "~16.5.4",
     "gifsicle": "~7.0.1",
-    "gm": "~1.23.1",
+    "gm": "~1.25.0",
     "grapheme-breaker": "0.3.2",
     "humps": "~2.0.1",
     "ioredis": "~5.3.2",

--- a/test/integration/models/attachment-orientation.js
+++ b/test/integration/models/attachment-orientation.js
@@ -1,0 +1,129 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import { promisify } from 'util';
+import { mkdtemp, rm, stat } from 'fs/promises';
+import { tmpdir } from 'os';
+import { basename, join } from 'path';
+
+import gm from 'gm';
+import { exiftool } from 'exiftool-vendored';
+import expect from 'unexpected';
+
+import cleanDB from '../../dbCleaner';
+import { User, Attachment } from '../../../app/models';
+
+const orientationNames = [
+  'Unknown', // No orientation tag
+  'TopLeft', // 1: No changes
+  'TopRight', // 2: Mirror horizontal
+  'BottomRight', // 3: Rotate 180
+  'BottomLeft', // 4: Mirror vertical
+  'LeftTop', // 5: Mirror horizontal and rotate 270 CW
+  'RightTop', // 6: Rotate 90 CW
+  'RightBottom', // 7: Mirror horizontal and rotate 90 CW
+  'LeftBottom', // 8: Rotate 270 CW
+];
+
+describe('Orientation', () => {
+  let tmpDir;
+  let luna;
+  before(async () => {
+    await cleanDB($pg_database);
+    tmpDir = await mkdtemp(join(tmpdir(), 'orient-test-'));
+    luna = new User({ username: 'luna', password: 'pw' });
+    await luna.create();
+  });
+
+  after(() => rm(tmpDir, { recursive: true }));
+
+  for (let orientation = 0; orientation <= 8; orientation++) {
+    describe(`Create attachment with ${orientationNames[orientation]} orientation`, () => {
+      let attachment;
+
+      before(async () => {
+        const filename = join(tmpDir, `img-${orientation}.jpg`);
+
+        await createTestImage(filename, orientation);
+        const { size } = await stat(filename);
+        attachment = new Attachment({
+          file: {
+            path: filename,
+            size,
+            name: basename(filename),
+            type: 'image/jpeg',
+          },
+          userId: luna.id,
+        });
+        await attachment.create();
+      });
+
+      it(`should create proper big file`, async () => {
+        const image = gm(attachment.getPath());
+        const o = await promisify(image.orientation.bind(image))();
+        expect(o, 'to be', orientation > 1 ? 'Unknown' : orientationNames[orientation]);
+
+        await expectOrientation(image, orientation);
+      });
+
+      it(`should create proper thumbnail file`, async () => {
+        const image = gm(attachment.getResizedImagePath('t'));
+        const o = await promisify(image.orientation.bind(image))();
+        expect(o, 'to be', orientation > 1 ? 'Unknown' : orientationNames[orientation]);
+
+        await expectOrientation(image, orientation);
+      });
+    });
+  }
+});
+
+/**
+ * Create black 200x300 image with white to-left 100x100 corner and apply
+ * orientation tag when it is not zero.
+ */
+async function createTestImage(filename, orientation) {
+  const image = gm(200, 300, '#000000')
+    .fill('#ffffff')
+    .drawRectangle(0, 0, 100, 100)
+    .compress('JPEG');
+
+  await promisify(image.write.bind(image))(filename);
+
+  if (orientation !== 0) {
+    await exiftool.write(filename, { 'Orientation#': orientation }, ['-overwrite_original']);
+  }
+}
+
+function patternForOrientation(orientation) {
+  switch (orientation) {
+    case 2:
+      return 'OXOOOO';
+    case 3:
+      return 'OOOOOX';
+    case 4:
+      return 'OOOOXO';
+    case 5:
+      return 'XOOOOO';
+    case 6:
+      return 'OOXOOO';
+    case 7:
+      return 'OOOOOX';
+    case 8:
+      return 'OOOXOO';
+    default:
+      return 'XOOOOO';
+  }
+}
+
+async function expectOrientation(image, orientation) {
+  image = image.filter('Point').resize(3, 3);
+  const buffer = await promisify(image.toBuffer.bind(image))('GRAY');
+
+  const pattern = patternForOrientation(orientation);
+  let newLine = '';
+
+  for (let i = 0; i < pattern.length; i++) {
+    newLine += buffer[i] === 0 ? 'O' : 'X';
+  }
+
+  expect(newLine, 'to be', pattern);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6064,7 +6064,7 @@ __metadata:
     file-type: ~16.5.4
     formdata-node: ~5.0.0
     gifsicle: ~7.0.1
-    gm: ~1.23.1
+    gm: ~1.25.0
     grapheme-breaker: 0.3.2
     humps: ~2.0.1
     ioredis: ~5.3.2
@@ -6550,15 +6550,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gm@npm:~1.23.1":
-  version: 1.23.1
-  resolution: "gm@npm:1.23.1"
+"gm@npm:~1.25.0":
+  version: 1.25.0
+  resolution: "gm@npm:1.25.0"
   dependencies:
     array-parallel: ~0.1.3
     array-series: ~0.1.5
     cross-spawn: ^4.0.0
     debug: ^3.1.0
-  checksum: 33180fce816bd1c2680e5dfdb7dbe6da58b52c627379df2bfca06bbb03d03ad657530da3a3c70f65f8020d19cbb8ed23711a2c0fb5c75d9ae941deca6511bf40
+  checksum: 4c4b56ef15b2d290d35178515698968f75906db9a7932d477754e0b49c8ee264de7a43a8642433ebfbdb281b3bd65eccf3c81316e91c25a0c353a2a7719773a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
After version 1.23.1 the 'gm' package stopped clearing image metadata after orientation correction. As a result, the picture was rotated, but the "Orientation" EXIF tag remained the same. This caused the image to display incorrectly in the browser. We now clear this tag if a rotation occurred.
