### PR TITLE
Read image orientation using exiftool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.13.0] - Not released
+### Fixed
+- GraphicsMagick cannot read the EXIF "Orientation" tag of some images. So now
+  we read it using exiftool and manually correct the orientation of the image.
 
 ## [2.12.2] - 2023-06-02
 ### Fixed

--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -358,25 +358,20 @@ export function addModel(dbAdapter) {
       // Fix EXIF orientation for original image, if JPEG
       if (this.mimeType === 'image/jpeg') {
         originalImage = gm(originalFile);
-        originalImage.orientationAsync = util.promisify(originalImage.orientation);
         originalImage.writeAsync = util.promisify(originalImage.write);
 
-        // orientation() returns a string. Possible values are:
-        // unknown, Unknown, TopLeft, TopRight, BottomRight, BottomLeft, LeftTop, RightTop, RightBottom, LeftBottom
-        // The first three options are fine, the rest should be fixed.
-        const orientation = await originalImage.orientationAsync();
+        const autoOrientCommands = await gmAutoOrientCommands(originalFile);
 
-        if (!['unknown', 'Unknown', 'TopLeft'].includes(orientation)) {
+        if (autoOrientCommands) {
           const img = originalImage
             .profile(`${__dirname}/../../lib/assets/sRGB.icm`)
-            .autoOrient()
+            .out(...autoOrientCommands)
             .quality(95);
           await img.writeAsync(originalFile);
           // Clear orientation tag
           await exiftool.write(originalFile, { 'Orientation#': null }, ['-overwrite_original']);
 
           originalImage = gm(originalFile);
-          originalImage.orientationAsync = util.promisify(originalImage.orientation);
           originalImage.writeAsync = util.promisify(originalImage.write);
 
           originalSize = await getImageSize(originalFile);
@@ -432,7 +427,6 @@ export function addModel(dbAdapter) {
         // because gm is acting up weirdly when writing files in parallel mode
         if (originalImage === null) {
           originalImage = gm(originalFile);
-          originalImage.orientationAsync = util.promisify(originalImage.orientation);
           originalImage.writeAsync = util.promisify(originalImage.write);
         }
 
@@ -682,4 +676,25 @@ function fitIntoBounds(size, bounds) {
   }
 
   return { width, height };
+}
+
+const orientationCommands = {
+  2: ['-flop'],
+  3: ['-rotate', 180],
+  4: ['-flip'],
+  5: ['-flip', '-rotate', 90],
+  6: ['-rotate', 90],
+  7: ['-flop', '-rotate', 90],
+  8: ['-rotate', 270],
+};
+
+async function gmAutoOrientCommands(fileName) {
+  const { Orientation } = await exiftool.read(fileName);
+  const commands = orientationCommands[Orientation];
+
+  if (!commands) {
+    return null;
+  }
+
+  return [...commands, '-page', '+0+0'];
 }


### PR DESCRIPTION
GraphicsMagick cannot read the EXIF "Orientation" tag of some images. So now we read it using exiftool and manually correct the orientation of the image.