### PR TITLE
bump up base docker image to 20.x based on Snyk hint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  node:20.3.1-slim
+FROM node:18.16.1-bookworm
 
 RUN apt-get update && \
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-buster
+FROM  node:20.3.1-slim
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Snyk suggests to bump up base image for docker to reduce multiple risks, see below

![image](https://github.com/FreeFeed/freefeed-server/assets/43109/da39819e-a881-48fb-a79f-3b4708b309ce)

here is trivial fix for #633 in Dockerfile (single line) to make sure risks are reduced