### PR TITLE
Use correct thumbnail URLs for WebP images when using imgproxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.14.0] - Not released
+### Fixed
+- Using correct thumbnail URLs for WebP images when using imgproxy. Imgproxy's
+  URLs should be based on original's URL, so we use original '.webp' file name
+  here with '?format=jpg' modifier.
 
 ## [2.13.0] - 2023-07-15
 ### Added

--- a/app/freefeed-app.ts
+++ b/app/freefeed-app.ts
@@ -22,6 +22,7 @@ import { reportError } from './support/exceptions';
 import { normalizeInputStrings } from './controllers/middlewares/normalize-input';
 import { AppContext } from './support/types';
 import { apiVersionMiddleware } from './setup/initializers/api-version';
+import { asyncContextMiddleware } from './support/app-async-context';
 
 const env = process.env.NODE_ENV || 'development';
 
@@ -38,6 +39,8 @@ class FreefeedApp extends Application<DefaultState, AppContext> {
 
     this.context.config = config;
     this.context.port = process.env.PORT ? parseInt(process.env.PORT) : config.port;
+
+    this.use(asyncContextMiddleware);
 
     this.use(
       koaBody({

--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -345,7 +345,7 @@ export function addModel(dbAdapter) {
       this.imageSizes.o = {
         w: originalSize.width,
         h: originalSize.height,
-        url: await this.getUrl(),
+        url: this.getUrl(),
       };
 
       if (this.mimeType === 'image/svg+xml') {

--- a/app/support/app-async-context.ts
+++ b/app/support/app-async-context.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+import defaultConfig, { type Config } from 'config';
+import { Middleware } from 'koa';
+
+type AppAsyncContext = {
+  config: Config;
+};
+
+const appAsyncContext = new AsyncLocalStorage<AppAsyncContext>();
+
+export const asyncContextMiddleware: Middleware = (ctx, next) =>
+  appAsyncContext.run({ config: ctx.config }, next);
+
+/**
+ * Returns the current application configuration for use in functions called
+ * directly or indirectly by controllers. It allows to not explicitly pass
+ * 'context' or 'config' to these functions. If not called from the controller
+ * context, it returns the current server config.
+ *
+ * @returns Config
+ */
+export function currentConfig(): Config {
+  return appAsyncContext.getStore()?.config ?? defaultConfig;
+}

--- a/config/default.js
+++ b/config/default.js
@@ -156,6 +156,8 @@ config.attachments = {
     // Non-writable tags: synthetic and permanent
     ignoreTags: [/^GPSPosition$/, /^SerialNumberFormat$/],
   },
+  // Use https://imgproxy.net/ to dynamically create image thumbnails
+  useImgProxy: false,
 };
 config.profilePictures = {
   defaultProfilePictureMediumUrl: 'http://placekitten.com/50/50',

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -21,6 +21,17 @@ declare module 'config' {
       url: string;
       path: string;
       fileSizeLimit: number;
+      maxCount: number;
+      imageSizes: Record<
+        string,
+        {
+          path: string;
+          bounds: {
+            width: number;
+            height: number;
+          };
+        }
+      >;
       storage: {
         rootDir: string;
       };
@@ -28,6 +39,7 @@ declare module 'config' {
         removeTags: RegExp[];
         ignoreTags: RegExp[];
       };
+      useImgProxy: boolean;
     };
     maintenance: {
       messageFile: string;


### PR DESCRIPTION
Imgproxy's URLs should be based on original's URL, so we use original '.webp' file name here with '?format=jpg' modifier.