### PR TITLE
Fix "discarding" backlinks in comments...

### DIFF
--- a/app/support/DbAdapter/backlinks.js
+++ b/app/support/DbAdapter/backlinks.js
@@ -64,9 +64,12 @@ const backlinksTrait = (superClass) =>
           { refPostUID, refCommentUID },
         );
       } else {
-        await db.raw(`delete from backlinks where ref_post_id = :refPostUID`, {
-          refPostUID,
-        });
+        await db.raw(
+          `delete from backlinks where ref_post_id = :refPostUID and ref_comment_id is null`,
+          {
+            refPostUID,
+          },
+        );
       }
 
       if (uuids.length === 0) {

--- a/test/integration/support/DbAdapter/backlinks.js
+++ b/test/integration/support/DbAdapter/backlinks.js
@@ -242,4 +242,32 @@ describe('Backlinks DB trait', () => {
       expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
     });
   });
+
+  describe('Counting backlinks in posts and comments', () => {
+    let jupiterCommentNo2;
+
+    after(() => {
+      marsPost.update({ body: `luna post: example.com/${lunaPost.id}` });
+      jupiterCommentNo2.destroy();
+    });
+
+    it(`should increase count by 1 when adding a comment with link`, async () => {
+      jupiterCommentNo2 = jupiter.newComment({
+        postId: marsPost.id,
+        body: `luna post: example.com/${lunaPost.id}`,
+      });
+      await jupiterCommentNo2.create();
+
+      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
+      expect(result, 'to equal', new Map([[lunaPost.id, 3]]));
+    });
+
+    it(`should decrease count by 1 (not 2) when link from post removed`, async () => {
+      // Making sure the backlinks in comments are not "discarded" when the link in their parent post is removed
+      await marsPost.update({ body: 'luna post: ah, never mind' });
+
+      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
+      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+    });
+  });
 });


### PR DESCRIPTION
...when the link in their parent post is removed.

Fixes this bug:

> - Есть популярный пост А.
> - Есть пост Б, в его теле есть ссылка на пост А.
> - В комментариях к посту Б есть ещё N ссылок на пост А.
> - Юзер удаляет А-бэклинк из тела поста Б.
> - Из БД удаляется не только A-бэклинк из поста Б, но и **все A-бэклинки из комментариев к посту Б**.
> - Таким образом, счётчик поста А уменьшается не на 1, а на N+1.
> - Бэклинки на другие посты в комментариях к посту Б при этом (к счастью) остаются на месте.
