### PR TITLE
Add `/v2/posts/:postId/backlinks` API method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `withModifiedConfig` helper function that allows to override configuration
   in test.
 
+- A new `/v2/posts/:postId/backlinks` API method that returns feed of all posts
+  that references to the given post.
+
 ## [2.13.2] - 2023-08-03
 ### Fixed
 - "Discarding" backlinks in comments when the link in their parent post is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in test.
 
 - A new `/v2/posts/:postId/backlinks` API method that returns feed of all posts
-  that references to the given post.
+  that reference the given post.
 
 ## [2.13.2] - 2023-08-03
 ### Fixed

--- a/app/controllers/api/v2/PostsController.js
+++ b/app/controllers/api/v2/PostsController.js
@@ -142,7 +142,7 @@ export const leave = compose([
 ]);
 
 /**
- * Returns feed of posts that references to the given post
+ * Returns feed of posts that reference the given post
  */
 export const getReferringPosts = compose([
   monitored('posts.referring'),

--- a/app/controllers/api/v2/TimelinesController.js
+++ b/app/controllers/api/v2/TimelinesController.js
@@ -137,7 +137,7 @@ export const metatags = compose([
  * @return {object}                                   - Object with the following sructure:
  *                                                      { limit:number, offset:number, sort:string, withMyPosts:boolean }
  */
-function getCommonParams(ctx, defaultSort = ORD_UPDATED) {
+export function getCommonParams(ctx, defaultSort = ORD_UPDATED) {
   const { query } = ctx.request;
 
   let limit = parseInt(query.limit, 10);

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -91,6 +91,7 @@ export const appTokensScopes = [
       'GET /vN/timelines-rss/:username',
       'GET /vN/posts/:postId',
       'GET /vN/posts/:postId/translated-body',
+      'GET /vN/posts/:postId/backlinks',
       'GET /vN/archives/post-by-old-name/:name',
       'GET /vN/allGroups',
       'GET /vN/comments/:commentId/likes',

--- a/app/routes/api/v2/PostsRoute.js
+++ b/app/routes/api/v2/PostsRoute.js
@@ -1,10 +1,17 @@
 import { getBySeqNumber } from '../../../controllers/api/v1/CommentsController';
-import { show, opengraph, getByIds, leave } from '../../../controllers/api/v2/PostsController';
+import {
+  show,
+  opengraph,
+  getByIds,
+  leave,
+  getReferringPosts,
+} from '../../../controllers/api/v2/PostsController';
 import { getTranslatedBody } from '../../../controllers/api/v2/TranslationController';
 
 export default function addRoutes(app) {
   app.get('/posts/:postId', show);
   app.get('/posts/:postId/translated-body', getTranslatedBody);
+  app.get('/posts/:postId/backlinks', getReferringPosts);
   app.get('/posts-opengraph/:postId', opengraph);
   app.get('/posts/:postId/comments/:seqNumber', getBySeqNumber);
   // We use POST here because this method can accept many post IDs

--- a/app/support/DbAdapter/backlinks.js
+++ b/app/support/DbAdapter/backlinks.js
@@ -1,5 +1,9 @@
+import pgFormat from 'pg-format';
+
 import { Comment } from '../../models';
 import { extractShortIds, extractUUIDs } from '../backlinks';
+
+import { andJoin, orJoin } from './utils';
 
 ///////////////////////////////////////////////////
 // Backlinks
@@ -83,6 +87,46 @@ const backlinksTrait = (superClass) =>
         select post_id, :refPostUID, :refCommentUID from unnest(:uuids::uuid[]) post_id
         on conflict do nothing`,
         { uuids, refPostUID, refCommentUID },
+      );
+    }
+
+    async getReferringPosts(
+      postId,
+      viewerId = null,
+      { limit = 30, offset = 0, sort = 'bumped', createdBefore = null, createdAfter = null } = {},
+    ) {
+      const [postsVisibilitySQL, notBannedSQLFabric] = await Promise.all([
+        this.postsVisibilitySQL(viewerId),
+        this.notBannedActionsSQLFabric(viewerId),
+      ]);
+
+      const commentsVisibilitySQL = orJoin([
+        'c.uid is null',
+        andJoin([pgFormat('c.hide_type=%L', Comment.VISIBLE), notBannedSQLFabric('c')]),
+      ]);
+
+      const allFilters = andJoin([
+        pgFormat('b.post_id = %L', postId),
+        // Don't count backlinks to the post itself
+        'b.post_id <> b.ref_post_id',
+        postsVisibilitySQL,
+        commentsVisibilitySQL,
+        createdBefore && pgFormat('p.created_at < %L', createdBefore),
+        createdAfter && pgFormat('p.created_at > %L', createdAfter),
+      ]);
+
+      const order = `p.${pgFormat('%I', `${sort}_at`)}`;
+
+      return await this.database.getCol(
+        `select distinct p.uid, ${order} from
+          backlinks b
+          join posts p on b.ref_post_id = p.uid
+          join users u on p.user_id = u.uid
+          left join comments c on b.ref_comment_id = c.uid
+        where ${allFilters}
+        order by ${order} desc
+        limit :limit offset :offset`,
+        { limit, offset },
       );
     }
   };

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -306,6 +306,17 @@ export class DbAdapter {
     refCommentUID?: Nullable<UUID>,
     db?: Knex,
   ): Promise<void>;
+  getReferringPosts(
+    postId: UUID,
+    viewerId?: Nullable<UUID>,
+    params?: {
+      limit?: number;
+      offset?: number;
+      sort?: 'bumped' | 'created';
+      createdBefore?: Nullable<ISO8601DateTimeString>;
+      createdAfter?: Nullable<ISO8601DateTimeString>;
+    },
+  ): Promise<UUID[]>;
 
   // Jobs
   createJob<T extends {}>(

--- a/test/functional/backlinks.js
+++ b/test/functional/backlinks.js
@@ -24,13 +24,13 @@ import Session from './realtime-session';
 
 describe('Backlinks in API output', () => {
   let luna, mars;
-  let lunaPostId, marsPostId;
+  let lunaPostId, marsPostId, lunaPostShortId;
 
   before(async () => {
     await cleanDB($pg_database);
     [luna, mars] = await createTestUsers(['luna', 'mars']);
 
-    ({ id: lunaPostId } = await createAndReturnPost(luna, 'Luna post'));
+    ({ id: lunaPostId, shortId: lunaPostShortId } = await createAndReturnPost(luna, 'Luna post'));
     ({ id: marsPostId } = await createAndReturnPost(
       mars,
       `As Luna said, example.com/${lunaPostId}`,
@@ -46,6 +46,26 @@ describe('Backlinks in API output', () => {
     const resp = await performJSONRequest(
       'GET',
       `/v2/search?qs=${encodeURIComponent(lunaPostId)}`,
+      null,
+      authHeaders(luna),
+    );
+    expect(resp, 'to satisfy', { posts: [{ id: marsPostId }] });
+  });
+
+  it(`should return Mars post by Luna post's backlinks`, async () => {
+    const resp = await performJSONRequest(
+      'GET',
+      `/v2/posts/${lunaPostId}/backlinks`,
+      null,
+      authHeaders(luna),
+    );
+    expect(resp, 'to satisfy', { posts: [{ id: marsPostId }] });
+  });
+
+  it(`should return Mars post by Luna post's backlinks with short ID`, async () => {
+    const resp = await performJSONRequest(
+      'GET',
+      `/v2/posts/${lunaPostShortId}/backlinks`,
       null,
       authHeaders(luna),
     );

--- a/test/integration/support/DbAdapter/backlinks.js
+++ b/test/integration/support/DbAdapter/backlinks.js
@@ -58,10 +58,14 @@ describe('Backlinks DB trait', () => {
       .create();
   });
 
-  it(`should calculate backlink counts for Luna, Mars and Venus posts`, async () => {
-    const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+  it(`should calculate backlinks for Luna, Mars and Venus posts`, async () => {
+    const [counts, referenced] = await getCountsAndReferenced([
+      lunaPost.id,
+      marsPost.id,
+      venusPost.id,
+    ]);
     expect(
-      result,
+      counts,
       'to equal',
       new Map([
         [lunaPost.id, 2],
@@ -69,6 +73,7 @@ describe('Backlinks DB trait', () => {
         [venusPost.id, 1],
       ]),
     );
+    expect(referenced, 'to equal', [[venusPost.id, marsPost.id], [venusPost.id], [marsPost.id]]);
   });
 
   describe('Venus becomes protected', () => {
@@ -76,24 +81,29 @@ describe('Backlinks DB trait', () => {
     after(() => venus.update({ isProtected: '0', isPrivate: '0' }));
 
     it(`should not count Venus post for anonymous`, async () => {
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      const [counts, referenced] = await getCountsAndReferenced([
+        lunaPost.id,
+        marsPost.id,
+        venusPost.id,
+      ]);
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 1],
           [venusPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[marsPost.id], [], [marsPost.id]]);
     });
 
     it(`should count Venus post for Luna`, async () => {
-      const result = await dbAdapter.getBacklinksCounts(
+      const [counts, referenced] = await getCountsAndReferenced(
         [lunaPost.id, marsPost.id, venusPost.id],
         luna.id,
       );
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 2],
@@ -101,6 +111,7 @@ describe('Backlinks DB trait', () => {
           [venusPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id], [venusPost.id], [marsPost.id]]);
     });
   });
 
@@ -109,39 +120,45 @@ describe('Backlinks DB trait', () => {
     after(() => venus.update({ isProtected: '0', isPrivate: '0' }));
 
     it(`should not count Venus post for anonymous`, async () => {
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      const [counts, referenced] = await getCountsAndReferenced([
+        lunaPost.id,
+        marsPost.id,
+        venusPost.id,
+      ]);
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 1],
           [venusPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[marsPost.id], [], [marsPost.id]]);
     });
 
     it(`should not count Venus post for Luna`, async () => {
-      const result = await dbAdapter.getBacklinksCounts(
+      const [counts, referenced] = await getCountsAndReferenced(
         [lunaPost.id, marsPost.id, venusPost.id],
         luna.id,
       );
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 1],
           [venusPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[marsPost.id], [], [marsPost.id]]);
     });
 
     it(`should count Venus post for Venus`, async () => {
-      const result = await dbAdapter.getBacklinksCounts(
+      const [counts, referenced] = await getCountsAndReferenced(
         [lunaPost.id, marsPost.id, venusPost.id],
         venus.id,
       );
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 2],
@@ -149,6 +166,7 @@ describe('Backlinks DB trait', () => {
           [venusPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id], [venusPost.id], [marsPost.id]]);
     });
   });
 
@@ -157,9 +175,13 @@ describe('Backlinks DB trait', () => {
     after(() => mars.unban(jupiter.username));
 
     it(`should count Jupiter comment for anonymous`, async () => {
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      const [counts, referenced] = await getCountsAndReferenced([
+        lunaPost.id,
+        marsPost.id,
+        venusPost.id,
+      ]);
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 2],
@@ -167,15 +189,16 @@ describe('Backlinks DB trait', () => {
           [venusPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id], [venusPost.id], [marsPost.id]]);
     });
 
     it(`should count Jupiter comment for Venus`, async () => {
-      const result = await dbAdapter.getBacklinksCounts(
+      const [counts, referenced] = await getCountsAndReferenced(
         [lunaPost.id, marsPost.id, venusPost.id],
         venus.id,
       );
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 2],
@@ -183,36 +206,39 @@ describe('Backlinks DB trait', () => {
           [venusPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id], [venusPost.id], [marsPost.id]]);
     });
 
     it(`should not count Jupiter comment for Mars`, async () => {
-      const result = await dbAdapter.getBacklinksCounts(
+      const [counts, referenced] = await getCountsAndReferenced(
         [lunaPost.id, marsPost.id, venusPost.id],
         mars.id,
       );
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 2],
           [marsPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id], [venusPost.id], []]);
     });
 
     it(`should not count Mars post for Jupiter`, async () => {
-      const result = await dbAdapter.getBacklinksCounts(
+      const [counts, referenced] = await getCountsAndReferenced(
         [lunaPost.id, marsPost.id, venusPost.id],
         jupiter.id,
       );
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 1],
           [marsPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[venusPost.id], [venusPost.id], []]);
     });
   });
 
@@ -221,15 +247,20 @@ describe('Backlinks DB trait', () => {
     after(() => mars.setGoneStatus(null));
 
     it(`should not count Mars post for anonymous`, async () => {
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id, marsPost.id, venusPost.id]);
+      const [counts, referenced] = await getCountsAndReferenced([
+        lunaPost.id,
+        marsPost.id,
+        venusPost.id,
+      ]);
       expect(
-        result,
+        counts,
         'to equal',
         new Map([
           [lunaPost.id, 1],
           [marsPost.id, 1],
         ]),
       );
+      expect(referenced, 'to equal', [[venusPost.id], [venusPost.id], []]);
     });
   });
 
@@ -238,8 +269,9 @@ describe('Backlinks DB trait', () => {
     after(() => lunaPost.update({ body: 'just a post' }));
 
     it(`should not count self-link to the Luna post`, async () => {
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 2]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
     });
   });
 
@@ -258,16 +290,18 @@ describe('Backlinks DB trait', () => {
       });
       await jupiterCommentNo2.create();
 
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 3]]));
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 3]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
     });
 
     it(`should decrease count by 1 (not 2) when link from post removed`, async () => {
       // Making sure the backlinks in comments are not "discarded" when the link in their parent post is removed
       await marsPost.update({ body: 'luna post: ah, never mind' });
 
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 2]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
     });
   });
 
@@ -288,18 +322,21 @@ describe('Backlinks DB trait', () => {
       });
       await jupiterPost.create();
 
-      let result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+      let [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 2]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
 
       await jupiterPost.update({ body: `luna post: /luna/${lunaPostShortId}` });
 
-      result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 3]]));
+      [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 3]]));
+      expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
 
       await jupiterPost.update({ body: `just a post` });
 
-      result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+      [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 2]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
     });
 
     it(`should count short links on comment update`, async () => {
@@ -309,18 +346,21 @@ describe('Backlinks DB trait', () => {
       });
       await jupiterCommentNo2.create();
 
-      let result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+      let [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 2]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
 
       await jupiterCommentNo2.update({ body: `luna post: /luna/${lunaPostShortId}` });
 
-      result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 3]]));
+      [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 3]]));
+      expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
 
       await jupiterCommentNo2.update({ body: `just a comment` });
 
-      result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+      [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 2]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
     });
 
     it(`should count short links on post create`, async () => {
@@ -334,8 +374,9 @@ describe('Backlinks DB trait', () => {
       });
       await jupiterPost.create();
 
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 3]]));
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 3]]));
+      expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
     });
 
     it(`should count short links on comment create`, async () => {
@@ -345,22 +386,34 @@ describe('Backlinks DB trait', () => {
       });
       await jupiterCommentNo2.create();
 
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 4]]));
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 4]]));
+      expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
     });
 
     it(`should count short links on comment destroy`, async () => {
       await jupiterCommentNo2.destroy();
 
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 3]]));
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 3]]));
+      expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
     });
 
     it(`should count short links on post destroy`, async () => {
       await jupiterPost.destroy();
 
-      const result = await dbAdapter.getBacklinksCounts([lunaPost.id]);
-      expect(result, 'to equal', new Map([[lunaPost.id, 2]]));
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 2]]));
+      expect(referenced, 'to equal', [[venusPost.id, marsPost.id]]);
     });
   });
 });
+
+function getCountsAndReferenced(postIds, viewerId = null) {
+  return Promise.all([
+    dbAdapter.getBacklinksCounts(postIds, viewerId),
+    Promise.all(
+      postIds.map((id) => dbAdapter.getReferringPosts(id, viewerId, { sort: 'created' })),
+    ),
+  ]);
+}


### PR DESCRIPTION
This method returns feed of all posts that references to the given post. It accepts postId in long and short forms.