### PR TITLE
Allow author to edit post regardless of access to existing dest. feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.15.0] - Not released
+### Changed
+- When editing a post, access rights to existing destination feeds of the post
+  are no longer checked. This change allows the author of the post to always be
+  able to edit it if he has access. Here are some examples of situations
+  affected by this change:
+  - The author wrote a post in a public group and his own feed. The group became
+    private, and the author lost access to it, but he still has access to his
+    post. He should be able to edit his post.
+  - The author sent a direct message, but the recipient deleted his account. The
+    author can no longer send direct messages to him, but he should still be
+    able to edit the existing direct message. This case is particularly
+    important because the author of the direct message cannot delete recipients
+    himself.
 
 ## [2.14.0] - 2023-09-02
 ### Added

--- a/app/controllers/api/v1/BookmarkletController.js
+++ b/app/controllers/api/v1/BookmarkletController.js
@@ -7,7 +7,7 @@ import { show as showPost } from '../v2/PostsController';
 import { downloadURL } from '../../../support/download-url';
 
 import { bookmarkletCreateInputSchema } from './data-schemes';
-import { checkDestNames } from './PostsController';
+import { getDestinationFeeds } from './PostsController';
 
 export const create = compose([
   authRequired(),
@@ -29,7 +29,7 @@ export const create = compose([
       destNames.push(author.username);
     }
 
-    const timelineIds = await checkDestNames(destNames, author);
+    const timelines = await getDestinationFeeds(author, destNames, null);
 
     // Attachments
     if (images.length === 0 && image !== '') {
@@ -51,7 +51,7 @@ export const create = compose([
       userId: author.id,
       body,
       attachments,
-      timelineIds,
+      timelineIds: timelines.map((f) => f.id),
     });
     await post.create();
 

--- a/app/models/group.js
+++ b/app/models/group.js
@@ -226,38 +226,6 @@ export function addModel(dbAdapter) {
     }
 
     /**
-     * Checks if the specified user can post to the timeline of this group
-     * and returns array of destination timelines or empty array if
-     * user can not post to this group.
-     *
-     * @param {User} postingUser
-     * @returns {Promise<Timeline[]>}
-     */
-    async getFeedsToPost(postingUser) {
-      const timeline = await dbAdapter.getUserNamedFeed(this.id, 'Posts');
-      const isSubscribed = await dbAdapter.isUserSubscribedToTimeline(postingUser.id, timeline.id);
-
-      if (this.isPrivate === '1' && !isSubscribed) {
-        return [];
-      }
-
-      const [admins, blocked] = await Promise.all([
-        this.getActiveAdministrators(),
-        dbAdapter.groupIdsBlockedUser(postingUser.id, [this.id]),
-      ]);
-
-      if (
-        blocked.length > 0 ||
-        admins.length === 0 ||
-        (this.isRestricted === '1' && !admins.some((a) => a.id === postingUser.id))
-      ) {
-        return [];
-      }
-
-      return [timeline];
-    }
-
-    /**
      * Blocks user in the group. adminId is the id of the admin who blocking the
      * user. This method doesn't perform any access checks, it even doesn't
      * check if the admin is actually a group administrator. Returns true if the

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1092,7 +1092,7 @@ export function addModel(dbAdapter) {
      * this user.
      *
      * @param {User|null} postingUser
-     * @returns {boolean}
+     * @returns {Promise<boolean>}
      */
     async acceptsDirectsFrom(postingUser) {
       if (!postingUser || this.id === postingUser.id) {
@@ -1120,30 +1120,6 @@ export function addModel(dbAdapter) {
       }
 
       return false;
-    }
-
-    /**
-     * Checks if the specified user can post to the timeline of this user
-     * returns array of destination (Directs) timelines
-     * or empty array if user can not post to this user.
-     *
-     * @param {User} postingUser
-     * @returns {Timeline[]}
-     */
-    async getFeedsToPost(postingUser) {
-      if (this.id === postingUser.id) {
-        // Users always can post to own timeline
-        return [await dbAdapter.getUserNamedFeed(this.id, 'Posts')];
-      }
-
-      if (!(await this.acceptsDirectsFrom(postingUser))) {
-        return [];
-      }
-
-      return await Promise.all([
-        dbAdapter.getUserNamedFeed(this.id, 'Directs'),
-        dbAdapter.getUserNamedFeed(postingUser.id, 'Directs'),
-      ]);
     }
 
     async updateLastActivityAt() {

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -124,6 +124,7 @@ export class DbAdapter {
   existsNormEmail(email: string): Promise<boolean>;
   getUserIdsWhoBannedUser(id: UUID): Promise<UUID[]>;
   getFeedOwnerById(id: UUID): Promise<User | Group | null>;
+  getFeedOwnerByUsername(name: string): Promise<User | Group | null>;
   getFeedOwnersByUsernames(names: string[]): Promise<(User | Group)[]>;
   getFeedOwnersByIds(ids: UUID[]): Promise<Nullable<User | Group>[]>;
   someUsersArePublic(userIds: UUID[], anonymousFriendly: boolean): Promise<boolean>;

--- a/test/functional/posts/edit-destinations.js
+++ b/test/functional/posts/edit-destinations.js
@@ -1,0 +1,114 @@
+/* eslint-env node, mocha */
+/* global  $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../../dbCleaner';
+import {
+  createTestUsers,
+  mutualSubscriptions,
+  createAndReturnPostToFeed,
+  performJSONRequest,
+  authHeaders,
+  createGroupAsync,
+  groupToPrivate,
+} from '../functional_test_helper';
+import { GONE_SUSPENDED } from '../../../app/models/user';
+
+describe('Update destinations of existing post', () => {
+  let luna, mars;
+  let post;
+
+  beforeEach(async () => {
+    await cleanDB($pg_database);
+
+    [luna, mars] = await createTestUsers(['luna', 'mars']);
+  });
+
+  describe('Luna sent direct message to Mars, Mars decide to delete his account', () => {
+    beforeEach(async () => {
+      await mutualSubscriptions([luna, mars]);
+
+      // Luna sent direct message to Mars
+      post = await createAndReturnPostToFeed([mars], luna, 'Hello, Mars!');
+
+      // Mars decide to delete his account
+      await mars.user.setGoneStatus(GONE_SUSPENDED);
+    });
+
+    it(`should allow Luna to update the direct post without 'feeds' field`, async () => {
+      const resp = await performJSONRequest(
+        'PUT',
+        `/v2/posts/${post.id}`,
+        { post: { body: 'Bye, Mars:(' } },
+        authHeaders(luna),
+      );
+
+      expect(resp, 'to satisfy', { __httpCode: 200 });
+    });
+
+    it(`should allow Luna to update the direct post with 'feeds' field`, async () => {
+      const resp = await performJSONRequest(
+        'PUT',
+        `/v2/posts/${post.id}`,
+        { post: { body: 'Bye, Mars:(', feeds: [mars.username] } },
+        authHeaders(luna),
+      );
+
+      expect(resp, 'to satisfy', { __httpCode: 200 });
+    });
+
+    it(`should not allow Luna to create new direct message to Mars`, async () => {
+      const resp = await performJSONRequest(
+        'POST',
+        `/v2/posts`,
+        { post: { body: 'Mars, where are you?' }, meta: { feeds: [mars.username] } },
+        authHeaders(luna),
+      );
+
+      expect(resp, 'to satisfy', { __httpCode: 403 });
+    });
+  });
+
+  describe('Luna wrote post to group, group became private', () => {
+    let celestials;
+    beforeEach(async () => {
+      celestials = await createGroupAsync(mars, 'celestials', 'Celestials');
+
+      post = await createAndReturnPostToFeed([celestials, luna], luna, 'Hello, world!');
+      await groupToPrivate(celestials.group, mars);
+    });
+
+    it(`should allow Luna to update the post without 'feeds' field`, async () => {
+      const resp = await performJSONRequest(
+        'PUT',
+        `/v2/posts/${post.id}`,
+        { post: { body: 'Hello again?' } },
+        authHeaders(luna),
+      );
+
+      expect(resp, 'to satisfy', { __httpCode: 200 });
+    });
+
+    it(`should allow Luna to update the post with 'feeds' field`, async () => {
+      const resp = await performJSONRequest(
+        'PUT',
+        `/v2/posts/${post.id}`,
+        { post: { body: 'Hello again?', feeds: [luna.username, celestials.username] } },
+        authHeaders(luna),
+      );
+
+      expect(resp, 'to satisfy', { __httpCode: 200 });
+    });
+
+    it(`should not allow Luna to create new post in private group`, async () => {
+      const resp = await performJSONRequest(
+        'POST',
+        `/v2/posts`,
+        { post: { body: 'Hello again?' }, meta: { feeds: [luna.username, celestials.username] } },
+        authHeaders(luna),
+      );
+
+      expect(resp, 'to satisfy', { __httpCode: 403 });
+    });
+  });
+});

--- a/test/integration/controllers/getDestinationFeeds.js
+++ b/test/integration/controllers/getDestinationFeeds.js
@@ -5,9 +5,9 @@ import { zipObject } from 'lodash';
 
 import cleanDB from '../../dbCleaner';
 import { User } from '../../../app/models';
-import { checkDestNames } from '../../../app/controllers/api/v1/PostsController';
+import { getDestinationFeeds } from '../../../app/controllers/api/v1/PostsController';
 
-describe('checkDestNames function', () => {
+describe('getDestinationFeeds function', () => {
   const userNames = ['luna', 'mars', 'venus', 'jupiter'];
   let users = {};
 
@@ -34,22 +34,22 @@ describe('checkDestNames function', () => {
     const directFeedIds = await Promise.all(
       [users.luna, users.mars, users.venus].map((u) => u.getDirectsTimelineId()),
     );
-    const feedIds = await checkDestNames(['mars', 'venus'], users.luna);
-    await expect(feedIds.sort(), 'to satisfy', directFeedIds.sort());
+    const feeds = await getDestinationFeeds(users.luna, ['mars', 'venus'], null);
+    await expect(feeds.map((f) => f.id).sort(), 'to satisfy', directFeedIds.sort());
   });
 
   it('should not allow to Luna to send direct to Jupiter', async () => {
-    const call = checkDestNames(['mars', 'venus', 'jupiter'], users.luna);
+    const call = getDestinationFeeds(users.luna, ['mars', 'venus', 'jupiter'], null);
     await expect(call, 'to be rejected with', /jupiter/);
   });
 
   it('should not allow to Luna to send direct to Saturn', async () => {
-    const call = checkDestNames(['mars', 'venus', 'saturn'], users.luna);
+    const call = getDestinationFeeds(users.luna, ['mars', 'venus', 'saturn'], null);
     await expect(call, 'to be rejected with', /saturn/);
   });
 
   it('should not allow to Jupiter to send direct to Luna and Mars', async () => {
-    const call = checkDestNames(['luna', 'mars', 'venus'], users.jupiter);
+    const call = getDestinationFeeds(users.jupiter, ['luna', 'mars', 'venus'], null);
     await expect(call, 'to be rejected with', /luna/).and('to be rejected with', /mars/);
   });
 });


### PR DESCRIPTION
When editing a post, access rights to existing destination feeds of the post are no longer checked. This change allows the author of the post to always be able to edit it if he has access. Here are some examples of situations affected by this change:
  - The author wrote a post in a public group and his own feed. The group became private, and the author lost access to it, but he still has access to his post. He should be able to edit his post.
  - The author sent a direct message, but the recipient deleted his account. The author can no longer send direct messages to him, but he should still be able to edit the existing direct message. This case is particularly important because the author of the direct message cannot delete recipients himself.