### PR TITLE
Allow to auto-subscribe to new comments on commented posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.17.0] - Not released
+### Added
+- Users can now subscribe to all comments of posts commented by them. For this
+  purpose one can set the `notifyOfCommentsOnCommentedPosts` flag to _true_ in
+  their preferences.
 
 ## [2.16.1] - 2023-11-25
 ### Fixed

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -201,6 +201,7 @@ export class Comment {
   hideType: 0 | 1 | 2 | 3;
   postId: UUID;
   seqNumber: number;
+  constructor(params: { userId: UUID; body: string; postId: UUID });
   create(): Promise<void>;
   destroy(destroyedBy?: User): Promise<boolean>;
   getPost(): Promise<Post>;

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -966,20 +966,29 @@ export function addModel(dbAdapter) {
      */
     async getCommentsListeners() {
       const listeners = new Set();
-      const [destinations, author, listenersMap] = await Promise.all([
-        this.getPostedTo(),
+      const [feeds, author, listenersMap] = await Promise.all([
+        this.getTimelines(),
         this.getCreatedBy(),
         dbAdapter.getCommentEventsListenersForPost(this.id),
       ]);
 
-      const directRecipients = destinations.filter((d) => d.isDirects()).map((d) => d.userId);
+      const directRecipientIds = feeds.filter((f) => f.isDirects()).map((f) => f.userId);
+      const commenterIds = feeds.filter((f) => f.isComments()).map((f) => f.userId);
 
-      for (const id of directRecipients) {
+      for (const id of directRecipientIds) {
         listeners.add(id);
       }
 
       if (author.preferences.notifyOfCommentsOnMyPosts) {
         listeners.add(author.id);
+      }
+
+      const commentators = await dbAdapter.getUsersByIds(commenterIds);
+
+      for (const commentator of commentators) {
+        if (commentator.preferences.notifyOfCommentsOnCommentedPosts) {
+          listeners.add(commentator.id);
+        }
       }
 
       for (const [id, enabled] of listenersMap.entries()) {

--- a/app/models/user-prefs.ts
+++ b/app/models/user-prefs.ts
@@ -52,6 +52,10 @@ const schema = {
       title: 'Notify of all comments on my posts',
       type: 'boolean',
     },
+    notifyOfCommentsOnCommentedPosts: {
+      title: 'Notify of all comments on posts commented by me',
+      type: 'boolean',
+    },
   },
   additionalProperties: false,
 };

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -193,6 +193,7 @@ export class DbAdapter {
   getPostsByIntIds(ids: number[]): Promise<Post[]>;
   filterSuspendedPosts(ids: UUID[]): Promise<UUID[]>;
   withdrawPostFromDestFeed(feedIntId: number, postUUID: UUID): Promise<boolean>;
+  getPostsPresentsInTimeline(postIds: UUID[], feedIntId: number): Promise<UUID[]>;
 
   // Likes
   unlikePost(postId: UUID, userId: UUID): Promise<boolean>;

--- a/app/support/DbAdapter/posts.js
+++ b/app/support/DbAdapter/posts.js
@@ -250,6 +250,18 @@ const postsTrait = (superClass) =>
     }
 
     /**
+     * Returns only ids of posts that presents in the given timeline
+     * @param {UUID[]} postIds - ids of posts
+     * @param {number} feedIntId - integer id of timeline
+     */
+    async getPostsPresentsInTimeline(postIds, feedIntId) {
+      return await this.database.getCol(
+        `select uid from posts where uid = any(:postIds) and feed_ids && :timelineIds::int[]`,
+        { postIds, timelineIds: [feedIntId] },
+      );
+    }
+
+    /**
      * Returns integer ids of private feeds that user can view
      * @param {String} userId   - UID of user
      * @return {Promise<Number[]>} - ids of feeds

--- a/config/default.js
+++ b/config/default.js
@@ -390,6 +390,8 @@ config.userPreferences = {
     sanitizeMediaMetadata: true,
     // Notify of all comments on my posts
     notifyOfCommentsOnMyPosts: false,
+    // Notify of all comments on posts commented by me
+    notifyOfCommentsOnCommentedPosts: false,
   },
   /**
    *  Here you can override the default values depending on the 'createdAt' time

--- a/test/integration/post-comment-events.ts
+++ b/test/integration/post-comment-events.ts
@@ -100,6 +100,31 @@ describe(`'post_comment' event emitting`, () => {
       });
     });
 
+    describe('Luna want to receive notifications about commented posts', () => {
+      beforeEach(async () => {
+        await luna.update({ preferences: { notifyOfCommentsOnCommentedPosts: true } });
+      });
+
+      it(`should not create notification when there are no comments of Luna`, async () => {
+        const post = await createPost(mars, 'Hello, world!');
+        await createComment(mars, post, 'Comment from Mars');
+
+        await expectUserEventsToBe(luna, []);
+        await expectUserEventsToBe(mars, []);
+      });
+
+      it(`should create notification about comment of Mars after comment of Luna`, async () => {
+        const post = await createPost(mars, 'Hello, world!');
+        await createComment(luna, post, 'Comment from Luna');
+        await createComment(mars, post, 'Comment from Mars');
+
+        await expectUserEventsToBe(luna, [
+          { event_type: ET.POST_COMMENT, created_by_user_id: mars.intId },
+        ]);
+        await expectUserEventsToBe(mars, []);
+      });
+    });
+
     describe('Direct message comments', () => {
       let post: Post;
       beforeEach(async () => {

--- a/test/integration/post-comment-events.ts
+++ b/test/integration/post-comment-events.ts
@@ -100,28 +100,41 @@ describe(`'post_comment' event emitting`, () => {
       });
     });
 
-    describe('Luna want to receive notifications about commented posts', () => {
-      beforeEach(async () => {
-        await luna.update({ preferences: { notifyOfCommentsOnCommentedPosts: true } });
+    describe('Notifications about commented posts', () => {
+      describe("Luna doesn't want to receive notifications about commented posts", () => {
+        it(`should not create notification about comment of Mars after comment of Luna`, async () => {
+          const post = await createPost(mars, 'Hello, world!');
+          await createComment(luna, post, 'Comment from Luna');
+          await createComment(mars, post, 'Comment from Mars');
+
+          await expectUserEventsToBe(luna, []);
+          await expectUserEventsToBe(mars, []);
+        });
       });
 
-      it(`should not create notification when there are no comments of Luna`, async () => {
-        const post = await createPost(mars, 'Hello, world!');
-        await createComment(mars, post, 'Comment from Mars');
+      describe('Luna want to receive notifications about commented posts', () => {
+        beforeEach(async () => {
+          await luna.update({ preferences: { notifyOfCommentsOnCommentedPosts: true } });
+        });
 
-        await expectUserEventsToBe(luna, []);
-        await expectUserEventsToBe(mars, []);
-      });
+        it(`should not create notification when there are no comments of Luna`, async () => {
+          const post = await createPost(mars, 'Hello, world!');
+          await createComment(mars, post, 'Comment from Mars');
 
-      it(`should create notification about comment of Mars after comment of Luna`, async () => {
-        const post = await createPost(mars, 'Hello, world!');
-        await createComment(luna, post, 'Comment from Luna');
-        await createComment(mars, post, 'Comment from Mars');
+          await expectUserEventsToBe(luna, []);
+          await expectUserEventsToBe(mars, []);
+        });
 
-        await expectUserEventsToBe(luna, [
-          { event_type: ET.POST_COMMENT, created_by_user_id: mars.intId },
-        ]);
-        await expectUserEventsToBe(mars, []);
+        it(`should create notification about comment of Mars after comment of Luna`, async () => {
+          const post = await createPost(mars, 'Hello, world!');
+          await createComment(luna, post, 'Comment from Luna');
+          await createComment(mars, post, 'Comment from Mars');
+
+          await expectUserEventsToBe(luna, [
+            { event_type: ET.POST_COMMENT, created_by_user_id: mars.intId },
+          ]);
+          await expectUserEventsToBe(mars, []);
+        });
       });
     });
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -117,6 +117,7 @@ declare module 'config' {
         acceptDirectsFrom: string;
         sanitizeMediaMetadata: boolean;
         notifyOfCommentsOnMyPosts: boolean;
+        notifyOfCommentsOnCommentedPosts: boolean;
       };
       overrides: {
         [k: string]:


### PR DESCRIPTION
Users can now subscribe to all comments of posts commented by them. For this purpose one can set the `notifyOfCommentsOnCommentedPosts` flag to _true_ in their preferences.