### PR TITLE
Use a full text parser for backlinks search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.19.0] - Not released
+### Fixed
+- Use a full text parser for backlinks search in their short form
+  (/username/shortId). It prevents false positives, when some URL in text
+  contains a shortlink-looking fragment.
 
 ## [2.18.1] - 2024-01-26
 ### Fixed

--- a/app/support/backlinks.ts
+++ b/app/support/backlinks.ts
@@ -1,7 +1,10 @@
 import { xor } from 'lodash';
+import { LINK } from 'social-text-tokenizer';
+import { linkHref } from 'social-text-tokenizer/prettifiers';
 
 import { List } from './open-lists';
 import { UUID } from './types';
+import { SHORT_LINK, tokenize } from './tokenize-text';
 
 export function getUpdatedUUIDs(text1: string, text2: string = '') {
   if (text1 === text2) {
@@ -19,19 +22,69 @@ export function getUpdatedShortIds(text1: string, text2: string = '') {
   return xor(extractShortIds(text1), extractShortIds(text2));
 }
 
-export const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
 export function extractUUIDs(text: string | null): UUID[] {
   return text ? [...text.matchAll(uuidRe)].map((m) => m[0]).filter(onlyUnique) : [];
 }
 
-export const shortLinkRe = /\/[A-Za-z0-9-]{3,35}\/([0-9a-f]{6,10})/gi;
+const shortLinkStr = `/[A-Za-z0-9-]{3,35}/([0-9a-f]{6,10})`;
+const shortLinkReStart = new RegExp(`^${shortLinkStr}`, 'i');
+const shortLinkReExact = new RegExp(`^${shortLinkStr}$`, 'i');
+
+const hashedShortLinkStr = `/[A-Za-z0-9-]{3,35}/([0-9a-f]{6,10}#[0-9a-f]{4,6})`;
+const hashedShortLinkReExact = new RegExp(`^${hashedShortLinkStr}$`, 'i');
+
 export function extractShortIds(text: string | null): string[] {
-  return text ? [...text.matchAll(shortLinkRe)].map((m) => m[1]).filter(onlyUnique) : [];
+  if (!text) {
+    return [];
+  }
+
+  return tokenize(text)
+    .map((token) => {
+      if (token.type === SHORT_LINK) {
+        const m = token.text.match(shortLinkReStart);
+        return m?.[1];
+      } else if (token.type === LINK) {
+        const href = linkHref(token.text);
+
+        try {
+          const url = new URL(href);
+          return url.pathname.match(shortLinkReExact)?.[1];
+        } catch {
+          return undefined;
+        }
+      }
+
+      return undefined;
+    })
+    .filter(Boolean)
+    .filter(onlyUnique) as string[];
 }
 
-export const hashedShortLinkRe = /\/[A-Za-z0-9-]{3,35}\/([0-9a-f]{6,10}#[0-9a-f]{4,6})/gi;
 export function extractHashedShortIds(text: string | null): string[] {
-  return text ? [...text.matchAll(hashedShortLinkRe)].map((m) => m[1]).filter(onlyUnique) : [];
+  if (!text) {
+    return [];
+  }
+
+  return tokenize(text)
+    .map((token) => {
+      if (token.type === SHORT_LINK) {
+        return token.text.match(hashedShortLinkReExact)?.[1];
+      } else if (token.type === LINK) {
+        const href = linkHref(token.text);
+
+        try {
+          const url = new URL(href);
+          return (url.pathname + url.search + url.hash).match(hashedShortLinkReExact)?.[1];
+        } catch {
+          return undefined;
+        }
+      }
+
+      return undefined;
+    })
+    .filter(Boolean)
+    .filter(onlyUnique) as string[];
 }
 
 function onlyUnique<T>(value: T, index: number, arr: T[]) {

--- a/app/support/tokenize-text.ts
+++ b/app/support/tokenize-text.ts
@@ -1,10 +1,13 @@
 import { emails, mentions, links, arrows, hashtags, withTexts } from 'social-text-tokenizer';
-import { reTokenizer, makeToken } from 'social-text-tokenizer/utils';
+import { reTokenizer, makeToken, wordAdjacentChars } from 'social-text-tokenizer/utils';
+import { withCharsAfter, withCharsBefore, withFilters } from 'social-text-tokenizer/filters';
 
-import { uuidRe } from './backlinks';
+const uuidRe = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
 
 export const UUID_TOKEN = 'UUID';
 export const HTML_TAG_TOKEN = 'HTML_TAG';
+export const REDDIT_LINK = 'REDDIT_LINK';
+export const SHORT_LINK = 'SHORT_LINK';
 
 export function htmlTagContent(text: string): string {
   return text.replace(/<\/?(.+?)>/g, '$1').trim();
@@ -17,6 +20,20 @@ export function isHtmlTagClosing(text: string): boolean {
 const htmlTags = reTokenizer(/<\/?.+?>/g, makeToken(HTML_TAG_TOKEN));
 const uuidStrings = reTokenizer(uuidRe, makeToken(UUID_TOKEN));
 
+const redditLinks = withFilters(
+  reTokenizer(/\/?r\/[A-Za-z\d]\w{1,20}/g, makeToken(REDDIT_LINK)),
+  withCharsBefore(wordAdjacentChars.withoutChars('/')),
+  withCharsAfter(wordAdjacentChars.withoutChars('/')),
+);
+
+const shortLinkRe = /\/[a-z\d-]{3,35}\/[\da-f]{6,10}(?:#[\da-f]{4,6})?/gi;
+
+const shortLinks = withFilters(
+  reTokenizer(shortLinkRe, makeToken(SHORT_LINK)),
+  withCharsBefore(wordAdjacentChars.withoutChars('/')),
+  withCharsAfter(wordAdjacentChars.withoutChars('/')),
+);
+
 export const tokenize = withTexts(
   hashtags(),
   emails(),
@@ -25,4 +42,6 @@ export const tokenize = withTexts(
   arrows(),
   htmlTags,
   uuidStrings,
+  shortLinks,
+  redditLinks,
 );

--- a/test/integration/support/DbAdapter/backlinks.js
+++ b/test/integration/support/DbAdapter/backlinks.js
@@ -379,6 +379,48 @@ describe('Backlinks DB trait', () => {
       expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
     });
 
+    it(`should count short links on post create, when link is 'example.com/abcd/{shortId}' URL`, async () => {
+      const post = new Post({
+        body: `probably a luna post: example.com/abcd/${lunaPostShortId}`,
+        userId: jupiter.id,
+        timelineIds: [jupiterFeed.id],
+      });
+      await post.create();
+
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 4]]));
+      expect(referenced, 'to equal', [[post.id, jupiterPost.id, venusPost.id, marsPost.id]]);
+      await post.destroy();
+    });
+
+    it(`should NOT count short links on post create, when link is 'http://localhost/{shortId}' URL`, async () => {
+      const post = new Post({
+        body: `not a luna post: http://localhost/${lunaPostShortId}`,
+        userId: jupiter.id,
+        timelineIds: [jupiterFeed.id],
+      });
+      await post.create();
+
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 3]]));
+      expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
+      await post.destroy();
+    });
+
+    it(`should NOT count short links on post create, when link is 'example.com/abcd/{shortId}/efg' URL`, async () => {
+      const post = new Post({
+        body: `not a luna post: example.com/abcd/${lunaPostShortId}/efg`,
+        userId: jupiter.id,
+        timelineIds: [jupiterFeed.id],
+      });
+      await post.create();
+
+      const [counts, referenced] = await getCountsAndReferenced([lunaPost.id]);
+      expect(counts, 'to equal', new Map([[lunaPost.id, 3]]));
+      expect(referenced, 'to equal', [[jupiterPost.id, venusPost.id, marsPost.id]]);
+      await post.destroy();
+    });
+
     it(`should count short links on comment create`, async () => {
       jupiterCommentNo2 = jupiter.newComment({
         postId: jupiterPost.id,


### PR DESCRIPTION
It prevents false positives, when some URL in text contains a shortlink-looking fragment