### PR TITLE
Fix a bug in comment visibility detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.19.0] - Not released
+### Fixed
+- Bug in comment visibility detection, that leads to incorrect behavior in the
+  following case:
+  1. User A turns off bans in some group G
+  2. User A bans user B
+  3. User A subscribes to the post P in group G
+  4. User B adds a new comment to the post P
+  
+  In this case user A won't get a new comment notification, even though she can
+  see the B's comment.
 
 ## [2.18.3] - 2024-02-23
 #### Changed

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -120,6 +120,8 @@ export class Group {
   createdAt: string; // numeric string
   updatedAt: string; // numeric string
   type: 'group';
+  constructor(params: unknown);
+  create(creatorId: UUID): Promise<this>;
   isGroup(): true;
   isUser(): false;
   getAdministrators(): Promise<User[]>;
@@ -130,6 +132,9 @@ export class Group {
 
   blockUser(userId: UUID, adminId: UUID): Promise<boolean>;
   unblockUser(userId: UUID, adminId: UUID): Promise<boolean>;
+
+  enableBansFor(userId: UUID, initiatorId?: UUID): Promise<void>;
+  disableBansFor(userId: UUID, initiatorId?: UUID): Promise<void>;
 }
 
 type PostUserState = {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -854,7 +854,7 @@ export function addModel(dbAdapter) {
      * Filter users that can not see this post
      *
      * Viewer CAN NOT see post if:
-     * - viwer is anonymous and post is not public or
+     * - viewer is anonymous and post is not public or
      * - viewer is authorized and
      *   - post author banned viewer or was banned by viewer or
      *   - post is private and viewer cannot read any of post's destination feeds


### PR DESCRIPTION
This bug leads to incorrect behavior in the following case:
  1. User A turns off bans in some group G
  2. User A bans user B
  3. User A subscribes to the post P in group G
  4. User B adds a new comment to the post P
  
In this case user A won't get a new comment notification, even though she can see the B's comment.