### PR TITLE
Symmetric bans (broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.19.0] - Not released
+#### Changed
+- The bans are fully symmetrical now. If A bans B, then:
+  - A doesn't see B's posts, comments content, likes and comment likes;
+  - B doesn't see A's posts, comments content, likes and comment likes.
+  
+  By default, comments are displayed as placeholders, but the viewer can turn
+  them off completely. Also, one can disable bans in some groups, see the
+  [2.7.0] release for the bans logic in this case.
+- /!\ The ban symmetry is DELIBERATELY BROKEN for now. It works for likes and
+  comment likes, but the A's comments content is still visible for B. Such
+  comments have an additional `_hideType = 4` field in API responses ('4' is the
+  `Comment.HIDDEN_VIEWER_BANNED` constant). The client code can hide such
+  comments on its level.
 
 ## [2.18.5] - 2024-04-09
 ### Fixed

--- a/app/controllers/middlewares/comment-access-required.js
+++ b/app/controllers/middlewares/comment-access-required.js
@@ -64,7 +64,7 @@ export function commentAccessRequired({ mustBeVisible }) {
       if (mustBeVisible) {
         throw new ForbiddenException('You have banned the author of this comment');
       } else {
-        comment.setHideType(Comment.HIDDEN_BANNED);
+        comment.setHideType(Comment.HIDDEN_AUTHOR_BANNED);
       }
     }
 

--- a/app/controllers/middlewares/comment-access-required.js
+++ b/app/controllers/middlewares/comment-access-required.js
@@ -64,13 +64,17 @@ export function commentAccessRequired({ mustBeVisible }) {
 
     if (mustBeVisible && banHideType === Comment.HIDDEN_AUTHOR_BANNED) {
       throw new ForbiddenException('You have banned the author of this comment');
-    } else if (mustBeVisible && banHideType === Comment.HIDDEN_VIEWER_BANNED) {
-      throw new ForbiddenException('The author of this comment has banned you');
+      // } else if (mustBeVisible && banHideType === Comment.HIDDEN_VIEWER_BANNED) {
+      //   throw new ForbiddenException('The author of this comment has banned you');
     } else if (banHideType) {
       comment.setHideType(banHideType);
     }
 
-    if (comment.hideType !== Comment.VISIBLE && mustBeVisible) {
+    if (
+      comment.hideType !== Comment.VISIBLE &&
+      banHideType !== Comment.HIDDEN_VIEWER_BANNED &&
+      mustBeVisible
+    ) {
       throw new ForbiddenException(`You don't have access to this comment`);
     }
 

--- a/app/models.d.ts
+++ b/app/models.d.ts
@@ -204,15 +204,19 @@ export class Attachment {
 export class Comment {
   static VISIBLE: 0;
   static DELETED: 1;
-  static HIDDEN_BANNED: 2;
+  // The author of the comment was banned by a viewer
+  static HIDDEN_AUTHOR_BANNED: 2;
   static HIDDEN_ARCHIVED: 3;
+  // A viewer was banned by the author of the comment
+  static HIDDEN_VIEWER_BANNED: 4;
   id: UUID;
   intId: number;
   body: string;
   userId: Nullable<UUID>;
-  hideType: 0 | 1 | 2 | 3;
+  hideType: 0 | 1 | 2 | 3 | 4;
   postId: UUID;
   seqNumber: number;
+  static hiddenBody(hideType: number): string;
   constructor(params: { userId: UUID; body: string; postId: UUID });
   create(): Promise<void>;
   destroy(destroyedBy?: User): Promise<boolean>;

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -20,8 +20,11 @@ export function addModel(dbAdapter) {
   class Comment {
     static VISIBLE = 0;
     static DELETED = 1;
-    static HIDDEN_BANNED = 2;
+    // The author of the comment was banned by a viewer
+    static HIDDEN_AUTHOR_BANNED = 2;
     static HIDDEN_ARCHIVED = 3;
+    // A viewer was banned by the author of the comment
+    static HIDDEN_VIEWER_BANNED = 4;
 
     id;
     intId;
@@ -40,10 +43,12 @@ export function addModel(dbAdapter) {
           return 'Visible comment';
         case this.DELETED:
           return 'Deleted comment';
-        case this.HIDDEN_BANNED:
-          return 'Hidden comment';
+        case this.HIDDEN_AUTHOR_BANNED:
+          return 'Comment from blocked user';
         case this.HIDDEN_ARCHIVED:
           return 'Archived comment';
+        case this.HIDDEN_VIEWER_BANNED:
+          return 'Comment from user who blocked you';
         default:
           return 'Hidden comment';
       }

--- a/app/models/user-prefs.ts
+++ b/app/models/user-prefs.ts
@@ -24,7 +24,12 @@ const schema = {
       uniqueItems: true,
       items: {
         type: 'integer',
-        enum: [commentModel.DELETED, commentModel.HIDDEN_BANNED, commentModel.HIDDEN_ARCHIVED],
+        enum: [
+          commentModel.DELETED,
+          commentModel.HIDDEN_AUTHOR_BANNED,
+          commentModel.HIDDEN_ARCHIVED,
+          commentModel.HIDDEN_VIEWER_BANNED,
+        ],
       },
     },
     sendNotificationsDigest: {

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -386,8 +386,8 @@ export default class PubsubListener {
 
             if (bannedUserIds.includes(data.comments.createdBy)) {
               hideType = Comment.HIDDEN_AUTHOR_BANNED;
-            } else if (bannedByUserIds.includes(data.comments.createdBy)) {
-              hideType = Comment.HIDDEN_VIEWER_BANNED;
+              // } else if (bannedByUserIds.includes(data.comments.createdBy)) {
+              //   hideType = Comment.HIDDEN_VIEWER_BANNED;
             }
 
             if (hideType !== null) {
@@ -403,6 +403,8 @@ export default class PubsubListener {
               data.comments.createdBy = null;
               data.users = data.users.filter((u) => u.id !== createdBy);
               data.admins = data.admins.filter((u) => u.id !== createdBy);
+            } else if (bannedByUserIds.includes(data.comments.createdBy)) {
+              data.comments._hideType = Comment.HIDDEN_VIEWER_BANNED;
             }
           }
         }

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -335,15 +335,24 @@ export default class PubsubListener {
     }
 
     // See doc/visibility-rules.md for details
-    const bansMap = await dbAdapter.getUsersBansIdsMap(userIds);
+    const [bansMap, bannedByMap] = await Promise.all([
+      dbAdapter.getUsersBansIdsMap(userIds),
+      dbAdapter.getUsersBanedByIdsMap(userIds),
+    ]);
 
+    /** @type {UUID[]} */
     let usersDisabledBans = [];
+    /** @type {UUID[]} */
+    let adminsDisabledBans = [];
 
     if (post) {
       const postGroups = await dbAdapter.getPostGroups(post.id);
-      usersDisabledBans = await dbAdapter
-        .getUsersWithDisabledBansInGroups(postGroups.map((g) => g.id))
-        .then((us) => us.map((u) => u.user_id));
+
+      // Users/admins who have disabled bans in some post groups
+      const groupIds = postGroups.map((g) => g.id);
+      const disabledBans = await dbAdapter.getUsersWithDisabledBansInGroups(groupIds);
+      usersDisabledBans = disabledBans.map((u) => u.user_id);
+      adminsDisabledBans = disabledBans.filter((u) => u.is_admin).map((u) => u.user_id);
     }
 
     await Promise.all(
@@ -355,20 +364,28 @@ export default class PubsubListener {
 
         // Bans
         if (post && userId) {
-          const banIds = (!usersDisabledBans.includes(userId) && bansMap.get(userId)) || [];
+          const bannedUserIds = (!usersDisabledBans.includes(userId) && bansMap.get(userId)) || [];
+          const bannedByUserIds =
+            (!adminsDisabledBans.includes(userId) && bannedByMap.get(userId)) || [];
+
+          const isBanned = (id) => bannedUserIds.includes(id) || bannedByUserIds.includes(id);
 
           if (
-            (type === eventNames.COMMENT_UPDATED && banIds.includes(data.comments.createdBy)) ||
-            (type === eventNames.LIKE_ADDED && banIds.includes(data.users.id)) ||
+            (type === eventNames.COMMENT_UPDATED && isBanned(data.comments.createdBy)) ||
+            (type === eventNames.LIKE_ADDED && isBanned(data.users.id)) ||
             ((type === eventNames.COMMENT_LIKE_ADDED || type === eventNames.COMMENT_LIKE_REMOVED) &&
-              (banIds.includes(data.comments.createdBy) || banIds.includes(data.comments.userId)))
+              (isBanned(data.comments.createdBy) || isBanned(data.comments.userId)))
           ) {
             return;
           }
 
           // A very special case: comment author is banned, but the viewer chooses
           // to see such comments as placeholders.
-          if (type === eventNames.COMMENT_CREATED && banIds.includes(data.comments.createdBy)) {
+          // TODO: add the 'bannedByUserIds' check and Comment.HIDDEN_BANNED_BY status
+          if (
+            type === eventNames.COMMENT_CREATED &&
+            bannedUserIds.includes(data.comments.createdBy)
+          ) {
             const user = await dbAdapter.getUserById(userId);
 
             if (user.getHiddenCommentTypes().includes(Comment.HIDDEN_BANNED)) {

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -381,20 +381,20 @@ export default class PubsubListener {
 
           // A very special case: comment author is banned, but the viewer chooses
           // to see such comments as placeholders.
-          // TODO: add the 'bannedByUserIds' check and Comment.HIDDEN_BANNED_BY status
+          // TODO: add the 'bannedByUserIds' check and Comment.HIDDEN_VIEWER_BANNED status
           if (
             type === eventNames.COMMENT_CREATED &&
             bannedUserIds.includes(data.comments.createdBy)
           ) {
             const user = await dbAdapter.getUserById(userId);
 
-            if (user.getHiddenCommentTypes().includes(Comment.HIDDEN_BANNED)) {
+            if (user.getHiddenCommentTypes().includes(Comment.HIDDEN_AUTHOR_BANNED)) {
               return;
             }
 
             const { createdBy } = data.comments;
-            data.comments.hideType = Comment.HIDDEN_BANNED;
-            data.comments.body = Comment.hiddenBody(Comment.HIDDEN_BANNED);
+            data.comments.hideType = Comment.HIDDEN_AUTHOR_BANNED;
+            data.comments.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
             data.comments.createdBy = null;
             data.users = data.users.filter((u) => u.id !== createdBy);
             data.admins = data.admins.filter((u) => u.id !== createdBy);

--- a/app/serializers/v2/comment.js
+++ b/app/serializers/v2/comment.js
@@ -45,8 +45,8 @@ export async function serializeCommentsFull(comments, viewerId) {
     };
 
     if (
-      bansMap[comment.id] === Comment.HIDDEN_AUTHOR_BANNED ||
-      bansMap[comment.id] === Comment.HIDDEN_VIEWER_BANNED
+      bansMap[comment.id] === Comment.HIDDEN_AUTHOR_BANNED // ||
+      // bansMap[comment.id] === Comment.HIDDEN_VIEWER_BANNED
     ) {
       ser.likes = 0;
       ser.hasOwnLike = false;
@@ -62,6 +62,10 @@ export async function serializeCommentsFull(comments, viewerId) {
       ser.likes = parseInt(commentLikesData.c_likes);
       ser.hasOwnLike = commentLikesData.has_own_like;
       userIds.add(comment.userId);
+
+      if (bansMap[comment.id]) {
+        ser._hideType = bansMap[comment.id];
+      }
     }
 
     return ser;

--- a/app/serializers/v2/comment.js
+++ b/app/serializers/v2/comment.js
@@ -44,12 +44,15 @@ export async function serializeCommentsFull(comments, viewerId) {
       createdBy: comment.userId,
     };
 
-    if (bansMap[comment.id]) {
+    if (
+      bansMap[comment.id] === Comment.HIDDEN_AUTHOR_BANNED ||
+      bansMap[comment.id] === Comment.HIDDEN_VIEWER_BANNED
+    ) {
       ser.likes = 0;
       ser.hasOwnLike = false;
 
-      ser.hideType = Comment.HIDDEN_AUTHOR_BANNED;
-      ser.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
+      ser.hideType = bansMap[comment.id];
+      ser.body = Comment.hiddenBody(ser.hideType);
       ser.createdBy = null;
     } else {
       const commentLikesData = likesInfo.find((it) => it.uid === comment.id) ?? {

--- a/app/serializers/v2/comment.js
+++ b/app/serializers/v2/comment.js
@@ -48,8 +48,8 @@ export async function serializeCommentsFull(comments, viewerId) {
       ser.likes = 0;
       ser.hasOwnLike = false;
 
-      ser.hideType = Comment.HIDDEN_BANNED;
-      ser.body = Comment.hiddenBody(Comment.HIDDEN_BANNED);
+      ser.hideType = Comment.HIDDEN_AUTHOR_BANNED;
+      ser.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
       ser.createdBy = null;
     } else {
       const commentLikesData = likesInfo.find((it) => it.uid === comment.id) ?? {

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -14,6 +14,7 @@ export function serializeComment(comment) {
       'createdAt',
       'updatedAt',
       'hideType',
+      '_hideType',
       'likes',
       'hasOwnLike',
       'seqNumber',

--- a/app/support/DbAdapter/bans.js
+++ b/app/support/DbAdapter/bans.js
@@ -13,9 +13,9 @@ const bansTrait = (superClass) =>
     }
 
     /**
-     * Returns Map.<userId, bannedUserIds>
+     * Returns Map<userId, bannedUserIds>
      * @param {string[]} userIds
-     * @return {Map.<string, string[]>}
+     * @return {Promise<Map<string, string[]>>}
      */
     async getUsersBansIdsMap(userIds) {
       const { rows } = await this.database.raw(
@@ -27,6 +27,23 @@ const bansTrait = (superClass) =>
         { userIds },
       );
       return new Map(rows.map((r) => [r.user_id, r.bans]));
+    }
+
+    /**
+     * Returns Map<userId, whoBannedUserIds>
+     * @param {string[]} userIds
+     * @return {Promise<Map<string, string[]>>}
+     */
+    async getUsersBanedByIdsMap(userIds) {
+      const { rows } = await this.database.raw(
+        `
+          select banned_user_id, array_agg(user_id) as bans
+          from bans where banned_user_id = any(:userIds)
+          group by banned_user_id
+          `,
+        { userIds },
+      );
+      return new Map(rows.map((r) => [r.banned_user_id, r.bans]));
     }
 
     async getUserIdsWhoBannedUser(userId) {

--- a/app/support/DbAdapter/comments.js
+++ b/app/support/DbAdapter/comments.js
@@ -183,12 +183,15 @@ const commentsTrait = (superClass) =>
         const hiddenCommentTypes = viewer.getHiddenCommentTypes();
 
         if (hiddenCommentTypes.length > 0) {
-          if (hiddenCommentTypes.includes(Comment.HIDDEN_BANNED) && bannedUsersIds.length > 0) {
+          if (
+            hiddenCommentTypes.includes(Comment.HIDDEN_AUTHOR_BANNED) &&
+            bannedUsersIds.length > 0
+          ) {
             query = query.where('user_id', 'not in', bannedUsersIds);
           }
 
           const ht = hiddenCommentTypes.filter(
-            (t) => t !== Comment.HIDDEN_BANNED && t !== Comment.VISIBLE,
+            (t) => t !== Comment.HIDDEN_AUTHOR_BANNED && t !== Comment.VISIBLE,
           );
 
           if (ht.length > 0) {
@@ -201,8 +204,8 @@ const commentsTrait = (superClass) =>
       const comments = responses.map((comm) => {
         if (bannedUsersIds.includes(comm.user_id)) {
           comm.user_id = null;
-          comm.hide_type = Comment.HIDDEN_BANNED;
-          comm.body = Comment.hiddenBody(Comment.HIDDEN_BANNED);
+          comm.hide_type = Comment.HIDDEN_AUTHOR_BANNED;
+          comm.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
         }
 
         return comm;

--- a/app/support/DbAdapter/comments.js
+++ b/app/support/DbAdapter/comments.js
@@ -171,48 +171,6 @@ const commentsTrait = (superClass) =>
       return parseInt(res[0].count);
     }
 
-    async getAllPostCommentsWithoutBannedUsers(postId, viewerUserId) {
-      let query = this.database('comments').orderBy('created_at', 'asc').where('post_id', postId);
-
-      const [viewer, bannedUsersIds] = await Promise.all([
-        viewerUserId ? this.getUserById(viewerUserId) : null,
-        viewerUserId ? this.getUserBansIds(viewerUserId) : [],
-      ]);
-
-      if (viewerUserId) {
-        const hiddenCommentTypes = viewer.getHiddenCommentTypes();
-
-        if (hiddenCommentTypes.length > 0) {
-          if (
-            hiddenCommentTypes.includes(Comment.HIDDEN_AUTHOR_BANNED) &&
-            bannedUsersIds.length > 0
-          ) {
-            query = query.where('user_id', 'not in', bannedUsersIds);
-          }
-
-          const ht = hiddenCommentTypes.filter(
-            (t) => t !== Comment.HIDDEN_AUTHOR_BANNED && t !== Comment.VISIBLE,
-          );
-
-          if (ht.length > 0) {
-            query = query.where('hide_type', 'not in', ht);
-          }
-        }
-      }
-
-      const responses = await query;
-      const comments = responses.map((comm) => {
-        if (bannedUsersIds.includes(comm.user_id)) {
-          comm.user_id = null;
-          comm.hide_type = Comment.HIDDEN_AUTHOR_BANNED;
-          comm.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
-        }
-
-        return comm;
-      });
-      return comments.map(initCommentObject);
-    }
-
     _deletePostComments(postId) {
       return this.database('comments').where({ post_id: postId }).delete();
     }

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -122,6 +122,8 @@ export class DbAdapter {
   getUsersByNormEmail(email: string): Promise<User[]>;
   existsEmail(email: string): Promise<boolean>;
   existsNormEmail(email: string): Promise<boolean>;
+  getUsersBansIdsMap(ids: UUID[]): Promise<Map<UUID, UUID[]>>;
+  getUsersBanedByIdsMap(ids: UUID[]): Promise<Map<UUID, UUID[]>>;
   getUserIdsWhoBannedUser(id: UUID): Promise<UUID[]>;
   getFeedOwnerById(id: UUID): Promise<User | Group | null>;
   getFeedOwnerByUsername(name: string): Promise<User | Group | null>;
@@ -181,6 +183,9 @@ export class DbAdapter {
   // Bans
   getUserBansIds(id: UUID): Promise<UUID[]>;
   getGroupsWithDisabledBans(userId: UUID, groupIds?: UUID[]): Promise<UUID[]>;
+  getUsersWithDisabledBansInGroups(
+    groupIds: UUID[],
+  ): Promise<{ user_id: UUID; is_admin: boolean }[]>;
   disableBansInGroup(userId: UUID, groupId: UUID, doDisable: boolean): Promise<boolean>;
 
   // Posts

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -343,6 +343,7 @@ const timelinesPostsTrait = (superClass) =>
       ]);
 
       const notBannedSQLFabric = await this.notBannedActionsSQLFabric(viewerId);
+      const bannedSQLsFabric = await this.bannedActionsSQLsFabric(viewerId);
 
       const allLikesSQL = `
       select
@@ -377,25 +378,36 @@ const timelinesPostsTrait = (superClass) =>
 
       const viewerIntId = viewerId ? await this._getUserIntIdByUUID(viewerId) : null;
 
-      const excludeBannedComments = params.hiddenCommentTypes.includes(
+      const excludeBannedByViewer = params.hiddenCommentTypes.includes(
         Comment.HIDDEN_AUTHOR_BANNED,
       );
-      const otherExcludedTypes = params.hiddenCommentTypes.filter(
-        (t) => t !== Comment.HIDDEN_AUTHOR_BANNED && t !== Comment.VISIBLE,
+      const excludeBannedByAuthor = params.hiddenCommentTypes.includes(
+        Comment.HIDDEN_VIEWER_BANNED,
       );
 
-      const bannedCommentsSQL = sqlNot(notBannedSQLFabric('c'));
+      const bannedOrVisibleTypes = [
+        Comment.VISIBLE,
+        Comment.HIDDEN_AUTHOR_BANNED,
+        Comment.HIDDEN_VIEWER_BANNED,
+      ];
+      const otherExcludedTypes = params.hiddenCommentTypes.filter(
+        (t) => !bannedOrVisibleTypes.includes(t),
+      );
+
+      const [bannedByViewerSQL, bannedByAuthorSQL] = bannedSQLsFabric('c');
 
       const commentFilterSQL = andJoin([
         sqlIn('c.post_id', uniqPostsIds),
-        excludeBannedComments ? sqlNot(bannedCommentsSQL) : 'true',
+        excludeBannedByViewer ? sqlNot(bannedByViewerSQL) : 'true',
+        excludeBannedByAuthor ? sqlNot(bannedByAuthorSQL) : 'true',
         sqlNotIn('c.hide_type', otherExcludedTypes),
       ]);
 
       const allCommentsSQL = pgFormat(
         `select
         ${commentFields.map((f) => `c.${f}`).join(', ')},
-        ${bannedCommentsSQL} as hide_as_banned,
+        ${excludeBannedByViewer ? 'false' : bannedByViewerSQL} as banned_by_viewer,
+        ${excludeBannedByAuthor ? 'false' : bannedByAuthorSQL} as banned_by_author,
         rank() over (partition by c.post_id order by c.created_at, c.id),
         count(*) over (partition by c.post_id),
         (select coalesce(count(*), 0) from 
@@ -419,7 +431,9 @@ const timelinesPostsTrait = (superClass) =>
         : ``;
       const commentsSQL = `
       with comments as (${allCommentsSQL})
-      select ${commentFields.join(', ')}, count, c_likes, has_own_like, hide_as_banned from comments
+      select ${commentFields.join(', ')}, count, c_likes, has_own_like,
+        banned_by_viewer, banned_by_author
+      from comments
       ${foldCommentsSql}
       order by created_at, id
     `;
@@ -468,10 +482,16 @@ const timelinesPostsTrait = (superClass) =>
       }
 
       for (const comm of commentsData) {
-        if (comm.hide_as_banned) {
+        if (comm.banned_by_viewer) {
           comm.user_id = null;
           comm.hide_type = Comment.HIDDEN_AUTHOR_BANNED;
           comm.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
+          comm.c_likes = '0';
+          comm.has_own_like = null;
+        } else if (comm.banned_by_author) {
+          comm.user_id = null;
+          comm.hide_type = Comment.HIDDEN_VIEWER_BANNED;
+          comm.body = Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED);
           comm.c_likes = '0';
           comm.has_own_like = null;
         }

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -377,9 +377,11 @@ const timelinesPostsTrait = (superClass) =>
 
       const viewerIntId = viewerId ? await this._getUserIntIdByUUID(viewerId) : null;
 
-      const excludeBannedComments = params.hiddenCommentTypes.includes(Comment.HIDDEN_BANNED);
+      const excludeBannedComments = params.hiddenCommentTypes.includes(
+        Comment.HIDDEN_AUTHOR_BANNED,
+      );
       const otherExcludedTypes = params.hiddenCommentTypes.filter(
-        (t) => t !== Comment.HIDDEN_BANNED && t !== Comment.VISIBLE,
+        (t) => t !== Comment.HIDDEN_AUTHOR_BANNED && t !== Comment.VISIBLE,
       );
 
       const bannedCommentsSQL = sqlNot(notBannedSQLFabric('c'));
@@ -468,8 +470,8 @@ const timelinesPostsTrait = (superClass) =>
       for (const comm of commentsData) {
         if (comm.hide_as_banned) {
           comm.user_id = null;
-          comm.hide_type = Comment.HIDDEN_BANNED;
-          comm.body = Comment.hiddenBody(Comment.HIDDEN_BANNED);
+          comm.hide_type = Comment.HIDDEN_AUTHOR_BANNED;
+          comm.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
           comm.c_likes = '0';
           comm.has_own_like = null;
         }

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -488,15 +488,20 @@ const timelinesPostsTrait = (superClass) =>
           comm.body = Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED);
           comm.c_likes = '0';
           comm.has_own_like = null;
-        } else if (comm.banned_by_author) {
-          comm.user_id = null;
-          comm.hide_type = Comment.HIDDEN_VIEWER_BANNED;
-          comm.body = Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED);
-          comm.c_likes = '0';
-          comm.has_own_like = null;
+          // } else if (comm.banned_by_author) {
+          //   comm.user_id = null;
+          //   comm.hide_type = Comment.HIDDEN_VIEWER_BANNED;
+          //   comm.body = Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED);
+          //   comm.c_likes = '0';
+          //   comm.has_own_like = null;
         }
 
         const comment = initCommentObject(comm);
+
+        if (comm.banned_by_author) {
+          comment._hideType = Comment.HIDDEN_VIEWER_BANNED;
+        }
+
         comment.likes = parseInt(comm.c_likes);
         comment.hasOwnLike = Boolean(comm.has_own_like);
         results[comm.post_id].comments.push(comment);

--- a/config/test.js
+++ b/config/test.js
@@ -52,7 +52,10 @@ module.exports = {
     defaults: {
       // User does't want to view banned comments by default (for compatibility
       // with old tests)
-      hideCommentsOfTypes: [2 /* Comment.HIDDEN_BANNED */],
+      hideCommentsOfTypes: [
+        2, // Comment.HIDDEN_AUTHOR_BANNED
+        4, // Comment.HIDDEN_VIEWER_BANNED
+      ],
     },
   },
 

--- a/doc/visibility-rules.md
+++ b/doc/visibility-rules.md
@@ -38,13 +38,14 @@ Comments, Likes and Comment likes (hereinafter "actions") shares the same logic.
 
 Actions on the given post is not visible for viewer if the post is not visible.
 
-Action is visible when:
+Action is visible when (AND-joined):
 * The action author is not banned by viewer OR post is published to a group
-where the viewer had disabled bans. Thus, all actions in groups with disabled
-bans are visible.
+  where the viewer had disabled bans.
+* Viewer is not banned by the action author OR post is published to a group where
+  the viewer *is admin* and had disabled bans.
 
 If the post is visible but the comment is not, the comment may appear as a stub
-(with hideType = HIDDEN_BANNED). It depends on *hideCommentsOfTypes* field of
+(with hideType = HIDDEN_AUTHOR_BANNED). It depends on *hideCommentsOfTypes* field of
 viewer properties.
 
 Handling the visibility of comments is a bit special (see the
@@ -57,13 +58,14 @@ to comment, the middleware acts as follows:
 
 ### In code
 The action visibility rules calculates in the following places:
-* app/support/DbAdapter/visibility.js, notBannedSQLFabric function. This makes
-  SQL filter fabric to select non-banned actions.
+* app/support/DbAdapter/visibility.js, bannedActionsSQLsFabric and
+  notBannedActionsSQLFabric functions. This functions makes SQL filter fabrics
+  to select (non-)banned actions.
 * app/support/DbAdapter/visibility.js, getUsersWhoCanSeeComment function. This
   function returns list of users (IDs) who can see the given comment.
-* app/support/DbAdapter/visibility.js, isCommentBannedForViewer function. This
-  function returns true if comment is banned (and should be hidden) for the
-  given viewer.
+* app/support/DbAdapter/visibility.js, isCommentBannedForViewer and
+  areCommentsBannedForViewerAssoc functions. This functions checks if comment(s)
+  is/are banned (and should be hidden) for the given viewer.
 * app/pubsub-listener.js, broadcastMessage function checks access for actions.
 * app/controllers/middlewares/comment-access-required.js, the
   'commentAccessRequired' middleware.

--- a/test/functional/comment_likes.js
+++ b/test/functional/comment_likes.js
@@ -723,14 +723,14 @@ describe('Comment likes', () => {
           res = await getCommentLikes(jupiterComment2.id, pluto);
           const responseJson = await res.json();
 
+          // Pluto, being banned by Luna, shouldn't be able to see Luna's like
           expect(responseJson, 'to satisfy', {
-            likes: expect.it('to be an array').and('to be non-empty').and('to have length', 3),
+            likes: expect.it('to be an array').and('to be non-empty').and('to have length', 2),
             users: expect.it('to be an array').and('to have items satisfying', schema.user),
           });
 
           expect(responseJson.likes[0].userId, 'to be', pluto.user.id);
-          expect(responseJson.likes[1].userId, 'to be', luna.user.id);
-          expect(responseJson.likes[2].userId, 'to be', mars.user.id);
+          expect(responseJson.likes[1].userId, 'to be', mars.user.id);
         });
       });
     });

--- a/test/functional/comments.js
+++ b/test/functional/comments.js
@@ -442,8 +442,8 @@ describe('CommentsController', () => {
             __httpCode: 200,
             comments: {
               id: commentIds[1],
-              body: Comment.hiddenBody(Comment.HIDDEN_BANNED),
-              hideType: Comment.HIDDEN_BANNED,
+              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+              hideType: Comment.HIDDEN_AUTHOR_BANNED,
               createdBy: null,
             },
           });
@@ -558,8 +558,8 @@ describe('CommentsController', () => {
             __httpCode: 200,
             comments: {
               id: commentIds[1],
-              body: Comment.hiddenBody(Comment.HIDDEN_BANNED),
-              hideType: Comment.HIDDEN_BANNED,
+              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+              hideType: Comment.HIDDEN_AUTHOR_BANNED,
               createdBy: null,
             },
           });

--- a/test/functional/events.js
+++ b/test/functional/events.js
@@ -1567,18 +1567,10 @@ describe('EventService', () => {
         await expectMentionEvents(lunaUserModel, []);
       });
 
-      it('should create mention_in_comment event for mentioned user banned by comment author', async () => {
+      it('should not create mention_in_comment event for mentioned user banned by comment author', async () => {
         await banUser(jupiter, mars);
         await createCommentAsync(jupiter, post.id, 'Mentioning @mars');
-        await expectMentionEvents(marsUserModel, [
-          {
-            user_id: marsUserModel.intId,
-            event_type: 'mention_in_comment',
-            created_by_user_id: jupiterUserModel.intId,
-            target_user_id: marsUserModel.intId,
-            post_author_id: lunaUserModel.intId,
-          },
-        ]);
+        await expectMentionEvents(marsUserModel, []);
         await expectMentionEvents(lunaUserModel, []);
         await expectMentionEvents(jupiterUserModel, []);
       });

--- a/test/functional/groups-without-bans.js
+++ b/test/functional/groups-without-bans.js
@@ -415,22 +415,15 @@ describe('Groups without bans', () => {
           ]);
         });
 
-        it(`should also see Venus comment in post to Celestials because of bans asymmetry`, async () => {
+        it(`should not see Venus comment in post to Celestials because of bans symmetry`, async () => {
           const resp = await shouldSeePost(postFromMarsToCelestials, luna);
-          expect(resp.comments, 'to satisfy', [
-            { createdBy: venus.user.id },
-            { createdBy: mars.user.id },
-          ]);
+          expect(resp.comments, 'to satisfy', [{ createdBy: mars.user.id }]);
         });
 
-        it(`should find all posts with 'in-comment:venus' because of bans asymmetry`, () =>
+        it(`should not find solo Celestials posts with 'in-comment:venus' because of bans symmetry`, () =>
           shouldFindPosts(
             'in-comment:venus',
-            [
-              postFromMarsToSelenites,
-              postFromMarsToSelenitesAndCelestials,
-              postFromMarsToCelestials,
-            ],
+            [postFromMarsToSelenites, postFromMarsToSelenitesAndCelestials],
             luna,
           ));
       });

--- a/test/functional/hidden-comments.js
+++ b/test/functional/hidden-comments.js
@@ -54,7 +54,7 @@ describe('Hidden comments', () => {
         expect(reply.comments, 'to have length', 2);
         const venusComment = reply.comments.find((c) => c.id === reply.posts.comments[0]);
         const lunaComment = reply.comments.find((c) => c.id === reply.posts.comments[1]);
-        expect(venusComment, 'to satisfy', { hideType: Comment.HIDDEN_BANNED });
+        expect(venusComment, 'to satisfy', { hideType: Comment.HIDDEN_AUTHOR_BANNED });
         expect(lunaComment, 'to satisfy', { hideType: Comment.VISIBLE });
       });
 
@@ -64,7 +64,7 @@ describe('Hidden comments', () => {
         expect(reply.comments, 'to have length', 2);
         const venusComment = reply.comments.find((c) => c.id === postInReply.comments[0]);
         const lunaComment = reply.comments.find((c) => c.id === postInReply.comments[1]);
-        expect(venusComment, 'to satisfy', { hideType: Comment.HIDDEN_BANNED });
+        expect(venusComment, 'to satisfy', { hideType: Comment.HIDDEN_AUTHOR_BANNED });
         expect(lunaComment, 'to satisfy', { hideType: Comment.VISIBLE });
       });
 
@@ -85,8 +85,8 @@ describe('Hidden comments', () => {
           await expect(test, 'when fulfilled', 'to satisfy', {
             comments: {
               createdBy: null,
-              hideType: Comment.HIDDEN_BANNED,
-              body: Comment.hiddenBody(Comment.HIDDEN_BANNED),
+              hideType: Comment.HIDDEN_AUTHOR_BANNED,
+              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
             },
           });
         });
@@ -96,7 +96,7 @@ describe('Hidden comments', () => {
     describe("Luna doesn't want to see comments from banned users", () => {
       beforeEach(async () => {
         await updateUserAsync(luna, {
-          preferences: { hideCommentsOfTypes: [Comment.HIDDEN_BANNED] },
+          preferences: { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] },
         });
       });
 
@@ -123,7 +123,7 @@ describe('Hidden comments', () => {
         const reply1 = await fetchPost(post.id, mars);
         expect(reply1.comments, 'to have length', 2);
         const venusComment = reply1.comments.find((c) => c.id === reply1.posts.comments[0]);
-        expect(venusComment, 'to satisfy', { hideType: Comment.HIDDEN_BANNED });
+        expect(venusComment, 'to satisfy', { hideType: Comment.HIDDEN_AUTHOR_BANNED });
 
         const delReply = await removeCommentAsync(mars, venusComment.id);
         delReply.status.should.eql(200);

--- a/test/functional/realtime.js
+++ b/test/functional/realtime.js
@@ -425,7 +425,7 @@ describe('Realtime (Socket.io)', () => {
               );
             });
 
-            it("Jupiter gets notifications about comment likes to Mars' comment", async () => {
+            it("Jupiter doesn't get notifications about comment likes to Mars' comment", async () => {
               const {
                 context: { commentLikeRealtimeMsg: msg },
               } = await expect(
@@ -434,14 +434,10 @@ describe('Realtime (Socket.io)', () => {
                 lunaPost.id,
                 'with comment having id',
                 marsComment.id,
-                'to get comment_like:new event from',
+                'not to get comment_like:new event from',
                 lunaContext,
               );
-              expect(
-                msg,
-                'to satisfy',
-                commentHavingNLikesExpectation(0, false, lunaContext.user.id),
-              );
+              expect(msg, 'to be', null);
             });
           });
         });
@@ -694,7 +690,7 @@ describe('Realtime (Socket.io)', () => {
               );
             });
 
-            it("Jupiter gets notifications about comment likes to Mars' comment", async () => {
+            it("Jupiter doesn't get notifications about comment likes to Mars' comment", async () => {
               const {
                 context: { commentLikeRealtimeMsg: msg },
               } = await expect(
@@ -703,14 +699,10 @@ describe('Realtime (Socket.io)', () => {
                 lunaTimeline,
                 'with comment having id',
                 marsComment.id,
-                'to get comment_like:new event from',
+                'not to get comment_like:new event from',
                 lunaContext,
               );
-              expect(
-                msg,
-                'to satisfy',
-                commentHavingNLikesExpectation(0, false, lunaContext.user.id),
-              );
+              expect(msg, 'to be', null);
             });
           });
         });
@@ -1136,7 +1128,7 @@ describe('Realtime (Socket.io)', () => {
               );
             });
 
-            it("Jupiter gets notifications about comment likes to Mars' comment", async () => {
+            it("Jupiter doesn't notifications about comment likes to Mars' comment", async () => {
               const {
                 context: { commentLikeRealtimeMsg: msg },
               } = await expect(
@@ -1145,14 +1137,10 @@ describe('Realtime (Socket.io)', () => {
                 lunaCommentsFeed,
                 'with comment having id',
                 marsComment.id,
-                'to get comment_like:new event from',
+                'not to get comment_like:new event from',
                 lunaContext,
               );
-              expect(
-                msg,
-                'to satisfy',
-                commentHavingNLikesExpectation(0, false, lunaContext.user.id),
-              );
+              expect(msg, 'to be', null);
             });
           });
         });

--- a/test/functional/realtime.js
+++ b/test/functional/realtime.js
@@ -440,7 +440,7 @@ describe('Realtime (Socket.io)', () => {
               expect(
                 msg,
                 'to satisfy',
-                commentHavingNLikesExpectation(1, false, lunaContext.user.id),
+                commentHavingNLikesExpectation(0, false, lunaContext.user.id),
               );
             });
           });
@@ -709,7 +709,7 @@ describe('Realtime (Socket.io)', () => {
               expect(
                 msg,
                 'to satisfy',
-                commentHavingNLikesExpectation(1, false, lunaContext.user.id),
+                commentHavingNLikesExpectation(0, false, lunaContext.user.id),
               );
             });
           });
@@ -1151,7 +1151,7 @@ describe('Realtime (Socket.io)', () => {
               expect(
                 msg,
                 'to satisfy',
-                commentHavingNLikesExpectation(1, false, lunaContext.user.id),
+                commentHavingNLikesExpectation(0, false, lunaContext.user.id),
               );
             });
           });

--- a/test/functional/symmetric-bans.js
+++ b/test/functional/symmetric-bans.js
@@ -1,0 +1,158 @@
+/* eslint-env node, mocha */
+
+import expect from 'unexpected';
+
+import { dbAdapter, Comment } from '../../app/models';
+import cleanDB from '../dbCleaner';
+
+import {
+  banUser,
+  createCommentAsync,
+  createAndReturnPost,
+  createTestUsers,
+  performJSONRequest,
+  authHeaders,
+  updateUserAsync,
+} from './functional_test_helper';
+
+describe('Symmetric bans', () => {
+  beforeEach(() => cleanDB(dbAdapter.database));
+  describe('Comments visibility', () => {
+    describe('Luna bans Mars, both commented the Venus post', () => {
+      let luna;
+      let mars;
+      let venus;
+      let post;
+      beforeEach(async () => {
+        [luna, mars, venus] = await createTestUsers(['luna', 'mars', 'venus']);
+        post = await createAndReturnPost(venus, 'Post body');
+        await banUser(luna, mars);
+        await createCommentAsync(luna, post.id, 'Comment from Luna');
+        await createCommentAsync(mars, post.id, 'Comment from Mars');
+      });
+
+      it('should show all comments to Venus', async () => {
+        const resp = await fetchPost(post.id, venus);
+        expect(resp.comments, 'to satisfy', [
+          { body: 'Comment from Luna', createdBy: luna.user.id },
+          { body: 'Comment from Mars', createdBy: mars.user.id },
+        ]);
+      });
+
+      it(`should not show Mars' comments to Luna`, async () => {
+        const resp = await fetchPost(post.id, luna);
+        expect(resp.comments, 'to satisfy', [
+          { body: 'Comment from Luna', createdBy: luna.user.id },
+        ]);
+      });
+
+      it(`should not show Luna's comments to Mars`, async () => {
+        const resp = await fetchPost(post.id, mars);
+        expect(resp.comments, 'to satisfy', [
+          { body: 'Comment from Mars', createdBy: mars.user.id },
+        ]);
+      });
+
+      describe('Luna and Mars wants to see all hidden comments', () => {
+        beforeEach(() =>
+          Promise.all([
+            updateUserAsync(luna, { preferences: { hideCommentsOfTypes: [] } }),
+            updateUserAsync(mars, { preferences: { hideCommentsOfTypes: [] } }),
+          ]),
+        );
+
+        it(`should show Mars' comments to Luna as placeholder`, async () => {
+          const resp = await fetchPost(post.id, luna);
+          expect(resp.comments, 'to satisfy', [
+            { body: 'Comment from Luna', createdBy: luna.user.id },
+            {
+              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+              createdBy: null,
+              hideType: Comment.HIDDEN_AUTHOR_BANNED,
+            },
+          ]);
+        });
+
+        it(`should show Luna's comments to Mars as placeholder`, async () => {
+          const resp = await fetchPost(post.id, mars);
+          expect(resp.comments, 'to satisfy', [
+            {
+              body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
+              createdBy: null,
+              hideType: Comment.HIDDEN_VIEWER_BANNED,
+            },
+            { body: 'Comment from Mars', createdBy: mars.user.id },
+          ]);
+        });
+      });
+
+      describe('Luna and Mars wants to see all comments except of HIDDEN_AUTHOR_BANNED', () => {
+        beforeEach(() =>
+          Promise.all([
+            updateUserAsync(luna, {
+              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] },
+            }),
+            updateUserAsync(mars, {
+              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] },
+            }),
+          ]),
+        );
+
+        it(`should not show Mars' comments to Luna`, async () => {
+          const resp = await fetchPost(post.id, luna);
+          expect(resp.comments, 'to satisfy', [
+            { body: 'Comment from Luna', createdBy: luna.user.id },
+          ]);
+        });
+
+        it(`should show Luna's comments to Mars as placeholder`, async () => {
+          const resp = await fetchPost(post.id, mars);
+          expect(resp.comments, 'to satisfy', [
+            {
+              body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
+              createdBy: null,
+              hideType: Comment.HIDDEN_VIEWER_BANNED,
+            },
+            { body: 'Comment from Mars', createdBy: mars.user.id },
+          ]);
+        });
+      });
+
+      describe('Luna and Mars wants to see all comments except of HIDDEN_VIEWER_BANNED', () => {
+        beforeEach(() =>
+          Promise.all([
+            updateUserAsync(luna, {
+              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_VIEWER_BANNED] },
+            }),
+            updateUserAsync(mars, {
+              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_VIEWER_BANNED] },
+            }),
+          ]),
+        );
+
+        it(`should show Mars' comments to Luna as placeholder`, async () => {
+          const resp = await fetchPost(post.id, luna);
+          expect(resp.comments, 'to satisfy', [
+            { body: 'Comment from Luna', createdBy: luna.user.id },
+            {
+              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+              createdBy: null,
+              hideType: Comment.HIDDEN_AUTHOR_BANNED,
+            },
+          ]);
+        });
+
+        it(`should not show Luna's comments to Mars`, async () => {
+          const resp = await fetchPost(post.id, mars);
+          expect(resp.comments, 'to satisfy', [
+            { body: 'Comment from Mars', createdBy: mars.user.id },
+          ]);
+        });
+      });
+    });
+  });
+});
+
+function fetchPost(postId, userCtx) {
+  return performJSONRequest('GET', `/v2/posts/${postId}`, null, authHeaders(userCtx));
+}

--- a/test/functional/symmetric-bans.js
+++ b/test/functional/symmetric-bans.js
@@ -1,144 +1,57 @@
 /* eslint-env node, mocha */
+/* global $database */
 
 import expect from 'unexpected';
 
-import { dbAdapter, Comment } from '../../app/models';
+import { dbAdapter, Comment, PubSub } from '../../app/models';
 import cleanDB from '../dbCleaner';
+import { getSingleton } from '../../app/app';
+import { PubSubAdapter, eventNames } from '../../app/support/PubSubAdapter';
 
 import {
   banUser,
-  createCommentAsync,
   createAndReturnPost,
   createTestUsers,
   performJSONRequest,
   authHeaders,
   updateUserAsync,
+  like,
+  likeComment,
 } from './functional_test_helper';
+import Session from './realtime-session';
 
 describe('Symmetric bans', () => {
   beforeEach(() => cleanDB(dbAdapter.database));
-  describe('Comments visibility', () => {
-    describe('Luna bans Mars, both commented the Venus post', () => {
-      let luna;
-      let mars;
-      let venus;
-      let post;
-      beforeEach(async () => {
-        [luna, mars, venus] = await createTestUsers(['luna', 'mars', 'venus']);
-        post = await createAndReturnPost(venus, 'Post body');
-        await banUser(luna, mars);
-        await createCommentAsync(luna, post.id, 'Comment from Luna');
-        await createCommentAsync(mars, post.id, 'Comment from Mars');
-      });
+  describe('Luna bans Mars, Venus wrote post', () => {
+    let luna;
+    let mars;
+    let venus;
+    let post;
+    beforeEach(async () => {
+      [luna, mars, venus] = await createTestUsers(['luna', 'mars', 'venus']);
+      post = await createAndReturnPost(venus, 'Post body');
+      await banUser(luna, mars);
+    });
 
-      it('should show all comments to Venus', async () => {
-        const resp = await fetchPost(post.id, venus);
-        expect(resp.comments, 'to satisfy', [
-          { body: 'Comment from Luna', createdBy: luna.user.id },
-          { body: 'Comment from Mars', createdBy: mars.user.id },
-        ]);
-      });
-
-      it(`should not show Mars' comments to Luna`, async () => {
-        const resp = await fetchPost(post.id, luna);
-        expect(resp.comments, 'to satisfy', [
-          { body: 'Comment from Luna', createdBy: luna.user.id },
-        ]);
-      });
-
-      it(`should not show Luna's comments to Mars`, async () => {
-        const resp = await fetchPost(post.id, mars);
-        expect(resp.comments, 'to satisfy', [
-          { body: 'Comment from Mars', createdBy: mars.user.id },
-        ]);
-      });
-
-      describe('Luna and Mars wants to see all hidden comments', () => {
-        beforeEach(() =>
-          Promise.all([
-            updateUserAsync(luna, { preferences: { hideCommentsOfTypes: [] } }),
-            updateUserAsync(mars, { preferences: { hideCommentsOfTypes: [] } }),
-          ]),
-        );
-
-        it(`should show Mars' comments to Luna as placeholder`, async () => {
-          const resp = await fetchPost(post.id, luna);
-          expect(resp.comments, 'to satisfy', [
-            { body: 'Comment from Luna', createdBy: luna.user.id },
-            {
-              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
-              createdBy: null,
-              hideType: Comment.HIDDEN_AUTHOR_BANNED,
-            },
-          ]);
+    describe('Comments visibility', () => {
+      describe('Luna and Mars both commented the Venus post', () => {
+        beforeEach(async () => {
+          await createComment(luna, post.id, 'Comment from Luna');
+          await createComment(mars, post.id, 'Comment from Mars');
         });
 
-        it(`should show Luna's comments to Mars as placeholder`, async () => {
-          const resp = await fetchPost(post.id, mars);
+        it('should show all comments to Venus', async () => {
+          const resp = await fetchPost(post.id, venus);
           expect(resp.comments, 'to satisfy', [
-            {
-              body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
-              createdBy: null,
-              hideType: Comment.HIDDEN_VIEWER_BANNED,
-            },
+            { body: 'Comment from Luna', createdBy: luna.user.id },
             { body: 'Comment from Mars', createdBy: mars.user.id },
           ]);
         });
-      });
-
-      describe('Luna and Mars wants to see all comments except of HIDDEN_AUTHOR_BANNED', () => {
-        beforeEach(() =>
-          Promise.all([
-            updateUserAsync(luna, {
-              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] },
-            }),
-            updateUserAsync(mars, {
-              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] },
-            }),
-          ]),
-        );
 
         it(`should not show Mars' comments to Luna`, async () => {
           const resp = await fetchPost(post.id, luna);
           expect(resp.comments, 'to satisfy', [
             { body: 'Comment from Luna', createdBy: luna.user.id },
-          ]);
-        });
-
-        it(`should show Luna's comments to Mars as placeholder`, async () => {
-          const resp = await fetchPost(post.id, mars);
-          expect(resp.comments, 'to satisfy', [
-            {
-              body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
-              createdBy: null,
-              hideType: Comment.HIDDEN_VIEWER_BANNED,
-            },
-            { body: 'Comment from Mars', createdBy: mars.user.id },
-          ]);
-        });
-      });
-
-      describe('Luna and Mars wants to see all comments except of HIDDEN_VIEWER_BANNED', () => {
-        beforeEach(() =>
-          Promise.all([
-            updateUserAsync(luna, {
-              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_VIEWER_BANNED] },
-            }),
-            updateUserAsync(mars, {
-              preferences: { hideCommentsOfTypes: [Comment.HIDDEN_VIEWER_BANNED] },
-            }),
-          ]),
-        );
-
-        it(`should show Mars' comments to Luna as placeholder`, async () => {
-          const resp = await fetchPost(post.id, luna);
-          expect(resp.comments, 'to satisfy', [
-            { body: 'Comment from Luna', createdBy: luna.user.id },
-            {
-              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
-              createdBy: null,
-              hideType: Comment.HIDDEN_AUTHOR_BANNED,
-            },
           ]);
         });
 
@@ -148,6 +61,227 @@ describe('Symmetric bans', () => {
             { body: 'Comment from Mars', createdBy: mars.user.id },
           ]);
         });
+
+        describe('Luna and Mars wants to see all hidden comments', () => {
+          beforeEach(() =>
+            Promise.all([
+              updateUserAsync(luna, { preferences: { hideCommentsOfTypes: [] } }),
+              updateUserAsync(mars, { preferences: { hideCommentsOfTypes: [] } }),
+            ]),
+          );
+
+          it(`should show Mars' comments to Luna as placeholder`, async () => {
+            const resp = await fetchPost(post.id, luna);
+            expect(resp.comments, 'to satisfy', [
+              { body: 'Comment from Luna', createdBy: luna.user.id },
+              {
+                body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+                createdBy: null,
+                hideType: Comment.HIDDEN_AUTHOR_BANNED,
+              },
+            ]);
+          });
+
+          it(`should show Luna's comments to Mars as placeholder`, async () => {
+            const resp = await fetchPost(post.id, mars);
+            expect(resp.comments, 'to satisfy', [
+              {
+                body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
+                createdBy: null,
+                hideType: Comment.HIDDEN_VIEWER_BANNED,
+              },
+              { body: 'Comment from Mars', createdBy: mars.user.id },
+            ]);
+          });
+        });
+
+        describe('Luna and Mars wants to see all comments except of HIDDEN_AUTHOR_BANNED', () => {
+          beforeEach(() =>
+            Promise.all([
+              updateUserAsync(luna, {
+                preferences: { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] },
+              }),
+              updateUserAsync(mars, {
+                preferences: { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] },
+              }),
+            ]),
+          );
+
+          it(`should not show Mars' comments to Luna`, async () => {
+            const resp = await fetchPost(post.id, luna);
+            expect(resp.comments, 'to satisfy', [
+              { body: 'Comment from Luna', createdBy: luna.user.id },
+            ]);
+          });
+
+          it(`should show Luna's comments to Mars as placeholder`, async () => {
+            const resp = await fetchPost(post.id, mars);
+            expect(resp.comments, 'to satisfy', [
+              {
+                body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
+                createdBy: null,
+                hideType: Comment.HIDDEN_VIEWER_BANNED,
+              },
+              { body: 'Comment from Mars', createdBy: mars.user.id },
+            ]);
+          });
+        });
+
+        describe('Luna and Mars wants to see all comments except of HIDDEN_VIEWER_BANNED', () => {
+          beforeEach(() =>
+            Promise.all([
+              updateUserAsync(luna, {
+                preferences: { hideCommentsOfTypes: [Comment.HIDDEN_VIEWER_BANNED] },
+              }),
+              updateUserAsync(mars, {
+                preferences: { hideCommentsOfTypes: [Comment.HIDDEN_VIEWER_BANNED] },
+              }),
+            ]),
+          );
+
+          it(`should show Mars' comments to Luna as placeholder`, async () => {
+            const resp = await fetchPost(post.id, luna);
+            expect(resp.comments, 'to satisfy', [
+              { body: 'Comment from Luna', createdBy: luna.user.id },
+              {
+                body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+                createdBy: null,
+                hideType: Comment.HIDDEN_AUTHOR_BANNED,
+              },
+            ]);
+          });
+
+          it(`should not show Luna's comments to Mars`, async () => {
+            const resp = await fetchPost(post.id, mars);
+            expect(resp.comments, 'to satisfy', [
+              { body: 'Comment from Mars', createdBy: mars.user.id },
+            ]);
+          });
+        });
+      });
+    });
+
+    describe('Likes visibility', () => {
+      describe('Luna and Mars both liked the Venus post', () => {
+        beforeEach(async () => {
+          await like(post.id, luna.authToken);
+          await like(post.id, mars.authToken);
+        });
+
+        it('should show both likes to Venus', async () => {
+          const resp = await fetchPost(post.id, venus);
+          expect(resp.posts.likes, 'to equal', [mars.user.id, luna.user.id]);
+        });
+
+        it(`should show only Luna's like to Luna`, async () => {
+          const resp = await fetchPost(post.id, luna);
+          expect(resp.posts.likes, 'to equal', [luna.user.id]);
+        });
+
+        it(`should show only Mars' like to Mars`, async () => {
+          const resp = await fetchPost(post.id, mars);
+          expect(resp.posts.likes, 'to equal', [mars.user.id]);
+        });
+      });
+    });
+
+    describe('Comment likes visibility', () => {
+      describe('Luna and Mars both liked the Venus comment', () => {
+        let comment;
+        beforeEach(async () => {
+          ({ comments: comment } = await createComment(venus, post.id, 'Venus comment'));
+          await likeComment(comment.id, luna);
+          await likeComment(comment.id, mars);
+        });
+
+        it('should show both comment likes to Venus', async () => {
+          const resp = await fetchPost(post.id, venus);
+          expect(resp.comments, 'to satisfy', [{ likes: 2, hasOwnLike: false }]);
+
+          const { likes } = await getCommentLikes(comment.id, venus);
+          expect(likes, 'to satisfy', [{ userId: mars.user.id }, { userId: luna.user.id }]);
+        });
+
+        it(`should show only Luna's comment like to Luna`, async () => {
+          const resp = await fetchPost(post.id, luna);
+          expect(resp.comments, 'to satisfy', [{ likes: 1, hasOwnLike: true }]);
+
+          const { likes } = await getCommentLikes(comment.id, luna);
+          expect(likes, 'to satisfy', [{ userId: luna.user.id }]);
+        });
+
+        it(`should show only Mars' comment like to Mars`, async () => {
+          const resp = await fetchPost(post.id, mars);
+          expect(resp.comments, 'to satisfy', [{ likes: 1, hasOwnLike: true }]);
+
+          const { likes } = await getCommentLikes(comment.id, mars);
+          expect(likes, 'to satisfy', [{ userId: mars.user.id }]);
+        });
+      });
+    });
+
+    describe('Realtime', () => {
+      let port;
+      before(async () => {
+        const app = await getSingleton();
+        port = process.env.PEPYATKA_SERVER_PORT || app.context.config.port;
+        const pubsubAdapter = new PubSubAdapter($database);
+        PubSub.setPublisher(pubsubAdapter);
+      });
+
+      let lunaSession, marsSession;
+      beforeEach(async () => {
+        [lunaSession, marsSession] = await Promise.all([
+          Session.create(port, 'Luna session'),
+          Session.create(port, 'Mars session'),
+        ]);
+
+        await Promise.all([
+          lunaSession.sendAsync('auth', { authToken: luna.authToken }),
+          marsSession.sendAsync('auth', { authToken: mars.authToken }),
+        ]);
+
+        await Promise.all([
+          lunaSession.sendAsync('subscribe', { post: [post.id] }),
+          marsSession.sendAsync('subscribe', { post: [post.id] }),
+        ]);
+      });
+
+      afterEach(() => [lunaSession, marsSession].forEach((s) => s.disconnect()));
+
+      describe('Comment creation (Luna and Mars wants to see all hidden comments)', () => {
+        beforeEach(() =>
+          Promise.all([
+            updateUserAsync(luna, { preferences: { hideCommentsOfTypes: [] } }),
+            updateUserAsync(mars, { preferences: { hideCommentsOfTypes: [] } }),
+          ]),
+        );
+
+        it(`should deliver "${eventNames.COMMENT_CREATED}" to Luna when Mars creates comment`, async () => {
+          const test = lunaSession.receiveWhile(eventNames.COMMENT_CREATED, () =>
+            createComment(mars, post.id, 'Comment from Mars'),
+          );
+          await expect(test, 'when fulfilled', 'to satisfy', {
+            comments: {
+              hideType: Comment.HIDDEN_AUTHOR_BANNED,
+              body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+              createdBy: null,
+            },
+          });
+        });
+
+        it(`should deliver "${eventNames.COMMENT_CREATED}" to Mars when Luna creates comment`, async () => {
+          const test = marsSession.receiveWhile(eventNames.COMMENT_CREATED, () =>
+            createComment(luna, post.id, 'Comment from Luna'),
+          );
+          await expect(test, 'when fulfilled', 'to satisfy', {
+            comments: {
+              hideType: Comment.HIDDEN_VIEWER_BANNED,
+              body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
+              createdBy: null,
+            },
+          });
+        });
       });
     });
   });
@@ -155,4 +289,17 @@ describe('Symmetric bans', () => {
 
 function fetchPost(postId, userCtx) {
   return performJSONRequest('GET', `/v2/posts/${postId}`, null, authHeaders(userCtx));
+}
+
+function createComment(userCtx, postId, body) {
+  return performJSONRequest(
+    'POST',
+    `/v2/comments`,
+    { comment: { body, postId } },
+    authHeaders(userCtx),
+  );
+}
+
+function getCommentLikes(commentId, userCtx) {
+  return performJSONRequest('GET', `/v2/comments/${commentId}/likes`, null, authHeaders(userCtx));
 }

--- a/test/functional/symmetric-bans.js
+++ b/test/functional/symmetric-bans.js
@@ -82,13 +82,14 @@ describe('Symmetric bans', () => {
             ]);
           });
 
-          it(`should show Luna's comments to Mars as placeholder`, async () => {
+          it(`should show Luna's comments to Mars with _hideType`, async () => {
             const resp = await fetchPost(post.id, mars);
             expect(resp.comments, 'to satisfy', [
               {
-                body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
-                createdBy: null,
-                hideType: Comment.HIDDEN_VIEWER_BANNED,
+                body: 'Comment from Luna',
+                createdBy: luna.user.id,
+                hideType: Comment.VISIBLE,
+                _hideType: Comment.HIDDEN_VIEWER_BANNED,
               },
               { body: 'Comment from Mars', createdBy: mars.user.id },
             ]);
@@ -114,13 +115,14 @@ describe('Symmetric bans', () => {
             ]);
           });
 
-          it(`should show Luna's comments to Mars as placeholder`, async () => {
+          it(`should show Luna's comments to Mars with _hideType`, async () => {
             const resp = await fetchPost(post.id, mars);
             expect(resp.comments, 'to satisfy', [
               {
-                body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
-                createdBy: null,
-                hideType: Comment.HIDDEN_VIEWER_BANNED,
+                body: 'Comment from Luna',
+                createdBy: luna.user.id,
+                hideType: Comment.VISIBLE,
+                _hideType: Comment.HIDDEN_VIEWER_BANNED,
               },
               { body: 'Comment from Mars', createdBy: mars.user.id },
             ]);
@@ -276,9 +278,10 @@ describe('Symmetric bans', () => {
           );
           await expect(test, 'when fulfilled', 'to satisfy', {
             comments: {
-              hideType: Comment.HIDDEN_VIEWER_BANNED,
-              body: Comment.hiddenBody(Comment.HIDDEN_VIEWER_BANNED),
-              createdBy: null,
+              hideType: Comment.VISIBLE,
+              _hideType: Comment.HIDDEN_VIEWER_BANNED,
+              body: 'Comment from Luna',
+              createdBy: luna.user.id,
             },
           });
         });

--- a/test/functional/usersV2.js
+++ b/test/functional/usersV2.js
@@ -269,7 +269,7 @@ describe('UsersControllerV2', () => {
     });
 
     it('should allow to update preferences with valid value', async () => {
-      const preferences = { hideCommentsOfTypes: [Comment.HIDDEN_BANNED] };
+      const preferences = { hideCommentsOfTypes: [Comment.HIDDEN_AUTHOR_BANNED] };
       const res = await updateUserAsync(luna, { preferences });
       const data = await res.json();
       expect(data, 'to satisfy', { users: { preferences } });

--- a/test/integration/controllers/comment-access-required.js
+++ b/test/integration/controllers/comment-access-required.js
@@ -92,8 +92,8 @@ describe('commentAccessRequired', () => {
         expect(ctx.state, 'to satisfy', {
           comment: {
             id: comment.id,
-            body: 'Hidden comment',
-            hideType: Comment.HIDDEN_BANNED,
+            body: Comment.hiddenBody(Comment.HIDDEN_AUTHOR_BANNED),
+            hideType: Comment.HIDDEN_AUTHOR_BANNED,
           },
         });
       });

--- a/test/integration/support/events/backlinks.js
+++ b/test/integration/support/events/backlinks.js
@@ -183,16 +183,20 @@ describe('EventService', () => {
         });
 
         it('should not create backlink_in_comment event for mentioned user who banned post author', async () => {
+          // Mars banned Luna
           await mars.ban(luna.username);
+          // Luna shouldn't allow to see Mars' comment, so no event will be created for her
           comment = await createComment(luna, venusPost, `Mentioning ${marsPost.id}`);
           await expectBacklinkEvents(mars, []);
           await mars.unban(luna.username);
         });
 
-        it('should create (!) backlink_in_comment event for banned mentioned user', async () => {
+        it('should not create backlink_in_comment event for banned mentioned user', async () => {
+          // Luna banned Mars
           await luna.ban(mars.username);
+          // Mars shouldn't allow to see Luna's comment, so no event will be created for him
           comment = await createComment(luna, venusPost, `Mentioning ${marsPost.id}`);
-          await expectBacklinkEvents(mars, [await backlinkInCommentEvent(comment, marsPost)]);
+          await expectBacklinkEvents(mars, []);
           await luna.unban(mars.username);
         });
 
@@ -451,10 +455,12 @@ describe('EventService', () => {
           await mars.unban(luna.username);
         });
 
-        it('should create (!) backlink_in_comment event for banned mentioned user', async () => {
+        it('should not create backlink_in_comment event for banned mentioned user', async () => {
+          // Luna banned Mars
           await luna.ban(mars.username);
+          // Mars shouldn't allow to see Luna's comment, so no event will be created for him
           comment = await createComment(luna, venusPost, `Mentioning ${marsComment.id}`);
-          await expectBacklinkEvents(mars, [await backlinkInCommentEvent(comment, marsComment)]);
+          await expectBacklinkEvents(mars, []);
           await luna.unban(mars.username);
         });
 


### PR DESCRIPTION
#### Changed
- The bans are fully symmetrical now. If A bans B, then:
  - A doesn't see B's posts, comments content, likes and comment likes;
  - B doesn't see A's posts, comments content, likes and comment likes.
  
  By default, comments are displayed as placeholders, but the viewer can turn them off completely. Also, one can disable bans in some groups, see the [2.7.0] release for the bans logic in this case.
- ⚠ BUT the ban symmetry is DELIBERATELY BROKEN for now. It works for likes and comment likes, but the A's comments content is still visible for B. Such comments have an additional `_hideType = 4` field in API responses ('4' is the `Comment.HIDDEN_VIEWER_BANNED` constant). The client code can hide such comments on its level.
