### PR TITLE
Hidden comment visibility updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.20.0] - Not released
+#### Changed
+- Comments from users who have blocked the current viewer are visible to the
+  viewer under his own posts.
+- The viewer can "unlock" the comment using the "unlock-banned" URL parameter
+  (`GET /v2/comments/:commentId?unlock-banned`). This parameter removes the
+  HIDDEN_AUTHOR_BANNED hide type from comment and allows the comment to be
+  viewed (if it is not HIDDEN_VIEWER_BANNED).
 
 ## [2.19.1] - 2024-04-26
 #### Changed

--- a/app/controllers/api/v1/CommentsController.js
+++ b/app/controllers/api/v1/CommentsController.js
@@ -109,10 +109,10 @@ export const destroy = compose([
 ]);
 
 export const getById = compose([
-  commentAccessRequired({ mustBeVisible: false }),
+  commentAccessRequired({ mustBeVisible: false, bannedUnlockParam: 'unlock-banned' }),
   async (ctx) => {
-    const { comment, user } = ctx.state;
-    ctx.body = await serializeCommentFull(comment, user?.id);
+    const { comment, user, unlockBannedComments } = ctx.state;
+    ctx.body = await serializeCommentFull(comment, user?.id, { unlockBannedComments });
   },
 ]);
 

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -364,9 +364,16 @@ export default class PubsubListener {
 
         // Bans
         if (post && userId) {
-          const bannedUserIds = (!usersDisabledBans.includes(userId) && bansMap.get(userId)) || [];
-          const bannedByUserIds =
-            (!adminsDisabledBans.includes(userId) && bannedByMap.get(userId)) || [];
+          let bannedUserIds = bansMap.get(userId) ?? [];
+          let bannedByUserIds = bannedByMap.get(userId) ?? [];
+
+          if (usersDisabledBans.includes(userId)) {
+            bannedUserIds = [];
+          }
+
+          if (adminsDisabledBans.includes(userId) || userId === post.userId) {
+            bannedByUserIds = [];
+          }
 
           const isBanned = (id) => bannedUserIds.includes(id) || bannedByUserIds.includes(id);
 

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -243,11 +243,11 @@ export class DbAdapter {
   ): Promise<(actionsTable: string, postsTable?: string, useIntBanIds?: boolean) => string>;
   isPostVisibleForViewer(postId: UUID, viewerId?: UUID): Promise<boolean>;
   getUsersWhoCanSeePost(postProps: { authorId: UUID; destFeeds: number[] }): Promise<List<UUID>>;
-  isCommentBannedForViewer(commentId: UUID, viewerId?: UUID): Promise<boolean>;
+  isCommentBannedForViewer(commentId: UUID, viewerId?: UUID): Promise<number[] | null>;
   areCommentsBannedForViewerAssoc(
     commentIds: UUID[],
     viewerId?: UUID,
-  ): Promise<{ [id: UUID]: boolean }>;
+  ): Promise<Map<UUID, number[]>>;
 
   getGroupsVisibility(accountIds: UUID[], viewerId: UUID | null): Promise<{ [k: UUID]: boolean }>;
 

--- a/app/support/DbAdapter/visibility.js
+++ b/app/support/DbAdapter/visibility.js
@@ -180,7 +180,7 @@ const visibilityTrait = (superClass) =>
 
     async isCommentBannedForViewer(commentId, viewerId = null) {
       const m = await this.areCommentsBannedForViewerAssoc([commentId], viewerId);
-      return m[commentId] ?? false;
+      return m.get(commentId) ?? null;
     }
 
     async areCommentsBannedForViewerAssoc(commentIds, viewerId = null) {
@@ -197,15 +197,22 @@ const visibilityTrait = (superClass) =>
           `,
         { commentIds },
       );
-      const result = {};
+      const result = new Map();
 
       for (const row of rows) {
+        const s = [];
+
         if (row.banned_by_viewer) {
-          result[row.uid] = Comment.HIDDEN_AUTHOR_BANNED;
-        } else if (row.banned_by_author) {
-          result[row.uid] = Comment.HIDDEN_VIEWER_BANNED;
-        } else {
-          result[row.uid] = false;
+          // Always first, when present
+          s.push(Comment.HIDDEN_AUTHOR_BANNED);
+        }
+
+        if (row.banned_by_author) {
+          s.push(Comment.HIDDEN_VIEWER_BANNED);
+        }
+
+        if (s.length > 0) {
+          result.set(row.uid, s);
         }
       }
 

--- a/app/support/DbAdapter/visibility.js
+++ b/app/support/DbAdapter/visibility.js
@@ -1,3 +1,4 @@
+import pgFormat from 'pg-format';
 import { intersection } from 'lodash';
 
 import { List } from '../open-lists';
@@ -152,13 +153,15 @@ const visibilityTrait = (superClass) =>
             `${actionsTable}.user_id`,
             viewerBannedBy.map((r) => r[useIntBanIds ? 'id' : 'uid']),
           ),
-          // And the post is not in some group, managed bi viewer, with bans disabled
+          // And the post is not in some group, managed by viewer, with bans disabled
           sqlNot(
             sqlIntarrayIn(
               `${postsTable}.destination_feed_ids`,
               feedsOfManagedGroupsWithDisabledBans,
             ),
           ),
+          // And the post is not authored by the viewer
+          pgFormat(`${postsTable}.user_id <> %L`, viewerId),
         ]),
       ];
     }
@@ -319,8 +322,9 @@ const visibilityTrait = (superClass) =>
           List.union(
             // All who banned comment author, except those who disabled bans
             List.difference(authorBannedBy, allWhoDisabledBans),
-            // All banned by comment author, except ADMINS who disabled bans
-            List.difference(bannedByAuthor, adminsWhoDisabledBans),
+            // All banned by comment author, except ADMINS who disabled bans and
+            // the post author
+            List.difference(bannedByAuthor, List.union(adminsWhoDisabledBans, [postAuthor])),
           ),
         ),
       );

--- a/doc/visibility-rules.md
+++ b/doc/visibility-rules.md
@@ -38,15 +38,20 @@ Comments, Likes and Comment likes (hereinafter "actions") shares the same logic.
 
 Actions on the given post is not visible for viewer if the post is not visible.
 
-Action is visible when (AND-joined):
-* The action author is not banned by viewer OR post is published to a group
-  where the viewer had disabled bans.
-* Viewer is not banned by the action author OR post is published to a group where
-  the viewer *is admin* and had disabled bans.
+Action is invisible when the action author is banned by viewer or the viewer is
+banned by the action author, with the following exceptions:
+
+* When *the action author is banned* by viewer, action is visible when:
+  * The post is published to a group where the viewer had disabled bans.
+* When *the viewer is banned* by the action author, action is visible when
+  (OR-joined):
+  * The post is published to a group where the viewer *is admin* and had
+    disabled bans;
+  * The post is authored by the viewer.
 
 If the post is visible but the comment is not, the comment may appear as a stub
-(with hideType = HIDDEN_AUTHOR_BANNED). It depends on *hideCommentsOfTypes* field of
-viewer properties.
+(with 'hideType' field value of HIDDEN_AUTHOR_BANNED or HIDDEN_VIEWER_BANNED).
+It depends on *hideCommentsOfTypes* field of viewer properties.
 
 Handling the visibility of comments is a bit special (see the
 'commentAccessRequired' middleware). If the viewer has access to post, but not

--- a/doc/visibility-rules.md
+++ b/doc/visibility-rules.md
@@ -61,6 +61,11 @@ to comment, the middleware acts as follows:
 * If the comment-related resource is requested (currently it is a comment like),
   the middleware throws a 403 error.
 
+Also, the viewer can "unlock" the comment using the "unlock-banned" URL
+parameter (`GET /v2/comments/:commentId?unlock-banned`). This parameter removes
+the HIDDEN_AUTHOR_BANNED hide type from comment and allows the comment to be
+viewed (if it is not HIDDEN_VIEWER_BANNED).
+
 ### In code
 The action visibility rules calculates in the following places:
 * app/support/DbAdapter/visibility.js, bannedActionsSQLsFabric and


### PR DESCRIPTION
#### Changed
- Comments from users who have blocked the current viewer are visible to the viewer under his own posts.
- The viewer can "unlock" the comment using the "unlock-banned" URL parameter (`GET /v2/comments/:commentId?unlock-banned`). This parameter removes the HIDDEN_AUTHOR_BANNED hide type from comment and allows the comment to be viewed (if it is not HIDDEN_VIEWER_BANNED).
