### PR TITLE
Configure comments folding in the server config

### DIFF
--- a/API_VERSIONS.md
+++ b/API_VERSIONS.md
@@ -5,6 +5,21 @@ All backward-incompatible FreeFeed API changes will be documented in this file.
 See the [About API versions](#about-api-versions) section in the end of this
 file for the general versioning information.
 
+## [3] - 2024-06-21
+
+### Changed
+- Serialized posts now contains the _omittedCommentsOffset_ field. If post
+  contains some omitted comments, this field contains the offset of omitted part
+  in the _comments_ array. Client must use the _omitCommentsOffset_ field to
+  determine, which of the _comments_ are before and after the omitted part.
+
+  It is a broken change because in V2 API responses, when some comments are
+  omitted, the _comments_ array always has two items. The V2 clients treats the
+  _comments_ array as [beforeOmitted, afterOmitted].
+
+  In the V3 API response, the _comments_ array can have more than two items, and
+  the _omittedCommentsOffset_ can have values other than '1'.
+
 ## [2] - 2022-11-01
 
 This is the initial API version (it is "2" instead of "1" for historical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.21.0] - Not released
+#### Added
+- The V3 API is now available. The only difference from V2 is:
+  - Serialized posts with omitted comments now have two comments after the
+    omitted part (and this count is defined in server config). They also have a
+    new _omitCommentsOffset_ field, that contains the offset of omitted part in
+    the _comments_ array (which now has three comments if the omitted part is
+    present). Client must use the _omitCommentsOffset_ field to determine, which
+    of the _comments_ are before and after the omitted part.
+
+    It is a broken change because the old clients expects the _comments_ array
+    of a post with omitted comments to always have two comments total.
 
 ## [2.20.0] - 2024-05-27
 #### Changed

--- a/app/api-versions.ts
+++ b/app/api-versions.ts
@@ -1,4 +1,5 @@
 export const API_VERSION_2 = 2;
+export const API_VERSION_3 = 3;
 
-export const API_VERSION_ACTUAL = API_VERSION_2;
+export const API_VERSION_ACTUAL = API_VERSION_3;
 export const API_VERSION_MINIMAL = API_VERSION_2;

--- a/app/controllers/api/v2/CalendarController.js
+++ b/app/controllers/api/v2/CalendarController.js
@@ -41,7 +41,7 @@ export const getMyCalendarDatePosts = compose([
   targetUserRequired(),
   monitored('calendar.datePosts'),
   async (ctx) => {
-    const { targetUser, user } = ctx.state;
+    const { targetUser, user, apiVersion } = ctx.state;
     const currentUserId = user.id;
     const { year, month, day } = ctx.params;
     const offset = parseInt(ctx.request.query.offset, 10) || 0;
@@ -78,7 +78,10 @@ export const getMyCalendarDatePosts = compose([
       foundPostsIds.length = limit;
     }
 
-    const feed = await serializeFeed(foundPostsIds, currentUserId, null, { isLastPage });
+    const feed = await serializeFeed(foundPostsIds, currentUserId, null, {
+      isLastPage,
+      apiVersion,
+    });
 
     const previousDay = await dbAdapter.getMyCalendarFirstDayWithPostsBeforeDate(
       currentUserId,

--- a/app/controllers/api/v2/SearchController.js
+++ b/app/controllers/api/v2/SearchController.js
@@ -14,9 +14,7 @@ export default class SearchController {
       const DEFAULT_LIMIT = 30;
       const MAX_LIMIT = 120;
 
-      const {
-        state: { user },
-      } = ctx;
+      const { user, apiVersion } = ctx.state;
       const query = (ctx.request.query.qs || '').trim();
       let offset = parseInt(ctx.request.query.offset, 10);
       let limit = parseInt(ctx.request.query.limit, 10);
@@ -48,7 +46,7 @@ export default class SearchController {
         postIds.length = limit;
       }
 
-      ctx.body = await serializeFeed(postIds, user && user.id, null, { isLastPage });
+      ctx.body = await serializeFeed(postIds, user && user.id, null, { isLastPage, apiVersion });
     },
   ]);
 }

--- a/app/controllers/api/v2/SummaryController.js
+++ b/app/controllers/api/v2/SummaryController.js
@@ -19,7 +19,7 @@ export const generalSummary = compose([
     const days = getDays(ctx.params.days);
     const limit = parseInt(ctx.request.query.limit, 10) || null;
 
-    const currentUser = ctx.state.user;
+    const { user: currentUser, apiVersion } = ctx.state;
 
     let destinations = [];
     let activities = [];
@@ -37,7 +37,10 @@ export const generalSummary = compose([
       limit,
     );
 
-    ctx.body = await serializeFeed(foundPostsIds, currentUser.id, null, { isLastPage: true });
+    ctx.body = await serializeFeed(foundPostsIds, currentUser.id, null, {
+      isLastPage: true,
+      apiVersion,
+    });
   },
 ]);
 
@@ -45,7 +48,7 @@ export const userSummary = compose([
   targetUserRequired(),
   monitored('summary.user'),
   async (ctx) => {
-    const { targetUser } = ctx.state;
+    const { targetUser, apiVersion } = ctx.state;
 
     const days = getDays(ctx.params.days);
 
@@ -57,6 +60,9 @@ export const userSummary = compose([
     // Get posts authored by target user, and provide current user (the reader) for filtering
     const foundPostsIds = await dbAdapter.getSummaryPostsIds(currentUserId, days, [timelineIntId]);
 
-    ctx.body = await serializeFeed(foundPostsIds, currentUserId, null, { isLastPage: true });
+    ctx.body = await serializeFeed(foundPostsIds, currentUserId, null, {
+      isLastPage: true,
+      apiVersion,
+    });
   },
 ]);

--- a/app/controllers/api/v2/TimelinesRSS.js
+++ b/app/controllers/api/v2/TimelinesRSS.js
@@ -222,11 +222,11 @@ async function postItemMaker(postId, data, ctx) {
 }
 
 async function loadAllComments(postId, ctx) {
-  const { user: viewer } = ctx.state;
+  const { user: viewer, apiVersion } = ctx.state;
   const [postWithStuff] = await dbAdapter.getPostsWithStuffByIds(
     [postId],
     viewer ? viewer.id : null,
-    { foldComments: false },
+    { foldComments: false, apiVersion },
   );
 
   return postWithStuff ? postWithStuff.comments.map((c) => serializeComment(c)) : [];

--- a/app/pubsub-listener.js
+++ b/app/pubsub-listener.js
@@ -746,7 +746,9 @@ export default class PubsubListener {
   }
 
   _postEventEmitter = async (socket, type, { postId, realtimeChannels }) => {
-    const json = await serializeSinglePost(postId, socket.userId);
+    const json = await serializeSinglePost(postId, socket.userId, {
+      apiVersion: socket.apiVersion,
+    });
     defaultEmitter(socket, type, { ...json, realtimeChannels });
   };
 

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -114,6 +114,7 @@ export async function serializeFeed(
     comments,
     likes,
     omittedComments,
+    omittedCommentsOffset,
     omittedLikes,
     backlinksCount,
   } of postsWithStuff.filter(Boolean)) {
@@ -124,6 +125,7 @@ export async function serializeFeed(
       attachments: attachments.map((a) => a.id),
       likes,
       omittedComments,
+      omittedCommentsOffset,
       omittedLikes,
       backlinksCount,
       notifyOfAllComments: false,

--- a/app/serializers/v2/post.js
+++ b/app/serializers/v2/post.js
@@ -71,7 +71,7 @@ export async function serializeFeed(
   postIds,
   viewerId,
   timeline = null,
-  { isLastPage = false, foldComments = true, foldLikes = true } = {},
+  { isLastPage = false, foldComments = true, foldLikes = true, apiVersion } = {},
 ) {
   const canViewTimeline = timeline ? await timeline.canShow(viewerId) : true;
 
@@ -94,6 +94,7 @@ export async function serializeFeed(
     hiddenCommentTypes,
     foldComments,
     foldLikes,
+    apiVersion,
   });
 
   const { notifyOfCommentsOnMyPosts = false, notifyOfCommentsOnCommentedPosts = false } =
@@ -218,9 +219,13 @@ export async function serializeFeed(
 export async function serializeSinglePost(
   postId,
   viewerId = null,
-  { foldComments = true, foldLikes = true } = {},
+  { foldComments = true, foldLikes = true, apiVersion } = {},
 ) {
-  const data = await serializeFeed([postId], viewerId, null, { foldComments, foldLikes });
+  const data = await serializeFeed([postId], viewerId, null, {
+    foldComments,
+    foldLikes,
+    apiVersion,
+  });
   [data.posts] = data.posts;
   Reflect.deleteProperty(data, 'timelines');
   Reflect.deleteProperty(data, 'admins');

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -274,6 +274,7 @@ const timelinesPostsTrait = (superClass) =>
      *   attachments: <array of Attachment objects>
      *   comments: <array of Comments objects>
      *   omittedComments: <number>
+     *   omittedCommentsOffset: <number>
      *   likes: <array of liker's UIDs>
      *   omittedLikes: <number>
      * }
@@ -454,6 +455,7 @@ const timelinesPostsTrait = (superClass) =>
           attachments: [],
           comments: [],
           omittedComments: 0,
+          omittedCommentsOffset: 0,
           likes: [],
           omittedLikes: 0,
           backlinksCount: backlinks.get(post.uid) || 0,
@@ -502,6 +504,8 @@ const timelinesPostsTrait = (superClass) =>
         results[comm.post_id].comments.push(comment);
         results[comm.post_id].omittedComments =
           params.foldComments && comm.count > params.maxUnfoldedComments ? comm.count - 2 : 0;
+        results[comm.post_id].omittedCommentsOffset =
+          results[comm.post_id].omittedComments > 0 ? 1 : 0;
 
         if (params.foldComments && results[comm.post_id].omittedComments > 0) {
           let omittedCLikes = results[comm.post_id].post.hasOwnProperty('omittedCommentLikes')

--- a/app/support/DbAdapter/timelines-posts.js
+++ b/app/support/DbAdapter/timelines-posts.js
@@ -1,8 +1,10 @@
+import config from 'config';
 import _ from 'lodash';
 import pgFormat from 'pg-format';
 
 import { Comment } from '../../models';
 import { List } from '../open-lists';
+import { API_VERSION_2 } from '../../api-versions';
 
 import { COMMENT_FIELDS, initCommentObject } from './comments';
 import { ATTACHMENT_FIELDS, initAttachmentObject } from './attachments';
@@ -287,12 +289,22 @@ const timelinesPostsTrait = (superClass) =>
       params = {
         foldComments: true,
         foldLikes: true,
-        maxUnfoldedComments: 3,
-        maxUnfoldedLikes: 4,
-        visibleFoldedLikes: 3,
         hiddenCommentTypes: [],
+        apiVersion: API_VERSION_2,
         ...params,
       };
+
+      const folding =
+        params.apiVersion === API_VERSION_2
+          ? {
+              // Legacy v2 parameters
+              headComments: 1,
+              tailComments: 1,
+              minOmittedComments: 2,
+              headLikes: 3,
+              minOmittedLikes: 2,
+            }
+          : config.foldingInPosts;
 
       const uniqPostsIds = _.uniq(postsIds);
 
@@ -365,9 +377,9 @@ const timelinesPostsTrait = (superClass) =>
 
       const foldLikesSql = params.foldLikes
         ? pgFormat(
-            `where count <= %L or rank <= %L`,
-            params.maxUnfoldedLikes,
-            params.visibleFoldedLikes,
+            `where count < %L or rank <= %L`,
+            folding.minOmittedLikes + folding.headLikes,
+            folding.headLikes,
           )
         : ``;
       const likesSQL = `
@@ -428,7 +440,12 @@ const timelinesPostsTrait = (superClass) =>
       );
 
       const foldCommentsSql = params.foldComments
-        ? pgFormat(`where count <= %L or rank = 1 or rank = count`, params.maxUnfoldedComments)
+        ? pgFormat(
+            `where count < %L or rank <= %L or rank > count - %L`,
+            folding.minOmittedComments + folding.headComments + folding.tailComments,
+            folding.headComments,
+            folding.tailComments,
+          )
         : ``;
       const commentsSQL = `
       with comments as (${allCommentsSQL})
@@ -503,9 +520,12 @@ const timelinesPostsTrait = (superClass) =>
         comment.hasOwnLike = Boolean(comm.has_own_like);
         results[comm.post_id].comments.push(comment);
         results[comm.post_id].omittedComments =
-          params.foldComments && comm.count > params.maxUnfoldedComments ? comm.count - 2 : 0;
+          params.foldComments &&
+          comm.count >= folding.minOmittedComments + folding.headComments + folding.tailComments
+            ? comm.count - folding.headComments - folding.tailComments
+            : 0;
         results[comm.post_id].omittedCommentsOffset =
-          results[comm.post_id].omittedComments > 0 ? 1 : 0;
+          results[comm.post_id].omittedComments > 0 ? folding.headComments : 0;
 
         if (params.foldComments && results[comm.post_id].omittedComments > 0) {
           let omittedCLikes = results[comm.post_id].post.hasOwnProperty('omittedCommentLikes')

--- a/config/default.js
+++ b/config/default.js
@@ -503,4 +503,12 @@ config.translation = {
   apiKey: 'OVERRIDE_IT',
 };
 
+config.foldingInPosts = {
+  headComments: 1, // Comments before omitted
+  tailComments: 2, // Comments after omitted
+  minOmittedComments: 2, // Minimum number of omitted comments
+  headLikes: 3, // Likes before omitted
+  minOmittedLikes: 2, // Minimum number of omitted likes
+};
+
 module.exports = config;

--- a/test/functional/common-routing.js
+++ b/test/functional/common-routing.js
@@ -9,7 +9,7 @@ import expect from 'unexpected';
 import { getSingleton } from '../../app/app';
 import { version as serverVersion } from '../../package.json';
 import cleanDB from '../dbCleaner';
-import { API_VERSION_ACTUAL, API_VERSION_MINIMAL } from '../../app/api-versions';
+import { API_VERSION_2, API_VERSION_ACTUAL, API_VERSION_MINIMAL } from '../../app/api-versions';
 
 import { createTestUser, updateUserAsync } from './functional_test_helper';
 
@@ -24,7 +24,7 @@ describe('Common API routing', () => {
     const resp = await fetch(`${app.context.config.host}/v2/users/whoami`);
     expect(resp.status, 'to be', 401);
     expect(resp.headers.get('X-Freefeed-Server'), 'to be', serverVersion);
-    expect(resp.headers.get('Freefeed-API-Version'), 'to be', API_VERSION_ACTUAL.toString(10));
+    expect(resp.headers.get('Freefeed-API-Version'), 'to be', API_VERSION_2.toString(10));
     expect(resp.headers.get('Access-Control-Expose-Headers'), 'to contain', 'X-Freefeed-Server');
     expect(resp.headers.get('Access-Control-Expose-Headers'), 'to contain', 'Freefeed-API-Version');
     expect(resp.headers.get('Access-Control-Expose-Headers'), 'to contain', 'Date');

--- a/test/functional/functional_test_helper.js
+++ b/test/functional/functional_test_helper.js
@@ -13,7 +13,7 @@ import Application from 'koa';
 import { dbAdapter, sessionTokenV1Store, User, Group } from '../../app/models';
 import { getSingleton as initApp } from '../../app/app';
 import { addMailListener } from '../../lib/mailer';
-import { API_VERSION_ACTUAL } from '../../app/api-versions';
+import { API_VERSION_2, API_VERSION_3, API_VERSION_ACTUAL } from '../../app/api-versions';
 import { createPost as iCreatePost } from '../integration/helpers/posts-and-comments';
 
 import * as schema from './schemaV2-helper';
@@ -1032,7 +1032,7 @@ export async function fetchPost(postId, viewerContext = null, params = {}) {
     returnError: false,
     allComments: false,
     allLikes: false,
-    apiVersion: 'v2',
+    apiVersion: API_VERSION_2,
     ...params,
   };
   const headers = {};
@@ -1043,7 +1043,7 @@ export async function fetchPost(postId, viewerContext = null, params = {}) {
 
   const response = await fetch(
     await apiUrl(
-      `/${params.apiVersion}/posts/${postId}?maxComments=${
+      `/v${params.apiVersion}/posts/${postId}?maxComments=${
         params.allComments ? 'all' : ''
       }&maxLikes=${params.allLikes ? 'all' : ''}`,
     ),
@@ -1059,7 +1059,7 @@ export async function fetchPost(postId, viewerContext = null, params = {}) {
     expect.fail('HTTP error (code {0}): {1}', response.status, post.err);
   }
 
-  if (params.apiVersion === 'v2') {
+  if (params.apiVersion === API_VERSION_2 || params.apiVersion === API_VERSION_3) {
     expect(post, 'to exhaustively satisfy', schema.postResponse);
   }
 

--- a/test/functional/posts/postsV2.js
+++ b/test/functional/posts/postsV2.js
@@ -65,6 +65,7 @@ describe('TimelinesControllerV2', () => {
           const post = await fetchPost(lunaPost.id, null, { allComments });
           expect(post.posts.comments, 'to have length', expComments);
           expect(post.posts.omittedComments, 'to equal', expOmitted);
+          expect(post.posts.omittedCommentsOffset, 'to equal', expOmitted > 0 ? 1 : 0);
         };
 
         describe('Folded comments', () => {

--- a/test/functional/realtime-modern-client.js
+++ b/test/functional/realtime-modern-client.js
@@ -6,7 +6,7 @@ import { getSingleton } from '../../app/app';
 import { PubSub } from '../../app/models';
 import { PubSubAdapter, eventNames } from '../../app/support/PubSubAdapter';
 import cleanDB from '../dbCleaner';
-import { API_VERSION_ACTUAL } from '../../app/api-versions';
+import { API_VERSION_MINIMAL } from '../../app/api-versions';
 
 import { createTestUser, createAndReturnPost, goPrivate } from './functional_test_helper';
 import Session from './realtime-session';
@@ -42,7 +42,7 @@ describe('Basic realtime operations with the modern client', () => {
     expect(resp, 'to equal', {
       success: true,
       userId: luna.user.id,
-      apiVersion: API_VERSION_ACTUAL,
+      apiVersion: API_VERSION_MINIMAL,
       rooms: {},
     });
   });
@@ -52,7 +52,7 @@ describe('Basic realtime operations with the modern client', () => {
     expect(resp, 'to equal', {
       success: true,
       userId: null,
-      apiVersion: API_VERSION_ACTUAL,
+      apiVersion: API_VERSION_MINIMAL,
       rooms: {},
     });
   });

--- a/test/functional/realtime-session.js
+++ b/test/functional/realtime-session.js
@@ -1,8 +1,6 @@
 import socketIO from 'socket.io-client';
 import socketIOModern from 'socket.io-client-modern';
 
-import { API_VERSION_ACTUAL } from '../../app/api-versions';
-
 const eventTimeout = 2000;
 const silenceTimeout = 500;
 
@@ -19,7 +17,6 @@ export default class Session {
     const options = {
       transports: ['websocket'],
       forceNew: true,
-      query: { apiVersion: API_VERSION_ACTUAL },
       ...extraOptions,
     };
     return new Promise((resolve, reject) => {
@@ -34,7 +31,6 @@ export default class Session {
     const options = {
       transports: ['websocket'],
       forceNew: true,
-      query: { apiVersion: API_VERSION_ACTUAL },
       ...extraOptions,
     };
     return new Promise((resolve, reject) => {

--- a/test/functional/realtime2.js
+++ b/test/functional/realtime2.js
@@ -68,7 +68,7 @@ describe('Realtime #2', () => {
       expect(resp, 'to equal', {
         success: true,
         userId: luna.user.id,
-        apiVersion: API_VERSION_ACTUAL,
+        apiVersion: API_VERSION_MINIMAL,
         rooms: {},
       });
     });
@@ -95,6 +95,15 @@ describe('Realtime #2', () => {
       });
       const resp = await session.sendAsync('status', null);
       expect(resp, 'to satisfy', { apiVersion: API_VERSION_MINIMAL });
+      await session.disconnect();
+    });
+
+    it(`should return actual API version if it is set`, async () => {
+      const session = await Session.create(port, 'Some session', {
+        query: { apiVersion: API_VERSION_ACTUAL },
+      });
+      const resp = await session.sendAsync('status', null);
+      expect(resp, 'to satisfy', { apiVersion: API_VERSION_ACTUAL });
       await session.disconnect();
     });
 

--- a/test/functional/schemaV2-helper.js
+++ b/test/functional/schemaV2-helper.js
@@ -222,6 +222,7 @@ const postBasic = {
     .and('to be empty')
     .or('to have items satisfying', 'to be UUID'),
   omittedComments: expect.it('to be a number'),
+  omittedCommentsOffset: expect.it('to be a number'),
   omittedLikes: expect.it('to be a number'),
   commentLikes: expect.it('to be a number'),
   ownCommentLikes: expect.it('to be a number'),

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -186,6 +186,14 @@ declare module 'config' {
           limits: TranslationLimits;
           serviceTitle: string;
         } & ({ service: 'test' } | { service: 'google'; apiKey: string }));
+
+    foldingInPosts: {
+      headComments: number;
+      tailComments: number;
+      minOmittedComments: number;
+      headLikes: number;
+      minOmittedLikes: number;
+    };
   };
 
   export type TranslationLimits = {


### PR DESCRIPTION
#### Added
- The V3 API is now available. The only difference from V2 is:
  - Serialized posts with omitted comments now have two comments after the omitted part (all fold parameters are defined in server config). They also have the new _omitCommentsOffset_ field, that contains the offset of omitted part in the _comments_ array (which now has three comments if the omitted part is present).

    It is a broken change because the old clients expects the _comments_ array of a post with omitted comments to always have two comments total.
