### PR TITLE
Add a new API endpoint `GET /v2/users/sparseMatches?qs=...`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.21.0] - Not released
+### Added
+- New API endpoint `GET /v2/users/sparseMatches?qs=...` to get list of
+  non-private users and groups, whose username _sparse matches_ the query
+  string. The sparse match means that the username must contain all the query
+  string letters in the given order, but with possible other letters in between.
+  For example, the 'ur[an]us', '[an]tenna', 's[a]tur[n]' matches the "an" query.
+
+  The query string should match the `[a-z0-9-]{2,}` regex.
+
+  The order of the results is not specified, the client should sort them at
+  their side.
 
 ## [2.20.0] - 2024-05-27
 #### Changed

--- a/app/controllers/api/v2/UsersController.js
+++ b/app/controllers/api/v2/UsersController.js
@@ -222,4 +222,22 @@ export default class UsersController {
       };
     },
   ]);
+
+  static sparseMatches = compose([
+    authRequired(),
+    async (ctx) => {
+      const { user } = ctx.state;
+      const qs = (ctx.request.query.qs ?? '').toLowerCase();
+
+      if (!/^[a-z0-9-]{2,}$/.test(qs)) {
+        ctx.status = 400;
+        throw new ValidationException('Invalid query string, expected: [a-z0-9-]{2,}');
+      }
+
+      const userIds = await dbAdapter.sparseMatchesUserIds(qs);
+      const users = await serializeUsersByIds(userIds, user.id);
+
+      ctx.body = { users };
+    },
+  ]);
 }

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -114,6 +114,7 @@ export const appTokensScopes = [
       'GET /vN/users/:username/statistics',
       'GET /vN/users/:username/subscribers',
       'GET /vN/users/:username/subscriptions',
+      'GET /vN/users/sparseMatches',
     ],
   },
   {

--- a/app/routes/api/v2/UsersRoute.js
+++ b/app/routes/api/v2/UsersRoute.js
@@ -7,6 +7,7 @@ export default function addRoutes(app) {
   app.get('/users/markAllDirectsAsRead', UsersControllerV2.markAllDirectsAsRead);
   app.post('/users/markAllNotificationsAsRead', UsersControllerV2.markAllNotificationsAsRead);
   app.get('/users/whoami', UsersControllerV2.whoAmI);
+  app.get('/users/sparseMatches', UsersControllerV2.sparseMatches);
   app.post('/users/verifyEmail', UsersControllerV2.verifyEmail);
   app.get('/users/:username/statistics', UsersControllerV2.statistics);
 }

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -157,6 +157,10 @@ export class DbAdapter {
     Map<UUID, typeof User.ACCEPT_DIRECTS_FROM_ALL | typeof User.ACCEPT_DIRECTS_FROM_FRIENDS>
   >;
   getAllUsersIds(limit?: number, offset?: number, types?: ('user' | 'group')[]): Promise<UUID[]>;
+  /**
+   * Returns unsorted IDs of users whose username sparse matches `query`.
+   */
+  sparseMatchesUserIds(query: string): Promise<UUID[]>;
 
   getUsersIdsByIntIds(intIds: number[]): Promise<{ id: number; uid: UUID }[]>;
   getPostsIdsByIntIds(intIds: number[]): Promise<{ id: number; uid: UUID }[]>;

--- a/app/support/DbAdapter/users.js
+++ b/app/support/DbAdapter/users.js
@@ -674,6 +674,13 @@ const usersTrait = (superClass) =>
         { limit, offset, types },
       );
     }
+
+    sparseMatchesUserIds(query) {
+      return this.database.getCol(
+        `select uid from users where username like :query and not is_private`,
+        { query: `%${query.split('').join('%')}%` },
+      );
+    }
   };
 
 export default usersTrait;

--- a/test/functional/users-sparse-match.js
+++ b/test/functional/users-sparse-match.js
@@ -1,0 +1,77 @@
+/* eslint-env node, mocha */
+
+import expect from 'unexpected';
+
+import cleanDB from '../dbCleaner';
+
+import { authHeaders, createTestUsers, performJSONRequest } from './functional_test_helper';
+
+/* global $pg_database */
+describe('sparseMatches', () => {
+  before(() => cleanDB($pg_database));
+
+  let luna;
+  before(
+    async () =>
+      ([luna] = await createTestUsers([
+        'luna',
+        'uranus',
+        'antenna',
+        'mars',
+        'venus',
+        'jupiter',
+        'saturn',
+      ])),
+  );
+
+  it('should not allow to search as anonymous', async () => {
+    const result = await performJSONRequest('GET', '/v2/users/sparseMatches', null);
+    expect(result, 'to satisfy', { __httpCode: 401 });
+  });
+
+  it('should not allow to call without search string', async () => {
+    const result = await performJSONRequest(
+      'GET',
+      '/v2/users/sparseMatches',
+      null,
+      authHeaders(luna),
+    );
+    expect(result, 'to satisfy', { __httpCode: 422 });
+  });
+
+  it('should not allow to call with too short search string', async () => {
+    const result = await performJSONRequest(
+      'GET',
+      '/v2/users/sparseMatches?qs=a',
+      null,
+      authHeaders(luna),
+    );
+    expect(result, 'to satisfy', { __httpCode: 422 });
+  });
+
+  it('should not allow to call with invalid search string', async () => {
+    const result = await performJSONRequest(
+      'GET',
+      `/v2/users/sparseMatches?qs=${encodeURIComponent('$ %$#')}`,
+      null,
+      authHeaders(luna),
+    );
+    expect(result, 'to satisfy', { __httpCode: 422 });
+  });
+
+  it('should search with valid search string', async () => {
+    const result = await performJSONRequest(
+      'GET',
+      `/v2/users/sparseMatches?qs=${encodeURIComponent('an')}`,
+      null,
+      authHeaders(luna),
+    );
+    expect(result, 'to satisfy', { __httpCode: 200 });
+    expect(
+      result.users.map(({ username }) => username),
+      'when sorted',
+      'to satisfy',
+      ['uranus', 'antenna', 'saturn'].sort(),
+    );
+  });
+});

--- a/test/integration/support/DbAdapter/users-sparse-match.js
+++ b/test/integration/support/DbAdapter/users-sparse-match.js
@@ -1,0 +1,54 @@
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../../../dbCleaner';
+import { User, dbAdapter } from '../../../../app/models';
+
+describe('sparseMatchesUserIds', () => {
+  before(() => cleanDB($pg_database));
+
+  const usernames = ['luna', 'uranus', 'antenna', 'mars', 'venus', 'jupiter', 'saturn'];
+  let users;
+
+  before(async () => {
+    users = usernames.map((username) => new User({ username, password: 'pw' }));
+    await Promise.all(users.map((user) => user.create()));
+  });
+
+  it('should find users that matches "a"', async () => {
+    const ids = await dbAdapter.sparseMatchesUserIds('a');
+    const names = ids.map((id) => users.find((u) => u.id === id).username);
+    expect(
+      names,
+      'when sorted',
+      'to equal',
+      ['luna', 'uranus', 'antenna', 'mars', 'saturn'].sort(),
+    );
+  });
+
+  it('should find users that matches "ua"', async () => {
+    const ids = await dbAdapter.sparseMatchesUserIds('ua');
+    const names = ids.map((id) => users.find((u) => u.id === id).username);
+    expect(names, 'when sorted', 'to equal', ['luna', 'uranus'].sort());
+  });
+
+  it('should find users that matches "an"', async () => {
+    const ids = await dbAdapter.sparseMatchesUserIds('an');
+    const names = ids.map((id) => users.find((u) => u.id === id).username);
+    expect(names, 'when sorted', 'to equal', ['antenna', 'uranus', 'saturn'].sort());
+  });
+
+  describe('Lona goes private', () => {
+    before(() => users.find((u) => u.username === 'luna').update({ isPrivate: '1' }));
+    after(() =>
+      users.find((u) => u.username === 'luna').update({ isPrivate: '0', isProtected: '0' }),
+    );
+
+    it('should find users that matches "ua", but without Luna', async () => {
+      const ids = await dbAdapter.sparseMatchesUserIds('ua');
+      const names = ids.map((id) => users.find((u) => u.id === id).username);
+      expect(names, 'when sorted', 'to equal', ['uranus'].sort());
+    });
+  });
+});


### PR DESCRIPTION
Added new API endpoint `GET /v2/users/sparseMatches?qs=...` to get list of non-private users and groups, whose username _sparse matches_ the query string. The sparse match means that the username must contain all the query string letters in the given order, but with possible other letters in between. For example, the 'ur[an]us', '[an]tenna', 's[a]tur[n]' matches the "an" query.

The query string should match the `[a-z0-9-]{2,}` regex.

The order of the results is not specified, the client should sort them at  their side.
