### PR TITLE
Return private users/groups by the exact match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.23.0] - Not released
+### Changed
+- The `GET /v2/users/sparseMatches?qs=...`  API endpoint now returns private
+  users and groups when the username _exactly matches_ the query string.
 
 ## [2.22.3] - 2024-09-19
 ### Fixed

--- a/app/support/DbAdapter/users.js
+++ b/app/support/DbAdapter/users.js
@@ -676,9 +676,10 @@ const usersTrait = (superClass) =>
     }
 
     sparseMatchesUserIds(query) {
+      query = query.toLowerCase();
       return this.database.getCol(
-        `select uid from users where username like :query and not is_private`,
-        { query: `%${query.split('').join('%')}%` },
+        `select uid from users where username like :sparseQuery and not is_private or username = :query`,
+        { sparseQuery: `%${query.split('').join('%')}%`, query },
       );
     }
   };

--- a/test/integration/support/DbAdapter/users-sparse-match.js
+++ b/test/integration/support/DbAdapter/users-sparse-match.js
@@ -39,7 +39,7 @@ describe('sparseMatchesUserIds', () => {
     expect(names, 'when sorted', 'to equal', ['antenna', 'uranus', 'saturn'].sort());
   });
 
-  describe('Lona goes private', () => {
+  describe('Luna goes private', () => {
     before(() => users.find((u) => u.username === 'luna').update({ isPrivate: '1' }));
     after(() =>
       users.find((u) => u.username === 'luna').update({ isPrivate: '0', isProtected: '0' }),
@@ -49,6 +49,12 @@ describe('sparseMatchesUserIds', () => {
       const ids = await dbAdapter.sparseMatchesUserIds('ua');
       const names = ids.map((id) => users.find((u) => u.id === id).username);
       expect(names, 'when sorted', 'to equal', ['uranus'].sort());
+    });
+
+    it('should find Luna using the exact query', async () => {
+      const ids = await dbAdapter.sparseMatchesUserIds('luna');
+      const names = ids.map((id) => users.find((u) => u.id === id).username);
+      expect(names, 'when sorted', 'to equal', ['luna'].sort());
     });
   });
 });


### PR DESCRIPTION
### Changed
- The `GET /v2/users/sparseMatches?qs=...`  API endpoint now returns private users and groups when the username _exactly matches_ the query string.
