### PR TITLE
Remove all the IFD1 metadata from the image after rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `GET /v2/users/sparseMatches?qs=...`  API endpoint now returns private
   users and groups when the username _exactly matches_ the query string.
+### Fixed
+- Remove all the IFD1 metadata (the thumbnail) from the image after rotation.
+  When the thumbnail data is broken (it is possible on some smartphone images),
+  it prevents the updated image from being saved.
 
 ## [2.22.3] - 2024-09-19
 ### Fixed

--- a/app/models/attachment.js
+++ b/app/models/attachment.js
@@ -724,13 +724,17 @@ async function gmAutoOrientCommands(fileName) {
  * @returns {Promise<void>}
  */
 async function clearOrientation(fileName) {
-  const orientTags = ['IFD0:Orientation', 'IFD1:Orientation'];
+  const orientTags = ['IFD0:Orientation'];
   const imageTags = await exiftool.readRaw(fileName, [
     ...orientTags.map((t) => `-${t}`),
     '-G1',
     '-n',
   ]);
-  const tagsToClean = {};
+
+  const tagsToClean = {
+    // Always remove all IFD1 (preview) section
+    'IFD1:all': null,
+  };
 
   // We do not want to change images if it is not necessary, so we ignore tag
   // values of '1' (Normal).

--- a/test/integration/models/attachments-sanitize.js
+++ b/test/integration/models/attachments-sanitize.js
@@ -17,7 +17,6 @@ import { createAttachment } from './attachment-helpers';
 
 const photoWithGPSPath = join(__dirname, '../../fixtures/photo-with-gps.jpg');
 const photoWithoutGPSPath = join(__dirname, '../../fixtures/photo-without-gps.jpg');
-const brokenFilePath = join(__dirname, '../../fixtures/broken-meta.jpg');
 
 const gpsTags = ['GPSLatitude', 'GPSLongitude', 'GPSPosition', 'GPSLatitudeRef', 'GPSLongitudeRef'];
 
@@ -115,19 +114,6 @@ describe('sanitizeOriginal model method', () => {
         name: `photo.jpg`,
         type: 'image/jpeg',
         content: await fsPromises.readFile(photoWithoutGPSPath),
-      });
-      const prevSize = att.fileSize;
-      const updated = await att.sanitizeOriginal();
-      expect(updated, 'to be false');
-      expect(prevSize, 'to equal', att.fileSize);
-      expect(att.sanitized, 'to be', SANITIZE_VERSION);
-    });
-
-    it(`should 'sanitize' a broken file`, async () => {
-      const att = await createAttachment(luna.id, {
-        name: `photo.jpg`,
-        type: 'image/jpeg',
-        content: await fsPromises.readFile(brokenFilePath),
       });
       const prevSize = att.fileSize;
       const updated = await att.sanitizeOriginal();


### PR DESCRIPTION
### Fixed
- Remove all the IFD1 metadata (the thumbnail) from the image after rotation. When the thumbnail data is broken (it is possible on some smartphone images), it prevents the updated image from being saved.
