### PR TITLE
Account search functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Private accounts are included in search results only if the viewer is
   subscribed to them or vice versa.
 
+  **After upgrading from 2.25.x**, it is recommended to run the
+  `bin/reindex_accounts.js` script to build search indexes for existing
+  accounts:
+  ```
+  yarn babel bin/reindex_accounts.js
+  ```
+
 ## [2.25.2] - 2025-09-21
 ### Fixed
 - Ensure cache invalidation after setting first user interaction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.26.0] - Not released
+### Added
+- Account search functionality: users and groups can now be found by their
+  usernames, screennames, and descriptions. The search is performed in parallel
+  with post and comment search.
+
+  Username search has some limitations compared to post/comment search:
+  - Morphology is not used
+  - Usernames are searched by _substrings_ (e.g., username `badapple` will be
+    found by queries `bad`, `apple`, `apple bad`, or `apple | pear -good`)
+  - Only the _and_, _or_, and _not_ operators are supported (other operators
+    are ignored)
+
+  The search API response now includes new `foundUsers` field: an array of
+  user/group IDs found by the search query
+
+  Private accounts are included in search results only if the viewer is
+  subscribed to them or vice versa.
 
 ## [2.25.2] - 2025-09-21
 ### Fixed

--- a/app/controllers/api/v2/SearchController.js
+++ b/app/controllers/api/v2/SearchController.js
@@ -1,8 +1,10 @@
 import compose from 'koa-compose';
+import { uniqBy } from 'lodash';
 
 import { dbAdapter } from '../../../models';
 import { serializeFeed } from '../../../serializers/v2/post';
 import { authRequired, monitored } from '../../middlewares';
+import { serializeUsersByIds } from '../../../serializers/v2/user';
 
 import { ORD_CREATED, ORD_UPDATED } from './TimelinesController';
 
@@ -15,6 +17,7 @@ export default class SearchController {
       const MAX_LIMIT = 120;
 
       const { user, apiVersion } = ctx.state;
+      const viewerId = user?.id ?? null;
       const query = (ctx.request.query.qs || '').trim();
       let offset = parseInt(ctx.request.query.offset, 10);
       let limit = parseInt(ctx.request.query.limit, 10);
@@ -31,14 +34,19 @@ export default class SearchController {
         limit = DEFAULT_LIMIT;
       }
 
-      const postIds = query
-        ? await dbAdapter.search(query, {
-            viewerId: user && user.id,
-            limit: limit + 1,
-            offset,
-            sort,
-          })
-        : []; // return nothing if query is empty
+      const [postIds, accountIds] = query
+        ? await Promise.all([
+            // Search posts and comments
+            dbAdapter.search(query, {
+              viewerId,
+              limit: limit + 1,
+              offset,
+              sort,
+            }),
+            // Search accounts
+            dbAdapter.searchInAccounts(query, { viewerId }),
+          ])
+        : [[], []];
 
       const isLastPage = postIds.length <= limit;
 
@@ -46,7 +54,20 @@ export default class SearchController {
         postIds.length = limit;
       }
 
-      ctx.body = await serializeFeed(postIds, user && user.id, null, { isLastPage, apiVersion });
+      const [serFeed, serUsers] = await Promise.all([
+        serializeFeed(postIds, viewerId, null, {
+          isLastPage,
+          apiVersion,
+        }),
+        serializeUsersByIds(accountIds, viewerId),
+      ]);
+
+      ctx.body = {
+        ...serFeed,
+        foundUsers: accountIds,
+        // We need to merge `users` with the `result.users`
+        users: uniqBy([...serFeed.users, ...serUsers], 'id'),
+      };
     },
   ]);
 }

--- a/app/support/DbAdapter/index.d.ts
+++ b/app/support/DbAdapter/index.d.ts
@@ -289,6 +289,13 @@ export class DbAdapter {
       maxQueryComplexity: number;
     }>,
   ): Promise<UUID[]>;
+  searchInAccounts(
+    query: string,
+    options?: Partial<{
+      viewerId: UUID | null;
+      maxQueryComplexity: number;
+    }>,
+  ): Promise<UUID[]>;
 
   // Visibility
   postsVisibilitySQL(

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -315,16 +315,18 @@ const searchTrait = (superClass) =>
       // Viewer can search the following user/group accounts:
       // - Public and protected
       // - Private, viewer subscribed to
+      // - Private, subscribed to viewer
       const privateAccIds = viewerId
         ? await this.database.getCol(
             joinLines([
-              `select u.uid`,
+              `select distinct u.uid`,
               `from users u`,
-              `join feeds f on u.uid = f.user_id`,
-              `join subscriptions s on f.uid = s.feed_id`,
-              `where s.user_id = :viewerId`,
-              `and f.name = 'Posts'`,
-              `and u.is_private`,
+              `join feeds f on u.uid = f.user_id and f.name = 'Posts'`,
+              `join feeds vf on vf.user_id = :viewerId and vf.name = 'Posts'`,
+              `left join subscriptions s on f.uid = s.feed_id and s.user_id = :viewerId`,
+              `left join subscriptions vs on vs.feed_id = vf.uid and vs.user_id = u.uid`,
+              `where u.is_private`,
+              `and (s.user_id is not null or vs.user_id is not null)`,
             ]),
             { viewerId },
           )

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -12,6 +12,7 @@ import {
   InScope,
   SeqTexts,
   IN_ACCOUNTS,
+  toPrefixQuery,
 } from '../search/query-tokens';
 import { List } from '../open-lists';
 import { Comment } from '../../models';
@@ -280,11 +281,26 @@ const searchTrait = (superClass) =>
         throw new Error(`The search query is too complex, try to simplify it`);
       }
 
-      // Collecting text query parts
+      // Collecting text query parts. This part is for the screennames and
+      // descriptions, we treat them as regular texts.
       let textQuery;
+
+      // We processing usernames in a special way, because we need to search
+      // _inside_ them. For example, we want to find 'badapple' username by the
+      // 'bad', 'apple' or 'bad apple' queries. Effectively, we want to search
+      // by substrings of username strings.
+      //
+      // To achieve this, we index all _suffixes_ of username ('badapple',
+      // 'adapple', 'dapple' and so on). Then we performing search by _prefix_
+      // query ('bad' -> 'bad*', 'apple' -> 'apple*'). With this approach we can
+      // find 'badapple' by 'bad' (matches by prefix to 'badapple' suffix),
+      // 'apple' (matches by prefix to 'apple' suffix) or 'bad apple' (matches
+      // both).
+      let usernameQuery;
 
       {
         const result = [];
+        const usernameResult = [];
 
         walkWithScope(parsedQuery, (token, scope) => {
           if ((scope & IN_ACCOUNTS) === 0) {
@@ -293,10 +309,12 @@ const searchTrait = (superClass) =>
 
           if (token instanceof SeqTexts) {
             result.push(token.toTSQuery());
+            usernameResult.push(toPrefixQuery(token).toTSQuery());
           }
 
           if (token instanceof InScope) {
             result.push(token.text.toTSQuery());
+            usernameResult.push(toPrefixQuery(token.text).toTSQuery());
           }
         });
 
@@ -305,11 +323,18 @@ const searchTrait = (superClass) =>
         if (result.length > 1) {
           textQuery = `(${textQuery})`;
         }
+
+        usernameQuery = usernameResult.join(' && ');
+
+        if (usernameResult.length > 1) {
+          usernameQuery = `(${usernameQuery})`;
+        }
       }
 
       const textSql = orJoin([
         textQuery && `u.screen_name_tsvector @@ ${textQuery}`,
         textQuery && `u.description_tsvector @@ ${textQuery}`,
+        usernameQuery && `u.username_tsvector @@ ${usernameQuery}`,
       ]);
 
       // Viewer can search the following user/group accounts:

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -11,6 +11,7 @@ import {
   ScopeStart,
   InScope,
   SeqTexts,
+  IN_ACCOUNTS,
 } from '../search/query-tokens';
 import { List } from '../open-lists';
 import { Comment } from '../../models';
@@ -19,6 +20,7 @@ import { sqlIn, sqlIntarrayIn, andJoin, orJoin, sqlNot } from './utils';
 
 /**
  * @typedef {import('../search/query-tokens').Token} Token
+ * @typedef {import('../types').UUID} UUID
  */
 
 ///////////////////////////////////////////////////
@@ -257,6 +259,105 @@ const searchTrait = (superClass) =>
       // console.log(fullSQL);
 
       return this.database.getCol(fullSQL);
+    }
+
+    /**
+     * Search in users/groups accounts
+     *
+     * @param {string} query
+     * @param {Object} options
+     * @param {UUID|null} options.viewerId
+     * @param {number} options.maxQueryComplexity
+     * @returns {Promise<UUID[]>}
+     */
+    async searchInAccounts(
+      query,
+      { viewerId = null, maxQueryComplexity = config.search.maxQueryComplexity } = {},
+    ) {
+      const parsedQuery = parseQuery(query);
+
+      if (queryComplexity(parsedQuery) > maxQueryComplexity) {
+        throw new Error(`The search query is too complex, try to simplify it`);
+      }
+
+      // Collecting text query parts
+      let textQuery;
+
+      {
+        const result = [];
+
+        walkWithScope(parsedQuery, (token, scope) => {
+          if (scope & (IN_ACCOUNTS === 0)) {
+            return;
+          }
+
+          if (token instanceof SeqTexts) {
+            result.push(token.toTSQuery());
+          }
+
+          if (token instanceof InScope) {
+            result.push(token.text.toTSQuery());
+          }
+        });
+
+        textQuery = result.join(' && ');
+
+        if (result.length > 1) {
+          textQuery = `(${textQuery})`;
+        }
+      }
+
+      const textSql = orJoin([
+        textQuery && `u.screen_name_tsvector @@ ${textQuery}`,
+        textQuery && `u.description_tsvector @@ ${textQuery}`,
+      ]);
+
+      // Viewer can search the following user/group accounts:
+      // - Public and protected
+      // - Private, viewer subscribed to
+      const privateAccIds = viewerId
+        ? await this.database.getCol(
+            joinLines([
+              `select u.uid`,
+              `from users u`,
+              `join feeds f on u.uid = f.user_id`,
+              `join subscriptions s on f.uid = s.feed_id`,
+              `where s.user_id = :viewerId`,
+              `and f.name = 'Posts'`,
+              `and u.is_private`,
+            ]),
+            { viewerId },
+          )
+        : [];
+
+      const accountsRestrictionSQL = orJoin(['not u.is_private', sqlIn('u.uid', privateAccIds)]);
+
+      let accIds = await this.database.getCol(
+        joinLines([
+          `select u.uid`,
+          `from users u`,
+          `where`,
+          andJoin([textSql, accountsRestrictionSQL]),
+        ]),
+      );
+
+      // Sort accounts by number of subscribers (descending)
+      if (accIds.length > 0) {
+        accIds = await this.database.getCol(
+          joinLines([
+            `select u.uid`,
+            `from users u`,
+            `left join feeds f on u.uid = f.user_id and f.name = 'Posts'`,
+            `left join subscriptions s on f.uid = s.feed_id`,
+            `where`,
+            sqlIn('u.uid', accIds),
+            `group by u.uid`,
+            `order by count(s.feed_id) desc`,
+          ]),
+        );
+      }
+
+      return accIds;
     }
 
     async _getAccountsUsedInQuery(parsedQuery, viewerId) {

--- a/app/support/DbAdapter/search.js
+++ b/app/support/DbAdapter/search.js
@@ -287,7 +287,7 @@ const searchTrait = (superClass) =>
         const result = [];
 
         walkWithScope(parsedQuery, (token, scope) => {
-          if (scope & (IN_ACCOUNTS === 0)) {
+          if ((scope & IN_ACCOUNTS) === 0) {
             return;
           }
 

--- a/app/support/DbAdapter/users-cache.js
+++ b/app/support/DbAdapter/users-cache.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 ///////////////////////////////////////////////////
 
 // We MUST increment this version when we change the structure of `users` table
-const cacheVersion = 1;
+const cacheVersion = 2;
 
 function cacheKey(id) {
   return `user_${cacheVersion}_${id}`;

--- a/app/support/DbAdapter/users.js
+++ b/app/support/DbAdapter/users.js
@@ -10,7 +10,7 @@ import { User, Group, Comment } from '../../models';
 import { normalizeEmail } from '../email-norm';
 import { List } from '../open-lists';
 import { MAX_DATE } from '../constants';
-import { toTSVector } from '../search/to-tsvector';
+import { toSuffixTSVector, toTSVector } from '../search/to-tsvector';
 
 import { initObject, prepareModelPayload } from './utils';
 
@@ -44,6 +44,9 @@ const usersTrait = (superClass) =>
 
       // raw() interprets '?' chars as positional placeholders so we must escape them
       // https://github.com/knex/knex/issues/2622
+      preparedPayload.username_tsvector = this.database.raw(
+        toSuffixTSVector(preparedPayload.username).replace(/\?/g, '\\?'),
+      );
       preparedPayload.screen_name_tsvector = this.database.raw(
         toTSVector(preparedPayload.screen_name).replace(/\?/g, '\\?'),
       );
@@ -167,10 +170,12 @@ const usersTrait = (superClass) =>
           );
         }
 
-        await trx.raw(`update users set username = :newUsername where uid = :userId`, {
-          userId,
-          newUsername,
-        });
+        const usernameTsvector = this.database.raw(toSuffixTSVector(newUsername));
+
+        await trx.raw(
+          `update users set username = :newUsername, username_tsvector = :usernameTsvector where uid = :userId`,
+          { userId, newUsername, usernameTsvector },
+        );
       });
       await this.cacheFlushUser(userId);
     }

--- a/app/support/DbAdapter/users.js
+++ b/app/support/DbAdapter/users.js
@@ -10,6 +10,7 @@ import { User, Group, Comment } from '../../models';
 import { normalizeEmail } from '../email-norm';
 import { List } from '../open-lists';
 import { MAX_DATE } from '../constants';
+import { toTSVector } from '../search/to-tsvector';
 
 import { initObject, prepareModelPayload } from './utils';
 
@@ -41,6 +42,15 @@ const usersTrait = (superClass) =>
     async createUser(payload) {
       const preparedPayload = prepareModelPayload(payload, USER_COLUMNS, USER_COLUMNS_MAPPING);
 
+      // raw() interprets '?' chars as positional placeholders so we must escape them
+      // https://github.com/knex/knex/issues/2622
+      preparedPayload.screen_name_tsvector = this.database.raw(
+        toTSVector(preparedPayload.screen_name).replace(/\?/g, '\\?'),
+      );
+      preparedPayload.description_tsvector = this.database.raw(
+        toTSVector(preparedPayload.description).replace(/\?/g, '\\?'),
+      );
+
       if (preparedPayload.email) {
         preparedPayload.email_norm = normalizeEmail(preparedPayload.email);
       }
@@ -52,6 +62,15 @@ const usersTrait = (superClass) =>
 
     async updateUser(userId, payload) {
       const preparedPayload = prepareModelPayload(payload, USER_COLUMNS, USER_COLUMNS_MAPPING);
+
+      // raw() interprets '?' chars as positional placeholders so we must escape them
+      // https://github.com/knex/knex/issues/2622
+      preparedPayload.screen_name_tsvector = this.database.raw(
+        toTSVector(preparedPayload.screen_name).replace(/\?/g, '\\?'),
+      );
+      preparedPayload.description_tsvector = this.database.raw(
+        toTSVector(preparedPayload.description).replace(/\?/g, '\\?'),
+      );
 
       if ('reset_password_token' in preparedPayload) {
         const { tokenTTL } = config.passwordReset;

--- a/app/support/search/query-syntax.md
+++ b/app/support/search/query-syntax.md
@@ -57,6 +57,10 @@ Example: `cat in-body: mouse` — the "cat" will be searched in posts and commen
 
 Example: `in-comments: mouse` — the "mouse" will be searched only in comment bodies.
 
+**in-users:** / **in-accounts:** — starting from this operator the search will be performed only in the usernames, screennames and descriptions of users and groups.
+
+Example: `in-users: mouse` — the "mouse" will be searched only in user names, screennames and descriptions.
+
 The global search scope operators switches search scope from itself to the end of the query or to the other global scope operator. 
 
 ### Interval operators

--- a/app/support/search/query-syntax.md
+++ b/app/support/search/query-syntax.md
@@ -4,9 +4,15 @@ The search query is a sequence of text terms and search operators.
 
 You can put the minus sign (`-`) right before the text term or operator to _exclude_ it from search results: `cat -mouse` will return documents with the "cat" word but without the "mouse" word.
 
+## Search scopes
+
+The search is performed across post and comment texts, as well as usernames, screennames, and descriptions of users and groups. By default, the search covers all these texts, but the search scope can be narrowed using scope operators.
+
+Full syntax is available in all search scopes except usernames (logins). Username search is limited: morphology is not used, _substrings_ of the login are searched, and only the _and_, _or_, and _not_ operators can be used (others are ignored). For example, the username `badapple` will be found by queries `bad`, `apple`, `apple bad`, or `apple | pear -good`.
+
 ## Text terms
 
-The text term is a word without white spaces (like `cat`, or `#mouse` or even `http://freefeed.net/`) or a double-quoted string that can include spaces: `"cat mouse"`. Putting text in double quotes tells search engine to search these words in the specific order and in exact word forms. It is also possible to search words by prefix (not in double quotes): `cat*`.
+The text term is a word without white spaces (like `cat`, or `#mouse` or even `http://freefeed.net/`) or a double-quoted string that can include spaces: `"cat mouse"`. Putting text in double quotes tells the search engine to search these words in the specific order and in exact word forms. It is also possible to search words by prefix (not in double quotes): `cat*`.
 
 By default _all_ text terms in query will be searched (AND is implied). You can use the "pipe" symbol (`|`) to search _any_ of them: `cat | mouse` will find documents with "cat" OR with "mouse". To search words in the specific order use the "plus" symbol (`+`): `cat + mouse` means these two words standing next to each other in that order.
 
@@ -20,7 +26,7 @@ Two important rules about the `+` and `|` symbols:
 
 General rule: in any operator you can omit dash symbol (if present) and the 's suffix of the plural word form. For example the `in-comments:` operator can also be written as `incomments:` or `incomment:`.
 
-Some operators takes user name as an arguments. In such operators you can use a special user name, `me` that means you, the current signed in user. The `cat from:me` query will find the "cat" word in all posts and comments of the current user.
+Some operators take a user name as an argument. In such operators you can use a special user name, `me` that means you, the current signed in user. The `cat from:me` query will find the "cat" word in all posts and comments of the current user.
 
 ### Full operators list
 
@@ -47,7 +53,7 @@ Some operators takes user name as an arguments. In such operators you can use a 
 
 ⚠ Warning: you can not use minus modifier with global search scope operators.
 
-By default, the search is performed both in post and comment bodies. The following operators changes this behavior.
+By default, the search is performed both in post and comment bodies. The following operators change this behavior.
 
 **in-body:** — starting from this operator the search will be performed only in the post bodies. 
 
@@ -61,7 +67,7 @@ Example: `in-comments: mouse` — the "mouse" will be searched only in comment b
 
 Example: `in-users: mouse` — the "mouse" will be searched only in user names, screennames and descriptions.
 
-The global search scope operators switches search scope from itself to the end of the query or to the other global scope operator. 
+The global search scope operators switch the search scope from themselves to the end of the query or to another global scope operator. 
 
 ### Interval operators
 
@@ -78,33 +84,33 @@ Some operators allow to specify the interval of the values. The interval syntax 
 
 ### Local search scope
 
-Local search scope operator are like global ones but without switching the global search scope.
+Local search scope operators are like global ones but without switching the global search scope.
 
 **in-body:word1,word2** or **in-body:"quoted text"** will search _any_ of word1, word2 or the "quoted text" in post body but will not change the global query scope. Note that there is no space after a colon.
 
-**in-comments:word1,word2** or **in-comments:"quoted text"** do the same for comments.
+**in-comments:word1,word2** or **in-comments:"quoted text"** does the same for comments.
 
 Example: `cat in-body:mouse dog` — the "cat" and "dog" will be searched in post and comments but the "mouse" will be searched only in posts.
 
 ### Content filtering
 
-**from:user1,user2** limits search to posts authored by user1 or user2. The `from:alice cat` query will search "cat" in posts authored by Alice _and in any their comments_ (not only in Alice's comments').
+**from:user1,user2** limits search to posts authored by user1 or user2. The `from:alice cat` query will search "cat" in posts authored by Alice _and in any of their comments_ (not only in Alice's comments).
 
 **in:user1,group2** limits search to posts published in user1 or group2 feeds.
 
-`cat in:cats` will find all post with the "cat" word in the @cats group.
+`cat in:cats` will find all posts with the "cat" word in the @cats group.
 
-`cat in:cats from:alice` will find all post with the "cat" word authored by Alice in the @cats group.
+`cat in:cats from:alice` will find all posts with the "cat" word authored by Alice in the @cats group.
 
-`cat in:cats,alice` will find all post with the "cat" word posted to the Alice's own feed OR to the @cats group.
+`cat in:cats,alice` will find all posts with the "cat" word posted to Alice's own feed OR to the @cats group.
 
-`cat in:cats in:alice` will find all post with the "cat" word posted to the Alice's own feed AND to the @cats group.
+`cat in:cats in:alice` will find all posts with the "cat" word posted to Alice's own feed AND to the @cats group.
 
-The "in:" operator has the "group:" alias, it left for compatibility.
+The "in:" operator has the "group:" alias, which is left for compatibility.
 
-**in-my:feed1,feed2** limit search to the current user's personal feeds. The personal feed names are: "saves", "directs", "discussions" and "friends". You can omit the 's suffix in these names. The "friends" feed means all feeds of users and groups current user subscribed to.
+**in-my:feed1,feed2** limits search to the current user's personal feeds. The personal feed names are: "saves", "directs", "discussions" and "friends". You can omit the 's suffix in these names. The "friends" feed means all feeds of users and groups the current user is subscribed to.
 
-`cat in-my:saves` will find all post with the "cat" word in my Saves feed.
+`cat in-my:saves` will find all posts with the "cat" word in my Saves feed.
 
 **commented-by:user1,user2** limits search to posts commented by user1 or user2.
 
@@ -148,6 +154,6 @@ The `post-date:` always sets the post date. The `in-comments: foo post-date:2020
 
 The "content" is defined by the current search scope. By default it is a post and comment bodies: `cat author:alice` will search the "cat" word in all Alice's posts and comments bodies.
 
-`in-body: author:alice cat` will search the "cat" word only in Alice's posts bodies. In this context the 'author:' works in same way as 'from:'.
+`in-body: author:alice cat` will search the "cat" word only in Alice's posts bodies. In this context, 'author:' works in the same way as 'from:'.
 
 `in-comments: author:alice cat` will search the "cat" word only in Alice's comments bodies.

--- a/app/support/search/query-tokens.ts
+++ b/app/support/search/query-tokens.ts
@@ -253,3 +253,24 @@ function exactPhraseToTSQuery(text: string): string {
     text,
   );
 }
+
+/**
+ * Transforms the text-related queries to prefix forms. It is used for username
+ * substring search.
+ */
+export function toPrefixQuery<T extends AnyText | SeqTexts | Text>(token: T): T {
+  if (token instanceof Text) {
+    if (token.phrase || token.text.endsWith('*')) {
+      return token;
+    }
+
+    return new Text(token.exclude, token.phrase, `${token.text}*`) as T;
+  }
+
+  if (token instanceof AnyText) {
+    return new AnyText(token.children.map(toPrefixQuery)) as T;
+  }
+
+  // token instanceof SeqTexts
+  return new SeqTexts(token.children.map(toPrefixQuery)) as T;
+}

--- a/app/support/search/query-tokens.ts
+++ b/app/support/search/query-tokens.ts
@@ -9,11 +9,12 @@ import { linkToText } from './norm';
 
 const ftsCfg = config.postgres.textSearchConfigName;
 
-export type Scope = 1 | 2 | 3;
+export type Scope = 1 | 2 | 4 | 7;
 
-export const IN_POSTS = 1 as Scope,
-  IN_COMMENTS = 2 as Scope,
-  IN_ALL = (IN_POSTS | IN_COMMENTS) as Scope;
+export const IN_POSTS: Scope = 1 as const,
+  IN_COMMENTS: Scope = 2 as const,
+  IN_ACCOUNTS: Scope = 4 as const,
+  IN_ALL: Scope = 7 as const; // = IN_POSTS | IN_COMMENTS | IN_ACCOUNTS
 
 export interface Token {
   getComplexity(): number;
@@ -185,6 +186,7 @@ export class InScope implements Token {
 export const scopeStarts: [RegExp, Scope][] = [
   [/^in-?body$/, IN_POSTS],
   [/^in-?comments?$/, IN_COMMENTS],
+  [/^in-?(user|account)s?$/, IN_ACCOUNTS],
 ];
 
 export const listConditions: [RegExp, string][] = [

--- a/app/support/search/to-tsvector.ts
+++ b/app/support/search/to-tsvector.ts
@@ -68,3 +68,23 @@ export function toTSVector(text: string) {
 
   return `(${vectors.join(' || ')})`;
 }
+
+/**
+ * Prepares suffixes of the text as a tsvector. The suffixes are used for
+ * username substring search.
+ */
+export function toSuffixTSVector(text: string): string {
+  // Leave only alphanumeric characters
+  text = text.toLowerCase().replace(/[^a-z0-9]+/g, '');
+
+  const parts = [];
+
+  // 'apple' should produce ['apple', 'pple', 'ple', 'le']
+  const minLen = 2;
+
+  for (let i = 0; i <= text.length - minLen; i++) {
+    parts.push(`'=${text.substring(i)}':${i + 1}`);
+  }
+
+  return pgFormat(`%L::tsvector`, parts.join(' '));
+}

--- a/bin/reindex_accounts.js
+++ b/bin/reindex_accounts.js
@@ -1,0 +1,148 @@
+/* eslint-disable no-await-in-loop */
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { program } from 'commander';
+
+import { setSearchConfig } from '../app/setup/postgres';
+import { dbAdapter } from '../app/models';
+import { toTSVector, toSuffixTSVector } from '../app/support/search/to-tsvector';
+import { delay } from '../app/support/timers';
+
+// Reindex search columns in 'users' table.
+// Usage: yarn babel bin/reindex_accounts.js --help
+
+const ZERO_UID = '00000000-00000000-00000000-00000000';
+const statusFile = path.join(__dirname, '../tmp/reindex_accounts.json');
+
+program
+  .option('--batch-size <batch size>', 'batch size', (v) => parseInt(v, 10), 1000)
+  .option('--delay <delay>', 'delay between batches, seconds', (v) => parseInt(v, 10), 1)
+  .option('--retries <count>', 'count of retries in case of failure', (v) => parseInt(v, 10), 10)
+  .option('--timeout <timeout>', 'timeout of transaction in PostgreSQL syntax', '1min')
+  .option('--restart', 'start indexing from the beginning');
+program.parse(process.argv);
+
+const [batchSize, delaySec, retries, timeout, restart] = [
+  program.getOptionValue('batchSize'),
+  program.getOptionValue('delay'),
+  program.getOptionValue('retries'),
+  program.getOptionValue('timeout'),
+  program.getOptionValue('restart'),
+];
+
+if (!isFinite(batchSize) || !isFinite(delaySec)) {
+  process.stderr.write(`⛔ Invalid program option\n`);
+  program.help();
+}
+
+process.stdout.write(`Running with batch size of ${batchSize} and delay of ${delaySec}\n`);
+process.stdout.write(`Status file: ${statusFile}\n`);
+process.stdout.write(`\n`);
+
+(async () => {
+  try {
+    await setSearchConfig();
+
+    let lastUID = ZERO_UID;
+
+    if (!restart) {
+      try {
+        const statusText = await fs.readFile(statusFile, { encoding: 'utf8' });
+        ({ lastUID } = JSON.parse(statusText));
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          throw new Error(`Cannot read status from ${statusFile}: ${err.message}`);
+        }
+
+        process.stdout.write(`Status file is not found, starting from the beginning...\n`);
+      }
+    }
+
+    process.stdout.write(`Indexing users starting from ${lastUID}...\n`);
+    let indexed = 0;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { rows } = await dbAdapter.database.raw(
+        `select uid, username, screen_name, description from users where uid > :lastUID order by uid limit :batchSize`,
+        { lastUID, batchSize },
+      );
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      let attemptsLeft = retries;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const start = Date.now();
+
+        try {
+          await dbAdapter.database.transaction(async (trx) => {
+            // Cannot use placeholder here: Postgres doesn't allow prepared statements for 'set'
+            await trx.raw(`set local statement_timeout to '${timeout.replace(/'/g, `''`)}'`);
+            await trx.raw(
+              `create temp table ftsdata (uid uuid, username_vector tsvector, screen_name_vector tsvector, description_vector tsvector) on commit drop`,
+            );
+            await trx('ftsdata').insert(
+              rows.map((r) => ({
+                uid: r.uid,
+                username_vector: trx.raw(toSuffixTSVector(r.username || '').replace(/\?/g, '\\?')),
+                screen_name_vector: trx.raw(toTSVector(r.screen_name || '').replace(/\?/g, '\\?')),
+                description_vector: trx.raw(toTSVector(r.description || '').replace(/\?/g, '\\?')),
+              })),
+            );
+            await trx.raw(
+              `update users set 
+                username_tsvector = username_vector,
+                screen_name_tsvector = screen_name_vector,
+                description_tsvector = description_vector
+              from ftsdata where users.uid = ftsdata.uid`,
+            );
+          });
+
+          indexed += rows.length;
+          lastUID = rows[rows.length - 1].uid;
+
+          const percent = (parseInt(lastUID.substr(0, 2), 16) * 100) >> 8;
+          const speed = Math.round((batchSize * 1000) / (Date.now() - start));
+          process.stdout.write(
+            `\tindexed ${indexed} users at ${speed} upd/sec (${percent}% of total)\n`,
+          );
+
+          await saveStatus(lastUID);
+
+          break;
+        } catch (e) {
+          if (e.code === '57014' /* query_canceled */ && attemptsLeft > 0) {
+            process.stdout.write(`\tquery canceled at ${Date.now() - start} ms, retrying...\n`);
+            attemptsLeft--;
+          } else {
+            throw e;
+          }
+        }
+
+        await delay(1000 * delaySec);
+      }
+    }
+
+    process.stdout.write(`All users indexed, starting VACUUM ANALYZE...\n`);
+    await dbAdapter.database.raw(`vacuum analyze users`);
+    process.stdout.write(`Done with users.\n`);
+
+    process.stdout.write(`All accounts were indexed.\n`);
+    await fs.unlink(statusFile);
+
+    process.exit(0);
+  } catch (e) {
+    process.stderr.write(`⛔ ERROR: ${e.message}\n`);
+    process.exit(1);
+  }
+})();
+
+async function saveStatus(lastUID) {
+  await fs.mkdir(path.dirname(statusFile), { recursive: true });
+  await fs.writeFile(statusFile, JSON.stringify({ lastUID }));
+}

--- a/migrations/20251005203423_users_search.ts
+++ b/migrations/20251005203423_users_search.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+export const up = (knex: Knex) =>
+  knex.schema.raw(`do $$begin 
+        alter table users add column screen_name_tsvector tsvector;
+        alter table users add column description_tsvector tsvector;
+        create index users_screen_name_tsvector_idx on users using gin(screen_name_tsvector);
+        create index users_description_tsvector_idx on users using gin(description_tsvector);
+    end$$`);
+
+export const down = (knex: Knex) =>
+  knex.schema.raw(`do $$begin 
+        alter table users drop column screen_name_tsvector;
+        alter table users drop column description_tsvector;
+    end$$`);

--- a/migrations/20251005203423_users_search.ts
+++ b/migrations/20251005203423_users_search.ts
@@ -2,14 +2,17 @@ import type { Knex } from 'knex';
 
 export const up = (knex: Knex) =>
   knex.schema.raw(`do $$begin 
+        alter table users add column username_tsvector tsvector;
         alter table users add column screen_name_tsvector tsvector;
         alter table users add column description_tsvector tsvector;
+        create index users_username_tsvector_idx on users using gin(username_tsvector);
         create index users_screen_name_tsvector_idx on users using gin(screen_name_tsvector);
         create index users_description_tsvector_idx on users using gin(description_tsvector);
     end$$`);
 
 export const down = (knex: Knex) =>
   knex.schema.raw(`do $$begin 
+        alter table users drop column username_tsvector;
         alter table users drop column screen_name_tsvector;
         alter table users drop column description_tsvector;
     end$$`);

--- a/test/functional/search.js
+++ b/test/functional/search.js
@@ -193,4 +193,34 @@ describe('SearchController', () => {
       });
     });
   });
+  describe('Search in account names and screennames', () => {
+    let luna, mars, post;
+    before(async () => {
+      await cleanDB($pg_database);
+
+      [luna, mars] = await funcTestHelper.createTestUsers(['luna', 'mars']);
+      await luna.user.update({ screenName: 'Quick brown fox' });
+      await mars.user.update({ screenName: 'Lazy dog' });
+
+      post = await funcTestHelper.justCreatePost(luna, 'hello from luna');
+    });
+
+    it('should find account by screen name', async () => {
+      const response = await funcTestHelper.performSearch(luna, 'quick');
+      expect(response, 'to satisfy', {
+        posts: [],
+        foundUsers: [luna.user.id],
+        users: [{ id: luna.user.id, screenName: 'Quick brown fox' }],
+      });
+    });
+
+    it('should find account and post', async () => {
+      const response = await funcTestHelper.performSearch(luna, 'luna');
+      expect(response, 'to satisfy', {
+        posts: [{ id: post.id }],
+        foundUsers: [luna.user.id],
+        users: [{ id: luna.user.id, screenName: 'Quick brown fox' }],
+      });
+    });
+  });
 });

--- a/test/integration/support/DbAdapter/search-in-accounts.js
+++ b/test/integration/support/DbAdapter/search-in-accounts.js
@@ -229,4 +229,45 @@ describe('Search in accounts', () => {
       expect(foundIds.slice(1), 'to contain', user2.id, user3.id);
     });
   });
+
+  describe('Search in usernames', () => {
+    async function createUserWithName(username) {
+      const user = await createUser(username);
+      await user.update({ screenName: 'something unrelated' });
+      return user;
+    }
+
+    it('should find accounts by full username', async () => {
+      const user = await createUserWithName('luna');
+      const foundIds = await dbAdapter.searchInAccounts('luna');
+      expect(foundIds, 'to equal', [user.id]);
+    });
+
+    it('should find accounts by part of username', async () => {
+      const user = await createUserWithName('welovebread');
+      const foundIds = await dbAdapter.searchInAccounts('love');
+      expect(foundIds, 'to equal', [user.id]);
+    });
+
+    it('should use logic in query', async () => {
+      const user1 = await createUserWithName('workworkwork');
+      const user2 = await createUserWithName('lifelifelife');
+      const user3 = await createUserWithName('worklifebalance');
+
+      {
+        const foundIds = await dbAdapter.searchInAccounts('work | life');
+        expect(foundIds.sort(), 'to equal', [user1.id, user2.id, user3.id].sort());
+      }
+
+      {
+        const foundIds = await dbAdapter.searchInAccounts('work | life -balance');
+        expect(foundIds.sort(), 'to equal', [user1.id, user2.id].sort());
+      }
+
+      {
+        const foundIds = await dbAdapter.searchInAccounts('work life');
+        expect(foundIds.sort(), 'to equal', [user3.id].sort());
+      }
+    });
+  });
 });

--- a/test/integration/support/DbAdapter/search-in-accounts.js
+++ b/test/integration/support/DbAdapter/search-in-accounts.js
@@ -118,6 +118,19 @@ describe('Search in accounts', () => {
         const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
         expect(foundIds, 'to contain', privateUser.id);
       });
+
+      it('should find private accounts if they are subscribed to viewer', async () => {
+        await privateUser.subscribeTo(viewer);
+        const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
+        expect(foundIds, 'to contain', privateUser.id);
+      });
+
+      it('should find private accounts with mutual subscription', async () => {
+        await viewer.subscribeTo(privateUser);
+        await privateUser.subscribeTo(viewer);
+        const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
+        expect(foundIds, 'to contain', privateUser.id);
+      });
     });
   });
 

--- a/test/integration/support/DbAdapter/search-in-accounts.js
+++ b/test/integration/support/DbAdapter/search-in-accounts.js
@@ -34,6 +34,21 @@ describe('Search in accounts', () => {
       const foundIds = await dbAdapter.searchInAccounts('brown fox');
       expect(foundIds, 'to equal', [account.id]);
     });
+
+    it('should find account with in-users scope', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('in-users: quick');
+      expect(foundIds, 'to equal', [account.id]);
+    });
+
+    it('should NOT find account with in-body scope', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('in-body: quick');
+      expect(foundIds, 'to equal', []);
+    });
+
+    it('should NOT find account with in-comments scope', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('in-comments: lazy');
+      expect(foundIds, 'to equal', []);
+    });
   });
 
   describe('Privacy restrictions', () => {
@@ -103,6 +118,44 @@ describe('Search in accounts', () => {
         const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
         expect(foundIds, 'to contain', privateUser.id);
       });
+    });
+  });
+
+  describe('Search scope handling', () => {
+    let user1, user2;
+
+    beforeEach(async () => {
+      [user1, user2] = await createUsers(['mercury', 'saturn']);
+
+      await user1.update({
+        screenName: 'Searchable Name',
+        description: 'first account',
+      });
+
+      await user2.update({
+        screenName: 'Another Name',
+        description: 'second account',
+      });
+    });
+
+    it('should find accounts only in in-users scope', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('in-users: searchable');
+      expect(foundIds, 'to equal', [user1.id]);
+    });
+
+    it('should find accounts from in-users scope even after switching', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('in-users: searchable in-body: account');
+      expect(foundIds, 'to equal', [user1.id]);
+    });
+
+    it('should NOT find accounts when text is only in other scope', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('in-body: searchable');
+      expect(foundIds, 'to equal', []);
+    });
+
+    it('should find accounts when switching to in-users scope', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('in-body: something in-users: searchable');
+      expect(foundIds, 'to equal', [user1.id]);
     });
   });
 

--- a/test/integration/support/DbAdapter/search-in-accounts.js
+++ b/test/integration/support/DbAdapter/search-in-accounts.js
@@ -1,0 +1,166 @@
+/* eslint-disable no-await-in-loop */
+/* eslint-env node, mocha */
+/* global $pg_database */
+import expect from 'unexpected';
+
+import cleanDB from '../../../dbCleaner';
+import { dbAdapter } from '../../../../app/models';
+import { createUser, createUsers } from '../../helpers/users';
+
+describe('Search in accounts', () => {
+  beforeEach(() => cleanDB($pg_database));
+
+  describe('Search single account', () => {
+    let account;
+    beforeEach(async () => {
+      account = await createUser('luna');
+      await account.update({
+        screenName: 'Quick brown fox',
+        description: 'jumps over the lazy dog',
+      });
+    });
+
+    it('should find account by screen name', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('quick');
+      expect(foundIds, 'to equal', [account.id]);
+    });
+
+    it('should find account by description', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('lazy');
+      expect(foundIds, 'to equal', [account.id]);
+    });
+
+    it('should find account by multiple words', async () => {
+      const foundIds = await dbAdapter.searchInAccounts('brown fox');
+      expect(foundIds, 'to equal', [account.id]);
+    });
+  });
+
+  describe('Privacy restrictions', () => {
+    let publicUser, protectedUser, privateUser, viewer;
+
+    beforeEach(async () => {
+      [publicUser, protectedUser, privateUser, viewer] = await createUsers([
+        'luna',
+        'mars',
+        'venus',
+        'jupiter',
+      ]);
+
+      await publicUser.update({
+        screenName: 'Public Account',
+        description: 'searchable content',
+      });
+
+      await protectedUser.update({
+        screenName: 'Protected Account',
+        description: 'searchable content',
+        isProtected: '1',
+      });
+
+      await privateUser.update({
+        screenName: 'Private Account',
+        description: 'searchable content',
+        isPrivate: '1',
+      });
+    });
+
+    describe('Anonymous user', () => {
+      it('should find public accounts', async () => {
+        const foundIds = await dbAdapter.searchInAccounts('searchable');
+        expect(foundIds, 'to contain', publicUser.id);
+      });
+
+      it('should find protected accounts', async () => {
+        const foundIds = await dbAdapter.searchInAccounts('searchable');
+        expect(foundIds, 'to contain', protectedUser.id);
+      });
+
+      it('should NOT find private accounts', async () => {
+        const foundIds = await dbAdapter.searchInAccounts('searchable');
+        expect(foundIds, 'not to contain', privateUser.id);
+      });
+    });
+
+    describe('Authenticated user', () => {
+      it('should find public accounts', async () => {
+        const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
+        expect(foundIds, 'to contain', publicUser.id);
+      });
+
+      it('should find protected accounts', async () => {
+        const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
+        expect(foundIds, 'to contain', protectedUser.id);
+      });
+
+      it('should NOT find private accounts if not subscribed', async () => {
+        const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
+        expect(foundIds, 'not to contain', privateUser.id);
+      });
+
+      it('should find private accounts if subscribed', async () => {
+        await viewer.subscribeTo(privateUser);
+        const foundIds = await dbAdapter.searchInAccounts('searchable', { viewerId: viewer.id });
+        expect(foundIds, 'to contain', privateUser.id);
+      });
+    });
+  });
+
+  describe('Sorting by subscribers count', () => {
+    let user1, user2, user3, subscriber1, subscriber2, subscriber3;
+
+    beforeEach(async () => {
+      [user1, user2, user3, subscriber1, subscriber2, subscriber3] = await createUsers([
+        'user1',
+        'user2',
+        'user3',
+        'subscriber1',
+        'subscriber2',
+        'subscriber3',
+      ]);
+
+      await user1.update({
+        screenName: 'Findable User One',
+        description: 'test account',
+      });
+
+      await user2.update({
+        screenName: 'Findable User Two',
+        description: 'test account',
+      });
+
+      await user3.update({
+        screenName: 'Findable User Three',
+        description: 'test account',
+      });
+    });
+
+    it('should sort accounts by subscribers count (descending)', async () => {
+      // user3 has 3 subscribers
+      await subscriber1.subscribeTo(user3);
+      await subscriber2.subscribeTo(user3);
+      await subscriber3.subscribeTo(user3);
+
+      // user1 has 2 subscribers
+      await subscriber1.subscribeTo(user1);
+      await subscriber2.subscribeTo(user1);
+
+      // user2 has 1 subscriber
+      await subscriber1.subscribeTo(user2);
+
+      const foundIds = await dbAdapter.searchInAccounts('findable');
+      expect(foundIds, 'to equal', [user3.id, user1.id, user2.id]);
+    });
+
+    it('should handle accounts with no subscribers', async () => {
+      // user1 has 1 subscriber
+      await subscriber1.subscribeTo(user1);
+
+      // user2 and user3 have no subscribers
+
+      const foundIds = await dbAdapter.searchInAccounts('findable');
+      expect(foundIds[0], 'to equal', user1.id);
+      expect(foundIds.slice(1), 'to contain', user2.id, user3.id);
+    });
+  });
+});

--- a/test/unit/support/search/to-tsvector.ts
+++ b/test/unit/support/search/to-tsvector.ts
@@ -2,7 +2,7 @@
 import expect from 'unexpected';
 import config from 'config';
 
-import { toTSVector } from '../../../../app/support/search/to-tsvector';
+import { toTSVector, toSuffixTSVector } from '../../../../app/support/search/to-tsvector';
 
 const ftsCfg = config.postgres.textSearchConfigName;
 
@@ -92,5 +92,84 @@ describe('toTSVector', () => {
         `'''21612a6d-dbfc-4ff1-9c0b-d41502ad3e63'':2'::tsvector)::tsvector` +
         `)`,
     );
+  });
+});
+
+describe('toSuffixTSVector', () => {
+  it('should return empty string for empty input', () => {
+    expect(toSuffixTSVector(''), 'to be', "''::tsvector");
+  });
+
+  it('should return empty string for single character', () => {
+    expect(toSuffixTSVector('a'), 'to be', "''::tsvector");
+  });
+
+  it('should generate single suffix for 2-character text', () => {
+    expect(toSuffixTSVector('ab'), 'to be', `'''=ab'':1'::tsvector`);
+  });
+
+  it('should generate suffixes for simple text', () => {
+    expect(
+      toSuffixTSVector('apple'),
+      'to be',
+      `'''=apple'':1 ''=pple'':2 ''=ple'':3 ''=le'':4'::tsvector`,
+    );
+  });
+
+  it('should generate suffixes for longer text', () => {
+    expect(
+      toSuffixTSVector('freefeed'),
+      'to be',
+      `'''=freefeed'':1 ''=reefeed'':2 ''=eefeed'':3 ''=efeed'':4 ''=feed'':5 ''=eed'':6 ''=ed'':7'::tsvector`,
+    );
+  });
+
+  it('should remove non-alphanumeric characters', () => {
+    expect(
+      toSuffixTSVector('hello-world'),
+      'to be',
+      `'''=helloworld'':1 ''=elloworld'':2 ''=lloworld'':3 ''=loworld'':4 ''=oworld'':5 ''=world'':6 ''=orld'':7 ''=rld'':8 ''=ld'':9'::tsvector`,
+    );
+  });
+
+  it('should convert to lowercase', () => {
+    expect(
+      toSuffixTSVector('Apple'),
+      'to be',
+      `'''=apple'':1 ''=pple'':2 ''=ple'':3 ''=le'':4'::tsvector`,
+    );
+  });
+
+  it('should handle mixed case with special characters', () => {
+    expect(
+      toSuffixTSVector('FreeFeed'),
+      'to be',
+      `'''=freefeed'':1 ''=reefeed'':2 ''=eefeed'':3 ''=efeed'':4 ''=feed'':5 ''=eed'':6 ''=ed'':7'::tsvector`,
+    );
+  });
+
+  it('should handle text with only special characters', () => {
+    expect(toSuffixTSVector('!!!@@@###'), 'to be', "''::tsvector");
+  });
+
+  it('should handle text with numbers', () => {
+    expect(
+      toSuffixTSVector('user123'),
+      'to be',
+      `'''=user123'':1 ''=ser123'':2 ''=er123'':3 ''=r123'':4 ''=123'':5 ''=23'':6'::tsvector`,
+    );
+  });
+
+  it('should handle username-like strings', () => {
+    expect(
+      toSuffixTSVector('john_doe'),
+      'to be',
+      `'''=johndoe'':1 ''=ohndoe'':2 ''=hndoe'':3 ''=ndoe'':4 ''=doe'':5 ''=oe'':6'::tsvector`,
+    );
+  });
+
+  it('should handle short usernames', () => {
+    expect(toSuffixTSVector('ab'), 'to be', `'''=ab'':1'::tsvector`);
+    expect(toSuffixTSVector('abc'), 'to be', `'''=abc'':1 ''=bc'':2'::tsvector`);
   });
 });


### PR DESCRIPTION
### Added
- Account search functionality: users and groups can now be found by their usernames, screennames, and descriptions. The search is performed in parallel with post and comment search.

  Username search has some limitations compared to post/comment search:
  - Morphology is not used
  - Usernames are searched by _substrings_ (e.g., username `badapple` will be found by queries `bad`, `apple`, `apple bad`, or `apple | pear -good`)
  - Only the _and_, _or_, and _not_ operators are supported (other operators are ignored)

  The search API response now includes new `foundUsers` field: an array of user/group IDs found by the search query

  Private accounts are included in search results only if the viewer is subscribed to them or vice versa.

  **After upgrading from 2.25.x**, it is recommended to run the `bin/reindex_accounts.js` script to build search indexes for existing accounts:
  ```
  yarn babel bin/reindex_accounts.js
  ```
