### PR TITLE
Filter out deleted comments from `GET /vN/comments/by-ids` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.26.0] - Not released
+### Fixed
+- Filter out deleted comments from `GET /vN/comments/by-ids` endpoint.
 
 ## [2.25.2] - 2025-09-21
 ### Fixed

--- a/app/controllers/api/v1/CommentsController.js
+++ b/app/controllers/api/v1/CommentsController.js
@@ -150,7 +150,7 @@ export const getByIds = compose([
       commentIds.length = maxCommentsByIds;
     }
 
-    const allComments = await dbAdapter.getCommentsByIds(commentIds);
+    const allComments = (await dbAdapter.getCommentsByIds(commentIds)).filter((c) => !c.toDelete);
     const postIds = uniq(allComments.map((c) => c.postId));
 
     const visiblePostIds = await dbAdapter.selectPostsVisibleByUser(postIds, viewer?.id);

--- a/app/support/DbAdapter/visibility.js
+++ b/app/support/DbAdapter/visibility.js
@@ -185,6 +185,26 @@ const visibilityTrait = (superClass) =>
       return m.get(commentId) ?? null;
     }
 
+    /**
+     * Check if comments are banned (hidden) for the given viewer and return a
+     * map of comment IDs to arrays of hide types.
+     *
+     * This method checks ban relationships between the viewer and comment
+     * authors according to the visibility rules. Comments in 'to_delete' status
+     * are excluded from the result.
+     *
+     * See doc/visibility-rules.md for the visibility rules details.
+     *
+     * @param {string[]} commentIds - Array of comment UUIDs to check
+     * @param {string|null} viewerId - Viewer's user UUID, or null for anonymous
+     * viewer
+     * @returns {Promise<Map<string, number[]>>} Map where keys are comment
+     *   UUIDs and values are arrays of hide type constants:
+     *   - Comment.HIDDEN_AUTHOR_BANNED: comment author is banned by viewer
+     *   - Comment.HIDDEN_VIEWER_BANNED: viewer is banned by comment author
+     *
+     * Only comments that should be hidden are included in the map.
+     */
     async areCommentsBannedForViewerAssoc(commentIds, viewerId = null) {
       const bannedSQLsFabric = await this.bannedActionsSQLsFabric(viewerId);
       const [bannedByViewerSQL, bannedByAuthorSQL] = bannedSQLsFabric('c');

--- a/test/functional/comments.js
+++ b/test/functional/comments.js
@@ -579,9 +579,14 @@ describe('CommentsController', () => {
       comments = [];
 
       for (let n = 0; n < nComments; n++) {
+        const author = n % 2 == 0 ? luna : mars;
         comments.push(
           // eslint-disable-next-line no-await-in-loop
-          await funcTestHelper.justCreateComment(n % 2 == 0 ? luna : mars, post.id, 'Comment'),
+          await funcTestHelper.justCreateComment(
+            author,
+            post.id,
+            `Comment from ${author.username}`,
+          ),
         );
       }
 
@@ -631,6 +636,113 @@ describe('CommentsController', () => {
         );
         expect(resp, 'to satisfy', {
           comments: commentIds.map((id, i) => ({ id, hideType: i % 2 === 1 ? 0 : 2 })),
+        });
+      });
+    });
+
+    describe('Visibility restrictions', () => {
+      let jupiter, privatePost, privateComments;
+
+      beforeEach(async () => {
+        // Create Jupiter who will have a private post
+        [jupiter] = await funcTestHelper.createTestUsers(['jupiter']);
+        await funcTestHelper.goPrivate(jupiter);
+
+        // Create a private post with comments
+        privatePost = await funcTestHelper.justCreatePost(jupiter, 'Private post');
+        privateComments = [];
+
+        for (let n = 0; n < 3; n++) {
+          privateComments.push(
+            // eslint-disable-next-line no-await-in-loop
+            await funcTestHelper.justCreateComment(jupiter, privatePost.id, `Private comment ${n}`),
+          );
+        }
+      });
+
+      it('should not return comments from private post for non-subscriber', async () => {
+        const commentIds = privateComments.map((c) => c.id);
+        const resp = await funcTestHelper.performJSONRequest(
+          'POST',
+          '/v2/comments/byIds',
+          {
+            commentIds,
+          },
+          funcTestHelper.authHeaders(luna),
+        );
+        expect(resp, 'to satisfy', {
+          comments: [],
+          commentsNotFound: commentIds,
+        });
+      });
+
+      it('should not return comments when viewer is banned by comment author', async () => {
+        // Mars bans Luna
+        await banUser(mars, luna);
+
+        // Try to get Mars's comments as Luna
+        const marsCommentIds = comments.filter((c, i) => i % 2 === 0).map((c) => c.id);
+        const resp = await funcTestHelper.performJSONRequest(
+          'POST',
+          '/v2/comments/byIds',
+          {
+            commentIds: marsCommentIds,
+          },
+          funcTestHelper.authHeaders(luna),
+        );
+
+        // Comments should be returned as hidden (hideType: Comment.HIDDEN_VIEWER_BANNED)
+        expect(resp, 'to satisfy', {
+          comments: marsCommentIds.map((id) => ({ id, hideType: Comment.HIDDEN_VIEWER_BANNED })),
+        });
+      });
+
+      it('should not return comments from post by banned author', async () => {
+        // Luna bans Venus (post author)
+        await banUser(luna, venus);
+
+        // Try to get all comments from Venus's post as Luna
+        const commentIds = comments.map((c) => c.id);
+        const resp = await funcTestHelper.performJSONRequest(
+          'POST',
+          '/v2/comments/byIds',
+          {
+            commentIds,
+          },
+          funcTestHelper.authHeaders(luna),
+        );
+
+        // All comments should be unavailable because the post itself is not visible
+        expect(resp, 'to satisfy', {
+          comments: [],
+          commentsNotFound: commentIds,
+        });
+      });
+
+      it('should not return deleted comments', async () => {
+        // Delete some comments
+        const [commentToDelete1, , commentToDelete2] = comments;
+
+        await funcTestHelper.removeCommentAsync(venus, commentToDelete1.id);
+        await funcTestHelper.removeCommentAsync(venus, commentToDelete2.id);
+
+        // Try to get all comments including deleted ones
+        const commentIds = comments.map((c) => c.id);
+        const resp = await funcTestHelper.performJSONRequest(
+          'POST',
+          '/v2/comments/byIds',
+          {
+            commentIds,
+          },
+          funcTestHelper.authHeaders(luna),
+        );
+
+        // Deleted comments should not be returned
+        expect(resp, 'to satisfy', {
+          comments: commentIds
+            .filter((id) => id !== commentToDelete1.id && id !== commentToDelete2.id)
+            .map((id) => ({ id })),
+          commentsNotFound: [commentToDelete1.id, commentToDelete2.id],
         });
       });
     });


### PR DESCRIPTION
### Fixed
- Filter out deleted comments from `GET /vN/comments/by-ids` endpoint.
