### PR TITLE
Pause accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.28.0] - Not released
+### Added
+- Account pause functionality: users can now pause their accounts with an optional
+  custom message that will be displayed in their profile.
+
+  New endpoint `POST /v1/users/pause-me` allows users to pause their account:
+  ```json
+  {
+    "password": "user-password",
+    "message": "Taking a break until February" // optional
+  }
+  ```
+
+  When an account is paused:
+  - The account receives `GONE_PAUSED` status (value: 15)
+  - The account can be resumed using the existing `POST /v1/users/resume-me` endpoint
+  - The pause message (if provided) is displayed in the user's `description` field
+  - User data is not deleted (unlike suspended accounts)
+
+- New `goneStatus` field in user serialization: inactive users now include a
+  `goneStatus` field in their API representation with one of three values:
+  - `"paused"` - account is paused by the user (status `GONE_PAUSED`)
+  - `"suspended"` - account is suspended (status `GONE_SUSPENDED`)
+  - `"deleted"` - account is in deletion process or deleted (statuses `GONE_COOLDOWN`,
+    `GONE_DELETION`, or `GONE_DELETED`)
+
+  This allows clients to distinguish between different types of inactive accounts
+  and display appropriate messages to users.
+
+  Example response:
+  ```json
+  {
+    "users": {
+      "id": "...",
+      "username": "luna",
+      "isGone": true,
+      "goneStatus": "paused",
+      "description": "Taking a break until February"
+    }
+  }
+  ```
 
 ## [2.27.0] - 2025-12-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The account can be resumed using the existing `POST /v1/users/resume-me` endpoint
   - The pause message (if provided) is displayed in the user's `description` field
   - User data is not deleted (unlike suspended accounts)
+  - The user receives an initial confirmation email
+  - Monthly reminder emails are sent to the user's email address with instructions
+    on how to resume or permanently delete the account
 
 - New `goneStatus` field in user serialization: inactive users now include a
   `goneStatus` field in their API representation with one of three values:

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -34,7 +34,7 @@ import {
 import { UsersControllerV2 } from '../../../controllers';
 import { profileCache } from '../../../support/ExtAuth';
 import { downloadURL } from '../../../support/download-url';
-import { GONE_COOLDOWN } from '../../../models/user';
+import { GONE_COOLDOWN, GONE_PAUSED } from '../../../models/user';
 
 import {
   userCreateInputSchema,
@@ -42,6 +42,7 @@ import {
   updateSubscriptionInputSchema,
   sendRequestInputSchema,
   userSuspendMeInputSchema,
+  userPauseMeInputSchema,
   userResumeMeInputSchema,
 } from './data-schemes';
 
@@ -381,6 +382,28 @@ export default class UsersController {
 
       await user.setGoneStatus(GONE_COOLDOWN);
       ctx.body = { message: 'Your account has been suspended' };
+    },
+  ]);
+
+  static pauseMe = compose([
+    authRequired(),
+    inputSchemaRequired(userPauseMeInputSchema),
+    monitored('users.pause-me'),
+    async (ctx) => {
+      const { user } = ctx.state;
+      const { password, message } = ctx.request.body;
+
+      if (!(await user.validPassword(password))) {
+        throw new ForbiddenException('Provided password is invalid');
+      }
+
+      await user.setGoneStatus(GONE_PAUSED);
+
+      if (message !== undefined) {
+        await user.setPauseMessage(message);
+      }
+
+      ctx.body = { message: 'Your account has been paused' };
     },
   ]);
 

--- a/app/controllers/api/v1/UsersController.js
+++ b/app/controllers/api/v1/UsersController.js
@@ -397,11 +397,11 @@ export default class UsersController {
         throw new ForbiddenException('Provided password is invalid');
       }
 
-      await user.setGoneStatus(GONE_PAUSED);
-
       if (message !== undefined) {
         await user.setPauseMessage(message);
       }
+
+      await user.setGoneStatus(GONE_PAUSED);
 
       ctx.body = { message: 'Your account has been paused' };
     },

--- a/app/controllers/api/v1/data-schemes/index.js
+++ b/app/controllers/api/v1/data-schemes/index.js
@@ -7,5 +7,6 @@ export {
   updateSubscriptionInputSchema,
   sendRequestInputSchema,
   userSuspendMeInputSchema,
+  userPauseMeInputSchema,
   userResumeMeInputSchema,
 } from './users';

--- a/app/controllers/api/v1/data-schemes/users.js
+++ b/app/controllers/api/v1/data-schemes/users.js
@@ -86,6 +86,24 @@ export const userSuspendMeInputSchema = {
   },
 };
 
+export const userPauseMeInputSchema = {
+  $schema: 'http://json-schema.org/schema#',
+
+  type: 'object',
+  required: ['password'],
+
+  properties: {
+    password: {
+      type: 'string',
+      description: 'Current user password',
+    },
+    message: {
+      type: 'string',
+      description: 'Optional pause message to display in profile',
+    },
+  },
+};
+
 export const userResumeMeInputSchema = {
   $schema: 'http://json-schema.org/schema#',
 

--- a/app/jobs/user-gone.js
+++ b/app/jobs/user-gone.js
@@ -2,7 +2,7 @@ import config from 'config';
 import { DateTime } from 'luxon';
 
 import { Job, dbAdapter } from '../models';
-import { GONE_COOLDOWN, GONE_DELETION, GONE_DELETED } from '../models/user';
+import { GONE_COOLDOWN, GONE_DELETION, GONE_DELETED, GONE_PAUSED } from '../models/user';
 import Mailer from '../../lib/mailer';
 import { deleteAllUserData } from '../../app/support/user-deletion';
 
@@ -11,11 +11,23 @@ export const USER_COOLDOWN_START = 'USER_COOLDOWN_START';
 export const USER_COOLDOWN_REMINDER = 'USER_COOLDOWN_REMINDER';
 export const USER_DELETION_START = 'USER_DELETION_START';
 export const USER_DELETE_DATA = 'USER_DELETE_DATA';
+export const USER_PAUSED_START = 'USER_PAUSED_START';
 
 // Job creators
 export function userCooldownStart(user) {
   return Job.create(
     USER_COOLDOWN_START,
+    {
+      id: user.id,
+      goneAt: user.goneAt.getTime(),
+    },
+    { uniqKey: user.id },
+  );
+}
+
+export function userPausedStart(user) {
+  return Job.create(
+    USER_PAUSED_START,
     {
       id: user.id,
       goneAt: user.goneAt.getTime(),
@@ -63,6 +75,20 @@ export function initHandlers(jobManager) {
           { unlockAt: deletionDate(user), uniqKey: user.id },
         ),
       ]);
+    }),
+  );
+
+  jobManager.on(
+    USER_PAUSED_START,
+    checkUserStatus(GONE_PAUSED, async (user) => {
+      // Send email to user
+      await Mailer.sendMail(
+        // User is gone so the regular .email field is empty
+        { screenName: user.screenName, email: user.hiddenEmail },
+        'You have paused your account',
+        { user },
+        `${config.appRoot}/app/scripts/views/mailer/user-pause-start.ejs`,
+      );
     }),
   );
 

--- a/app/jobs/user-gone.js
+++ b/app/jobs/user-gone.js
@@ -12,6 +12,7 @@ export const USER_COOLDOWN_REMINDER = 'USER_COOLDOWN_REMINDER';
 export const USER_DELETION_START = 'USER_DELETION_START';
 export const USER_DELETE_DATA = 'USER_DELETE_DATA';
 export const USER_PAUSED_START = 'USER_PAUSED_START';
+export const USER_PAUSED_REMINDER = 'USER_PAUSED_REMINDER';
 
 // Job creators
 export function userCooldownStart(user) {
@@ -89,6 +90,31 @@ export function initHandlers(jobManager) {
         { user },
         `${config.appRoot}/app/scripts/views/mailer/user-pause-start.ejs`,
       );
+
+      // Schedule monthly reminder
+      await Job.create(
+        USER_PAUSED_REMINDER,
+        { id: user.id, goneAt: user.goneAt.getTime() },
+        { unlockAt: pauseReminderDate(user), uniqKey: user.id },
+      );
+    }),
+  );
+
+  jobManager.on(
+    USER_PAUSED_REMINDER,
+    checkUserStatus(GONE_PAUSED, async (user, job) => {
+      // Send reminder email to user
+      await Mailer.sendMail(
+        // User is gone so the regular .email field is empty
+        { screenName: user.screenName, email: user.hiddenEmail },
+        'Your account is still paused',
+        { user },
+        `${config.appRoot}/app/scripts/views/mailer/user-pause-reminder.ejs`,
+      );
+
+      // Schedule next monthly reminder
+      await job.relock(pauseReminderDate(user, 1));
+      await job.keep();
     }),
   );
 
@@ -168,4 +194,15 @@ export function deletionDate(user) {
   return DateTime.fromJSDate(user.goneAt)
     .plus({ days: config.userDeletion.cooldownDays })
     .toJSDate();
+}
+
+export function pauseReminderDate(user, monthsFromNow = 1) {
+  return (
+    DateTime.fromJSDate(user.goneAt)
+      .setZone(config.ianaTimeZone)
+      // Schedule reminder to 9:00
+      .startOf('day')
+      .plus({ months: monthsFromNow, hours: 9 })
+      .toJSDate()
+  );
 }

--- a/app/models/auth-tokens/app-tokens-scopes.ts
+++ b/app/models/auth-tokens/app-tokens-scopes.ts
@@ -47,6 +47,7 @@ export const alwaysDisallowedRoutes = [
   'POST /vN/ext-auth/auth-finish',
   // User suspend/resume
   'POST /vN/users/suspend-me',
+  'POST /vN/users/pause-me',
   'POST /vN/users/resume-me',
   // User creation
   'POST /vN/users',

--- a/app/models/user-prefs.ts
+++ b/app/models/user-prefs.ts
@@ -61,6 +61,11 @@ const schema = {
       title: 'Notify of all comments on posts commented by me',
       type: 'boolean',
     },
+    pauseMessage: {
+      title: 'Message to display when account is paused',
+      type: 'string',
+      maxLength: 1500,
+    },
   },
   additionalProperties: false,
 };

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -18,7 +18,7 @@ import { s3Client } from '../support/s3';
 import { BadRequestException, NotFoundException, ValidationException } from '../support/exceptions';
 import { Comment, Post, PubSub as pubSub } from '../models';
 import { EventService } from '../support/EventService';
-import { userCooldownStart, userDataDeletionStart } from '../jobs/user-gone';
+import { userCooldownStart, userDataDeletionStart, userPausedStart } from '../jobs/user-gone';
 import { allExternalProviders } from '../support/ExtAuth';
 import { spawnAsync } from '../support/spawn-async';
 
@@ -30,7 +30,9 @@ const randomBytes = util.promisify(crypto.randomBytes);
 
 // Account is suspended for unknown period
 export const GONE_SUSPENDED = 10;
-// Account is suspended for cooldown period, the next state is GONE_DELETION
+// Account is paused by user themself, and can be resumed
+export const GONE_PAUSED = 15;
+// Account is suspended for cooldown period (can be resumed), the next state is GONE_DELETION
 export const GONE_COOLDOWN = 20;
 // Cooldown period is over, user data is being deleted, the next state is GONE_DELETED
 export const GONE_DELETION = 30;
@@ -39,6 +41,7 @@ export const GONE_DELETED = 40;
 
 export const GONE_NAMES = {
   [GONE_SUSPENDED]: 'SUSPENDED',
+  [GONE_PAUSED]: 'PAUSED',
   [GONE_COOLDOWN]: 'COOLDOWN',
   [GONE_DELETION]: 'DELETION',
   [GONE_DELETED]: 'DELETED',
@@ -206,7 +209,7 @@ export function addModel(dbAdapter) {
      * User.isResumable is true if user is gone but can be resumed
      */
     get isResumable() {
-      return [GONE_COOLDOWN].includes(this.goneStatus);
+      return [GONE_COOLDOWN, GONE_PAUSED].includes(this.goneStatus);
     }
 
     static stopList(skipExtraList) {
@@ -558,6 +561,10 @@ export function addModel(dbAdapter) {
 
       if (status === GONE_COOLDOWN) {
         await userCooldownStart(this);
+      }
+
+      if (status === GONE_PAUSED) {
+        await userPausedStart(this);
       }
 
       if (status === GONE_DELETION) {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -578,6 +578,38 @@ export function addModel(dbAdapter) {
       await Promise.all(managedGroupIds.map((id) => pubSub.globalUserUpdate(id)));
     }
 
+    /**
+     * Set or clear pause message for the user
+     * @param {string|null} message - Pause message text or null to clear
+     */
+    async setPauseMessage(message) {
+      if (message === null) {
+        await dbAdapter.setUserSysPrefs(this.id, 'pauseMessage', null);
+        return;
+      }
+
+      const trimmedMessage = message.trim();
+
+      if (!trimmedMessage) {
+        await dbAdapter.setUserSysPrefs(this.id, 'pauseMessage', null);
+        return;
+      }
+
+      if (trimmedMessage.length > 1500) {
+        throw new ValidationException('Pause message is too long (max 1500 characters)');
+      }
+
+      await dbAdapter.setUserSysPrefs(this.id, 'pauseMessage', trimmedMessage);
+    }
+
+    /**
+     * Get pause message for the user
+     * @returns {Promise<string|null>}
+     */
+    async getPauseMessage() {
+      return await dbAdapter.getUserSysPrefs(this.id, 'pauseMessage', null);
+    }
+
     get goneStatusName() {
       if (this.goneStatus === null) {
         return 'ACTIVE';

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -81,6 +81,9 @@ export function addModel(dbAdapter) {
       this.description = params.description || '';
       this.frontendPreferences = params.frontendPreferences || {};
       this.preferences = validateUserPrefs(params.preferences, true, params.createdAt);
+      // The .hiddenPauseMessage field holds pause message for inactive users
+      // Must be set after validateUserPrefs to get the validated value
+      this.hiddenPauseMessage = this.preferences?.pauseMessage || '';
 
       this.isPrivate = params.isPrivate;
       this.isProtected = this.isPrivate === '1' ? '1' : params.isProtected;
@@ -583,15 +586,14 @@ export function addModel(dbAdapter) {
      * @param {string|null} message - Pause message text or null to clear
      */
     async setPauseMessage(message) {
-      if (message === null) {
-        await dbAdapter.setUserSysPrefs(this.id, 'pauseMessage', null);
-        return;
-      }
+      const prefs = this.preferences || {};
 
-      const trimmedMessage = message.trim();
+      const trimmedMessage = message?.trim() ?? '';
 
       if (!trimmedMessage) {
-        await dbAdapter.setUserSysPrefs(this.id, 'pauseMessage', null);
+        delete prefs.pauseMessage;
+        await dbAdapter.updateUser(this.id, { preferences: prefs });
+        this.preferences = prefs;
         return;
       }
 
@@ -599,15 +601,21 @@ export function addModel(dbAdapter) {
         throw new ValidationException('Pause message is too long (max 1500 characters)');
       }
 
-      await dbAdapter.setUserSysPrefs(this.id, 'pauseMessage', trimmedMessage);
+      prefs.pauseMessage = trimmedMessage;
+      await dbAdapter.updateUser(this.id, { preferences: prefs });
+      this.preferences = prefs;
     }
 
     /**
      * Get pause message for the user
-     * @returns {Promise<string|null>}
+     * @returns {string|null}
      */
-    async getPauseMessage() {
-      return await dbAdapter.getUserSysPrefs(this.id, 'pauseMessage', null);
+    getPauseMessage() {
+      if (!this.isActive) {
+        return this.hiddenPauseMessage || null;
+      }
+
+      return this.preferences?.pauseMessage || null;
     }
 
     get goneStatusName() {

--- a/app/routes/api/v1/UsersRoute.js
+++ b/app/routes/api/v1/UsersRoute.js
@@ -11,6 +11,7 @@ export default function addRoutes(app) {
   app.post('/users/:username/sendRequest', UsersController.sendRequest);
   app.get('/users/me', UsersController.showMe);
   app.post('/users/suspend-me', UsersController.suspendMe);
+  app.post('/users/pause-me', UsersController.pauseMe);
   app.post('/users/resume-me', UsersController.resumeMe);
   app.get('/users/:username', UsersController.show);
   app.put('/users/updatePassword', UsersController.updatePassword);

--- a/app/scripts/views/mailer/user-pause-reminder.ejs
+++ b/app/scripts/views/mailer/user-pause-reminder.ejs
@@ -1,0 +1,15 @@
+Your account is still paused
+-------------------------------
+
+Your account @<%=user.username %> has been paused since <%= user.goneAt.toLocaleDateString() %>.
+
+This is a reminder that you can resume your account at any time, 
+or delete it permanently if you no longer need it. 
+
+To resume your account, enter your username/email and password 
+in <%= config.mailer.host %>/signin and follow the instructions. 
+
+To delete your account permanently, you can do so by logging in 
+and going to Settings.
+
+<%= config.siteTitle %> Team

--- a/app/scripts/views/mailer/user-pause-start.ejs
+++ b/app/scripts/views/mailer/user-pause-start.ejs
@@ -1,0 +1,10 @@
+You have paused your account
+-------------------------------
+
+Your account @<%= user.username %> has been paused by your request. You can
+resume your account any time before. 
+
+To resume your account, enter your username/email and password in <%=
+config.mailer.host %>/signin and follow the instructions.
+
+<%= config.siteTitle %> Team

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -1,6 +1,7 @@
 import { pick, uniq } from 'lodash';
 
 import { User, dbAdapter } from '../../models';
+import { GONE_PAUSED, GONE_SUSPENDED } from '../../models/user';
 
 /**
  * @typedef { import('../../support/types').UUID } UUID
@@ -54,6 +55,14 @@ function pickAccountProps(user) {
 
   if (!user.isActive) {
     s.isGone = true;
+
+    if (user.goneStatus === GONE_PAUSED) {
+      s.goneStatus = 'paused';
+    } else if (user.goneStatus === GONE_SUSPENDED) {
+      s.goneStatus = 'suspended';
+    } else {
+      s.goneStatus = 'deleted';
+    }
   }
 
   return s;
@@ -119,9 +128,29 @@ export async function serializeUsersByIds(userIds, viewerId = null, withAdmins =
   const groupIds = allUserIds.filter((id) => usersAssoc[id]?.type === 'group');
   const blockedInGroups = viewerId ? await dbAdapter.groupIdsBlockedUser(viewerId, groupIds) : [];
 
+  // Load pause messages for GONE_PAUSED users
+  const pausedUserIds = allUserIds.filter(
+    (id) => usersAssoc[id]?.goneStatus === GONE_PAUSED && usersAssoc[id]?.type === 'user',
+  );
+  const pauseMessages = {};
+
+  if (pausedUserIds.length > 0) {
+    await Promise.all(
+      pausedUserIds.map(async (id) => {
+        pauseMessages[id] = await dbAdapter.getUserSysPrefs(id, 'pauseMessage', null);
+      }),
+    );
+  }
+
   // Serialize
   return allUserIds.map((id) => {
     const obj = pickAccountProps(usersAssoc[id]);
+
+    // Add pause message to description for GONE_PAUSED users
+    if (pauseMessages[id]) {
+      obj.description = pauseMessages[id];
+    }
+
     obj.statistics = (!obj.isGone && statsAssoc[id]) || defaultStats;
 
     if (obj.type === 'group') {

--- a/app/serializers/v2/user.js
+++ b/app/serializers/v2/user.js
@@ -128,27 +128,15 @@ export async function serializeUsersByIds(userIds, viewerId = null, withAdmins =
   const groupIds = allUserIds.filter((id) => usersAssoc[id]?.type === 'group');
   const blockedInGroups = viewerId ? await dbAdapter.groupIdsBlockedUser(viewerId, groupIds) : [];
 
-  // Load pause messages for GONE_PAUSED users
-  const pausedUserIds = allUserIds.filter(
-    (id) => usersAssoc[id]?.goneStatus === GONE_PAUSED && usersAssoc[id]?.type === 'user',
-  );
-  const pauseMessages = {};
-
-  if (pausedUserIds.length > 0) {
-    await Promise.all(
-      pausedUserIds.map(async (id) => {
-        pauseMessages[id] = await dbAdapter.getUserSysPrefs(id, 'pauseMessage', null);
-      }),
-    );
-  }
-
   // Serialize
   return allUserIds.map((id) => {
     const obj = pickAccountProps(usersAssoc[id]);
 
     // Add pause message to description for GONE_PAUSED users
-    if (pauseMessages[id]) {
-      obj.description = pauseMessages[id];
+    const pauseMessage = usersAssoc[id]?.getPauseMessage?.();
+
+    if (usersAssoc[id]?.goneStatus === GONE_PAUSED && pauseMessage) {
+      obj.description = pauseMessage;
     }
 
     obj.statistics = (!obj.isGone && statsAssoc[id]) || defaultStats;

--- a/config/default.js
+++ b/config/default.js
@@ -434,6 +434,8 @@ config.userPreferences = {
     notifyOfCommentsOnMyPosts: false,
     // Notify of all comments on posts commented by me
     notifyOfCommentsOnCommentedPosts: false,
+    // Message to display when account is paused
+    pauseMessage: '',
   },
   /**
    *  Here you can override the default values depending on the 'createdAt' time

--- a/test/functional/gone-users.js
+++ b/test/functional/gone-users.js
@@ -568,6 +568,59 @@ describe('Gone users', () => {
       }
     });
 
+    it(`should allow Luna to pause themself without message`, async () => {
+      await setGoneStatus(luna, null);
+
+      {
+        const resp = await performJSONRequest(
+          'POST',
+          `/v1/users/pause-me`,
+          { password: luna.password },
+          authHeaders(luna),
+        );
+        expect(resp, 'to satisfy', { __httpCode: 200, message: /paused/ });
+      }
+
+      {
+        const resp = await performJSONRequest('GET', `/v1/users/${luna.username}`);
+        expect(resp, 'to satisfy', { users: { isGone: true, goneStatus: 'paused' } });
+      }
+    });
+
+    it(`should allow Luna to pause themself with message`, async () => {
+      await setGoneStatus(luna, null);
+      const pauseMessage = 'Taking a break until next month';
+
+      {
+        const resp = await performJSONRequest(
+          'POST',
+          `/v1/users/pause-me`,
+          { password: luna.password, message: pauseMessage },
+          authHeaders(luna),
+        );
+        expect(resp, 'to satisfy', { __httpCode: 200, message: /paused/ });
+      }
+
+      {
+        const resp = await performJSONRequest('GET', `/v1/users/${luna.username}`);
+        expect(resp, 'to satisfy', {
+          users: { isGone: true, goneStatus: 'paused', description: pauseMessage },
+        });
+      }
+    });
+
+    it(`should not allow Luna to pause with wrong password`, async () => {
+      await setGoneStatus(luna, null);
+
+      const resp = await performJSONRequest(
+        'POST',
+        `/v1/users/pause-me`,
+        { password: 'wrong-password' },
+        authHeaders(luna),
+      );
+      expect(resp, 'to satisfy', { __httpCode: 403 });
+    });
+
     it(`should not allow Luna to start session but return token to resume`, async () => {
       const resp = await performJSONRequest('POST', `/v1/session`, {
         username: luna.username,

--- a/test/functional/gone-users.js
+++ b/test/functional/gone-users.js
@@ -63,7 +63,15 @@ describe('Gone users', () => {
       const resp = await performJSONRequest('GET', `/v2/timelines/${luna.username}`);
       expect(resp, 'to satisfy', {
         timelines: { posts: [], subscribers: [] },
-        users: [{ id: luna.user.id, isProtected: '1', isPrivate: '1', isGone: true }],
+        users: [
+          {
+            id: luna.user.id,
+            isProtected: '1',
+            isPrivate: '1',
+            isGone: true,
+            goneStatus: 'deleted',
+          },
+        ],
         subscriptions: [],
         subscribers: [],
         posts: [],
@@ -79,7 +87,15 @@ describe('Gone users', () => {
       );
       expect(resp, 'to satisfy', {
         timelines: { posts: [], subscribers: [] },
-        users: [{ id: luna.user.id, isProtected: '1', isPrivate: '1', isGone: true }],
+        users: [
+          {
+            id: luna.user.id,
+            isProtected: '1',
+            isPrivate: '1',
+            isGone: true,
+            goneStatus: 'deleted',
+          },
+        ],
         subscriptions: [],
         subscribers: [],
         posts: [],
@@ -247,7 +263,7 @@ describe('Gone users', () => {
             setGoneStatus(luna, GONE_SUSPENDED),
           );
           await expect(test, 'when fulfilled', 'to satisfy', {
-            user: { id: luna.user.id, isGone: true },
+            user: { id: luna.user.id, isGone: true, goneStatus: 'suspended' },
           });
         }
       });
@@ -266,7 +282,7 @@ describe('Gone users', () => {
             setGoneStatus(luna, GONE_SUSPENDED),
           );
           await expect(test, 'when fulfilled', 'to satisfy', [
-            { user: { id: luna.user.id, isGone: true } },
+            { user: { id: luna.user.id, isGone: true, goneStatus: 'suspended' } },
             { user: { id: selenites.group.id, isRestricted: '1' } },
           ]);
         });
@@ -548,7 +564,7 @@ describe('Gone users', () => {
 
       {
         const resp = await performJSONRequest('GET', `/v1/users/${luna.username}`);
-        expect(resp, 'to satisfy', { users: { isGone: true } });
+        expect(resp, 'to satisfy', { users: { isGone: true, goneStatus: 'deleted' } });
       }
     });
 

--- a/test/integration/models/user/gone.js
+++ b/test/integration/models/user/gone.js
@@ -25,6 +25,7 @@ import {
 } from '../../../../app/jobs/user-gone';
 import { initJobProcessing } from '../../../../app/jobs';
 import { addMailListener } from '../../../../lib/mailer';
+import { serializeUsersByIds } from '../../../../app/serializers/v2/user';
 
 const expect = unexpected.clone();
 expect.use(unexpectedDate);
@@ -73,6 +74,12 @@ describe(`User's 'gone' status`, () => {
         isProtected: '1',
         goneStatus: GONE_SUSPENDED,
         goneAt: expect.it('to be close to', now),
+      });
+
+      const [serializedLuna] = await serializeUsersByIds([luna.id]);
+      expect(serializedLuna, 'to satisfy', {
+        isGone: true,
+        goneStatus: 'suspended',
       });
     });
 
@@ -206,6 +213,12 @@ describe(`User's 'gone' status`, () => {
       // Check that the user profile is really cleaned
       expect(user, 'to satisfy', { goneStatus: GONE_DELETED, hiddenEmail: '' });
 
+      const [serializedLuna] = await serializeUsersByIds([luna.id]);
+      expect(serializedLuna, 'to satisfy', {
+        isGone: true,
+        goneStatus: 'deleted',
+      });
+
       expect(capturedMail, 'to satisfy', { envelope: { to: ['luna@lovegood.good'] } });
       const parsedMail = await simpleParser(capturedMail.response);
       expect(parsedMail, 'to satisfy', {
@@ -250,6 +263,18 @@ describe(`User's 'gone' status`, () => {
 
       const savedMessage = await luna.getPauseMessage();
       expect(savedMessage, 'to be', pauseMessage);
+    });
+
+    it(`should show pause message in description when user is serialized`, async () => {
+      const pauseMessage = 'On vacation until March';
+      await luna.setGoneStatus(GONE_PAUSED);
+      await luna.setPauseMessage(pauseMessage);
+
+      const [serializedLuna] = await serializeUsersByIds([luna.id]);
+
+      expect(serializedLuna.description, 'to be', pauseMessage);
+      expect(serializedLuna.isGone, 'to be', true);
+      expect(serializedLuna.goneStatus, 'to be', 'paused');
     });
 
     it(`should trim pause message`, async () => {

--- a/test/integration/models/user/gone.js
+++ b/test/integration/models/user/gone.js
@@ -230,8 +230,9 @@ describe(`User's 'gone' status`, () => {
 
   describe(`Paused user status (GONE_PAUSED)`, () => {
     let luna;
+    let originalLunaProps;
 
-    before(async () => {
+    beforeEach(async () => {
       await cleanDB($pg_database);
 
       luna = new User({
@@ -241,6 +242,9 @@ describe(`User's 'gone' status`, () => {
         password: 'pw',
       });
       await luna.create();
+
+      // Save original props for restore test
+      originalLunaProps = pick(luna, ['username', 'screenName', 'email']);
     });
 
     it(`should clean user's fields when status is set to GONE_PAUSED`, async () => {
@@ -261,7 +265,7 @@ describe(`User's 'gone' status`, () => {
       const pauseMessage = 'Taking a break until February';
       await luna.setPauseMessage(pauseMessage);
 
-      const savedMessage = await luna.getPauseMessage();
+      const savedMessage = luna.getPauseMessage();
       expect(savedMessage, 'to be', pauseMessage);
     });
 
@@ -281,14 +285,14 @@ describe(`User's 'gone' status`, () => {
       const pauseMessage = '  Spaces around  ';
       await luna.setPauseMessage(pauseMessage);
 
-      const savedMessage = await luna.getPauseMessage();
+      const savedMessage = luna.getPauseMessage();
       expect(savedMessage, 'to be', 'Spaces around');
     });
 
     it(`should not save empty pause message`, async () => {
       await luna.setPauseMessage('   ');
 
-      const savedMessage = await luna.getPauseMessage();
+      const savedMessage = luna.getPauseMessage();
       expect(savedMessage, 'to be', null);
     });
 
@@ -306,7 +310,7 @@ describe(`User's 'gone' status`, () => {
       await luna.setPauseMessage('Some message');
       await luna.setPauseMessage(null);
 
-      const savedMessage = await luna.getPauseMessage();
+      const savedMessage = luna.getPauseMessage();
       expect(savedMessage, 'to be', null);
     });
 
@@ -314,22 +318,21 @@ describe(`User's 'gone' status`, () => {
       await luna.setPauseMessage('Some message');
       await luna.setGoneStatus(GONE_SUSPENDED);
 
-      const savedMessage = await luna.getPauseMessage();
+      luna = await dbAdapter.getUserById(luna.id);
+      const savedMessage = luna.getPauseMessage();
       expect(savedMessage, 'to be', 'Some message');
 
       await luna.setGoneStatus(null);
-      const savedMessageAfter = await luna.getPauseMessage();
+      luna = await dbAdapter.getUserById(luna.id);
+      const savedMessageAfter = luna.getPauseMessage();
       expect(savedMessageAfter, 'to be', 'Some message');
     });
 
     it(`should restore user's fields when status is cleared`, async () => {
+      await luna.setGoneStatus(GONE_PAUSED);
       await luna.setGoneStatus(null);
       const luna1 = await dbAdapter.getUserById(luna.id);
-      expect(
-        pick(luna1, ['username', 'screenName', 'email']),
-        'to equal',
-        pick(luna, ['username', 'screenName', 'email']),
-      );
+      expect(pick(luna1, ['username', 'screenName', 'email']), 'to equal', originalLunaProps);
     });
   });
 

--- a/test/integration/models/user/gone.js
+++ b/test/integration/models/user/gone.js
@@ -11,6 +11,7 @@ import cleanDB from '../../../dbCleaner';
 import { User, dbAdapter } from '../../../../app/models';
 import {
   GONE_SUSPENDED,
+  GONE_PAUSED,
   GONE_COOLDOWN,
   GONE_DELETION,
   GONE_DELETED,
@@ -20,6 +21,7 @@ import {
   USER_COOLDOWN_REMINDER,
   USER_DELETION_START,
   USER_DELETE_DATA,
+  USER_PAUSED_START,
 } from '../../../../app/jobs/user-gone';
 import { initJobProcessing } from '../../../../app/jobs';
 import { addMailListener } from '../../../../lib/mailer';
@@ -32,6 +34,7 @@ const jobTypes = [
   USER_COOLDOWN_REMINDER,
   USER_DELETION_START,
   USER_DELETE_DATA,
+  USER_PAUSED_START,
 ];
 
 describe(`User's 'gone' status`, () => {
@@ -209,6 +212,109 @@ describe(`User's 'gone' status`, () => {
         to: { text: '"luna" <luna@lovegood.good>' },
         subject: 'Your account has been deleted',
       });
+    });
+  });
+
+  describe(`Paused user status (GONE_PAUSED)`, () => {
+    let luna;
+
+    before(async () => {
+      await cleanDB($pg_database);
+
+      luna = new User({
+        username: 'luna',
+        screenName: 'Luna Lovegood',
+        email: 'luna@lovegood.good',
+        password: 'pw',
+      });
+      await luna.create();
+    });
+
+    it(`should clean user's fields when status is set to GONE_PAUSED`, async () => {
+      const [, now] = await Promise.all([luna.setGoneStatus(GONE_PAUSED), dbAdapter.now()]);
+      const luna1 = await dbAdapter.getUserById(luna.id);
+      expect(luna1, 'to satisfy', {
+        username: 'luna',
+        screenName: 'luna',
+        email: '',
+        isPrivate: '1',
+        isProtected: '1',
+        goneStatus: GONE_PAUSED,
+        goneAt: expect.it('to be close to', now),
+      });
+    });
+
+    it(`should restore user's fields when status is cleared`, async () => {
+      await luna.setGoneStatus(null);
+      const luna1 = await dbAdapter.getUserById(luna.id);
+      expect(
+        pick(luna1, ['username', 'screenName', 'email']),
+        'to equal',
+        pick(luna, ['username', 'screenName', 'email']),
+      );
+    });
+  });
+
+  describe(`Paused user's jobs`, () => {
+    let luna,
+      jobManager,
+      capturedMail = null;
+    let removeMailListener = () => null;
+
+    before(async () => {
+      await cleanDB($pg_database);
+
+      luna = new User({
+        username: 'luna',
+        screenName: 'Luna Lovegood',
+        email: 'luna@lovegood.good',
+        password: 'pw',
+      });
+      await luna.create();
+
+      jobManager = await initJobProcessing();
+      removeMailListener = addMailListener((r) => (capturedMail = r));
+    });
+
+    after(removeMailListener);
+
+    beforeEach(() => (capturedMail = null));
+
+    it(`should create only start job when user changes status to GONE_PAUSED`, async () => {
+      const [, now] = await Promise.all([luna.setGoneStatus(GONE_PAUSED), dbAdapter.now()]);
+
+      const jobs = await dbAdapter.getAllJobs(jobTypes);
+      expect(jobs, 'to satisfy', [
+        {
+          name: USER_PAUSED_START,
+          payload: { id: luna.id, goneAt: luna.goneAt.getTime() },
+          unlockAt: expect.it('to be close to', now),
+        },
+      ]);
+    });
+
+    it(`should send email to user's real address`, async () => {
+      await jobManager.fetchAndProcess();
+
+      expect(capturedMail, 'to satisfy', { envelope: { to: ['luna@lovegood.good'] } });
+      const parsedMail = await simpleParser(capturedMail.response);
+      expect(parsedMail, 'to satisfy', {
+        to: { text: '"luna" <luna@lovegood.good>' },
+        subject: 'You have paused your account',
+      });
+    });
+
+    it(`should not create any deletion jobs after the start job processed`, async () => {
+      const jobs = await dbAdapter.getAllJobs(jobTypes);
+      expect(jobs, 'to be empty');
+    });
+
+    it(`should allow user to resume account`, async () => {
+      await luna.setGoneStatus(null);
+      const user = await dbAdapter.getUserById(luna.id);
+
+      expect(user.goneStatus, 'to be', null);
+      expect(user.email, 'to be', 'luna@lovegood.good');
     });
   });
 });

--- a/test/integration/models/user/gone.js
+++ b/test/integration/models/user/gone.js
@@ -244,6 +244,59 @@ describe(`User's 'gone' status`, () => {
       });
     });
 
+    it(`should save pause message when provided`, async () => {
+      const pauseMessage = 'Taking a break until February';
+      await luna.setPauseMessage(pauseMessage);
+
+      const savedMessage = await luna.getPauseMessage();
+      expect(savedMessage, 'to be', pauseMessage);
+    });
+
+    it(`should trim pause message`, async () => {
+      const pauseMessage = '  Spaces around  ';
+      await luna.setPauseMessage(pauseMessage);
+
+      const savedMessage = await luna.getPauseMessage();
+      expect(savedMessage, 'to be', 'Spaces around');
+    });
+
+    it(`should not save empty pause message`, async () => {
+      await luna.setPauseMessage('   ');
+
+      const savedMessage = await luna.getPauseMessage();
+      expect(savedMessage, 'to be', null);
+    });
+
+    it(`should reject too long pause message`, async () => {
+      const longMessage = 'a'.repeat(1501);
+
+      await expect(
+        luna.setPauseMessage(longMessage),
+        'to be rejected with',
+        /Pause message is too long/,
+      );
+    });
+
+    it(`should clear pause message when set to null`, async () => {
+      await luna.setPauseMessage('Some message');
+      await luna.setPauseMessage(null);
+
+      const savedMessage = await luna.getPauseMessage();
+      expect(savedMessage, 'to be', null);
+    });
+
+    it(`should keep pause message when status changes`, async () => {
+      await luna.setPauseMessage('Some message');
+      await luna.setGoneStatus(GONE_SUSPENDED);
+
+      const savedMessage = await luna.getPauseMessage();
+      expect(savedMessage, 'to be', 'Some message');
+
+      await luna.setGoneStatus(null);
+      const savedMessageAfter = await luna.getPauseMessage();
+      expect(savedMessageAfter, 'to be', 'Some message');
+    });
+
     it(`should restore user's fields when status is cleared`, async () => {
       await luna.setGoneStatus(null);
       const luna1 = await dbAdapter.getUserById(luna.id);

--- a/test/integration/models/user/gone.js
+++ b/test/integration/models/user/gone.js
@@ -22,6 +22,7 @@ import {
   USER_DELETION_START,
   USER_DELETE_DATA,
   USER_PAUSED_START,
+  USER_PAUSED_REMINDER,
 } from '../../../../app/jobs/user-gone';
 import { initJobProcessing } from '../../../../app/jobs';
 import { addMailListener } from '../../../../lib/mailer';
@@ -36,6 +37,7 @@ const jobTypes = [
   USER_DELETION_START,
   USER_DELETE_DATA,
   USER_PAUSED_START,
+  USER_PAUSED_REMINDER,
 ];
 
 describe(`User's 'gone' status`, () => {
@@ -385,9 +387,42 @@ describe(`User's 'gone' status`, () => {
       });
     });
 
-    it(`should not create any deletion jobs after the start job processed`, async () => {
+    it(`should create monthly reminder job after the start job processed`, async () => {
       const jobs = await dbAdapter.getAllJobs(jobTypes);
-      expect(jobs, 'to be empty');
+      expect(jobs, 'to satisfy', [
+        {
+          name: USER_PAUSED_REMINDER,
+          payload: { id: luna.id, goneAt: luna.goneAt.getTime() },
+          unlockAt: expect.it('to be a date'),
+        },
+      ]);
+    });
+
+    it(`should send reminder email when reminder job is processed`, async () => {
+      const jobs = await dbAdapter.getAllJobs(jobTypes);
+      const reminderJob = jobs.find((job) => job.name === USER_PAUSED_REMINDER);
+      // Manually unlock reminder job
+      await reminderJob.setUnlockAt(0);
+
+      await jobManager.fetchAndProcess();
+
+      expect(capturedMail, 'to satisfy', { envelope: { to: ['luna@lovegood.good'] } });
+      const parsedMail = await simpleParser(capturedMail.response);
+      expect(parsedMail, 'to satisfy', {
+        to: { text: '"luna" <luna@lovegood.good>' },
+        subject: 'Your account is still paused',
+      });
+    });
+
+    it(`should schedule next reminder after processing current one`, async () => {
+      const jobs = await dbAdapter.getAllJobs(jobTypes);
+      expect(jobs, 'to satisfy', [
+        {
+          name: USER_PAUSED_REMINDER,
+          payload: { id: luna.id, goneAt: luna.goneAt.getTime() },
+          unlockAt: expect.it('to be a date'),
+        },
+      ]);
     });
 
     it(`should allow user to resume account`, async () => {
@@ -396,6 +431,21 @@ describe(`User's 'gone' status`, () => {
 
       expect(user.goneStatus, 'to be', null);
       expect(user.email, 'to be', 'luna@lovegood.good');
+    });
+
+    it(`should not send reminders after user resumed account`, async () => {
+      // Jobs remain but will be skipped by checkUserStatus
+      const jobs = await dbAdapter.getAllJobs(jobTypes);
+      const reminderJob = jobs.find((job) => job.name === USER_PAUSED_REMINDER);
+
+      if (reminderJob) {
+        // Manually unlock to test that handler skips it
+        await reminderJob.setUnlockAt(0);
+        await jobManager.fetchAndProcess();
+
+        // No new email should be sent since user is no longer paused
+        expect(capturedMail, 'to be', null);
+      }
     });
   });
 });

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -122,6 +122,7 @@ declare module 'config' {
         sanitizeMediaMetadata: boolean;
         notifyOfCommentsOnMyPosts: boolean;
         notifyOfCommentsOnCommentedPosts: boolean;
+        pauseMessage: string;
       };
       overrides: {
         [k: string]:


### PR DESCRIPTION
### Added
- Account pause functionality: users can now pause their accounts with an optional custom message that will be displayed in their profile.

  New endpoint `POST /v1/users/pause-me` allows users to pause their account:
  ```json
  {
    "password": "user-password",
    "message": "Taking a break until February" // optional
  }
  ```

  When an account is paused:
  - The account receives `GONE_PAUSED` status (value: 15)
  - The account can be resumed using the existing `POST /v1/users/resume-me` endpoint
  - The pause message (if provided) is displayed in the user's `description` field
  - User data is not deleted (unlike suspended accounts)

- New `goneStatus` field in user serialization: inactive users now include a `goneStatus` field in their API representation with one of three values:
  - `"paused"` - account is paused by the user (status `GONE_PAUSED`)
  - `"suspended"` - account is suspended (status `GONE_SUSPENDED`)
  - `"deleted"` - account is in deletion process or deleted (statuses `GONE_COOLDOWN`,
    `GONE_DELETION`, or `GONE_DELETED`)

  This allows clients to distinguish between different types of inactive accounts  and display appropriate messages to users.

  Example response:
  ```json
  {
    "users": {
      "id": "...",
      "username": "luna",
      "isGone": true,
      "goneStatus": "paused",
      "description": "Taking a break until February"
    }
  }
  ```
